### PR TITLE
feat: Entry バックエンド実装（レイヤードアーキテクチャ）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Oryzae
+
+ジャーナリング支援アプリのバックエンド。
+
+## Quick Commands
+
+```bash
+pnpm install              # 依存インストール
+pnpm --filter @oryzae/server dev        # 開発サーバー起動
+pnpm --filter @oryzae/server typecheck  # 型チェック
+pnpm --filter @oryzae/server test       # テスト実行
+```
+
+## Architecture
+
+レイヤードアーキテクチャ: `presentation → application → domain ← infrastructure`
+
+- domain は何にも依存しない（最内層）
+- infrastructure は domain の gateway IF を実装する（依存性逆転）
+- `--no-verify` は原則禁止
+
+## Directory
+
+```
+apps/server/src/contexts/
+  entry/           # エントリ管理コンテキスト
+    presentation/  # HTTP ↔ ユースケース変換
+    application/   # ユースケース（1ファイル = 1ユースケース）
+    domain/        # ビジネスルール（models, services, gateways）
+    infrastructure/ # Supabase 実装
+  shared/          # コンテキスト間共有
+```
+
+## Design Docs
+
+- `OryzaeArchitecture-2.md` — サーバーアーキテクチャ（正）
+- `EditorAPIInterfaceDesign.md` — 型設計（Base Entry / Editor Extension）

--- a/README.md
+++ b/README.md
@@ -1,0 +1,235 @@
+# Oryzae
+
+ジャーナリング支援アプリ「オリゼー」のバックエンド。
+日記・日誌を通じて「問い」を育て、記録を「発酵」させるためのサーバーサイド API。
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---|---|
+| 言語 | TypeScript |
+| API フレームワーク | Hono |
+| DB / 認証 | Supabase (PostgreSQL + Auth + RLS) |
+| モノレポ | pnpm workspaces |
+| テスト | Vitest |
+| バリデーション | Zod |
+
+## 前提条件
+
+- **Node.js** v20 以上
+- **pnpm** v10 以上
+- **Docker Desktop** （Supabase ローカル環境に必要）
+
+## セットアップ
+
+### 1. 依存インストール
+
+```bash
+pnpm install
+```
+
+### 2. Supabase CLI のインストール
+
+```bash
+brew install supabase/tap/supabase
+```
+
+### 3. Supabase ローカル環境の起動
+
+```bash
+supabase init     # 初回のみ（supabase/ ディレクトリが既にあればスキップ）
+supabase start    # Docker でローカル Supabase を起動
+```
+
+起動すると以下のような情報が表示されます:
+
+```
+API URL: http://127.0.0.1:54321
+anon key: eyJ...
+service_role key: eyJ...
+```
+
+### 4. 環境変数の設定
+
+```bash
+cp apps/server/.env.example apps/server/.env
+```
+
+`.env` を編集して、`supabase start` で表示された値を設定:
+
+```
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=（表示された anon key）
+SUPABASE_SERVICE_ROLE_KEY=（表示された service_role key）
+PORT=3000
+```
+
+### 5. DB マイグレーション
+
+ローカル Supabase を使う場合、`supabase start` 時に `supabase/migrations/` 配下の SQL が自動適用されます。
+
+手動で適用する場合:
+
+```bash
+supabase db reset
+```
+
+### 6. サーバー起動
+
+```bash
+pnpm --filter @oryzae/server dev
+```
+
+`Server running on http://localhost:3000` と表示されれば成功。
+
+## 動作確認
+
+### ヘルスチェック
+
+```bash
+curl http://localhost:3000/health
+```
+
+```json
+{"status":"ok"}
+```
+
+### テストユーザーの作成
+
+Supabase ローカルダッシュボード（http://127.0.0.1:54323）にアクセスし、
+Authentication > Users から手動でユーザーを作成するか、以下のコマンドで作成:
+
+```bash
+# ユーザー登録
+curl -X POST http://127.0.0.1:54321/auth/v1/signup \
+  -H "apikey: YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "password": "password123"}'
+```
+
+### アクセストークンの取得
+
+```bash
+# ログイン → access_token を取得
+curl -X POST http://127.0.0.1:54321/auth/v1/token?grant_type=password \
+  -H "apikey: YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "password": "password123"}'
+```
+
+レスポンスの `access_token` を以降のリクエストで使います。
+以下のコマンドで変数に保存しておくと便利です:
+
+```bash
+TOKEN="取得した access_token をここに貼り付け"
+```
+
+### エントリの CRUD 操作
+
+**新規作成**
+
+```bash
+curl -X POST http://localhost:3000/api/v1/entries \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "今日、カント君の展示に行った。",
+    "mediaUrls": [],
+    "editorType": "typetrace",
+    "editorVersion": "1.0.0",
+    "extension": {"averageWPM": 6.64, "erasureTraces": []}
+  }'
+```
+
+**一覧取得**
+
+```bash
+curl http://localhost:3000/api/v1/entries \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**詳細取得**（最新 snapshot 含む）
+
+```bash
+curl http://localhost:3000/api/v1/entries/{id} \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**更新**
+
+```bash
+curl -X PUT http://localhost:3000/api/v1/entries/{id} \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "今日、カント君の展示に行った。すごく良かった。",
+    "mediaUrls": [],
+    "editorType": "typetrace",
+    "editorVersion": "1.0.0",
+    "extension": {"averageWPM": 7.2, "erasureTraces": []}
+  }'
+```
+
+**削除**
+
+```bash
+curl -X DELETE http://localhost:3000/api/v1/entries/{id} \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+## テスト
+
+```bash
+# ユニットテスト実行
+pnpm --filter @oryzae/server test
+
+# ウォッチモード
+pnpm --filter @oryzae/server test:watch
+
+# 型チェック
+pnpm --filter @oryzae/server typecheck
+```
+
+## API エンドポイント
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| GET | `/health` | ヘルスチェック |
+| POST | `/api/v1/entries` | エントリ新規作成 |
+| GET | `/api/v1/entries` | エントリ一覧（`?cursor=&limit=` でページネーション） |
+| GET | `/api/v1/entries/:id` | エントリ詳細（最新 snapshot 含む） |
+| PUT | `/api/v1/entries/:id` | エントリ更新（entries 更新 + snapshot 追記） |
+| DELETE | `/api/v1/entries/:id` | エントリ削除（cascade で snapshots も削除） |
+
+## ディレクトリ構成
+
+```
+apps/server/src/
+├── index.ts                              # エントリーポイント
+└── contexts/
+    ├── entry/                            # エントリ管理コンテキスト
+    │   ├── presentation/routes/          # HTTP ↔ ユースケース変換
+    │   ├── application/usecases/         # 1 ユースケース = 1 ファイル
+    │   ├── domain/
+    │   │   ├── models/                   # BaseEntry, EntrySnapshot
+    │   │   ├── services/                 # 純粋ドメインロジック
+    │   │   └── gateways/                 # 外部依存の抽象 IF
+    │   └── infrastructure/repositories/  # Supabase 実装
+    └── shared/                           # コンテキスト間共有
+        ├── infrastructure/               # Supabase クライアント
+        └── presentation/middleware/      # 認証, エラーハンドリング
+
+supabase/migrations/                      # DB マイグレーション
+```
+
+## アーキテクチャ
+
+レイヤードアーキテクチャを採用。依存方向は:
+
+```
+presentation → application → domain ← infrastructure
+```
+
+- **domain** は何にも依存しない（最内層）
+- **infrastructure** は domain の gateway IF を実装する（依存性逆転）
+- 詳細は `OryzaeArchitecture-2.md` を参照

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,0 +1,4 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+PORT=3000

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@oryzae/server",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "hono": "^4.7.0",
+    "@hono/node-server": "^1.14.0",
+    "@supabase/supabase-js": "^2.49.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.1.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/apps/server/src/contexts/entry/application/errors/entry.errors.ts
+++ b/apps/server/src/contexts/entry/application/errors/entry.errors.ts
@@ -1,0 +1,6 @@
+export class EntryNotFoundError extends Error {
+  constructor(entryId: string) {
+    super(`Entry not found: ${entryId}`);
+    this.name = 'EntryNotFoundError';
+  }
+}

--- a/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
@@ -1,0 +1,41 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
+import type { BaseEntry } from '../../domain/models/entry';
+
+interface CreateEntryInput {
+  content: string;
+  mediaUrls: string[];
+  editorType: string;
+  editorVersion: string;
+  extension: Record<string, unknown>;
+}
+
+export class CreateEntryUsecase {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(userId: string, input: CreateEntryInput): Promise<BaseEntry> {
+    const now = new Date().toISOString();
+    const entry: BaseEntry = {
+      id: crypto.randomUUID(),
+      userId,
+      content: input.content,
+      mediaUrls: input.mediaUrls,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.entryRepo.save(entry);
+    await this.snapshotRepo.append({
+      entryId: entry.id,
+      content: input.content,
+      editorType: input.editorType,
+      editorVersion: input.editorVersion,
+      extension: input.extension,
+    });
+
+    return entry;
+  }
+}

--- a/apps/server/src/contexts/entry/application/usecases/delete-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/delete-entry.usecase.ts
@@ -1,0 +1,13 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import { EntryNotFoundError } from '../errors/entry.errors';
+
+export class DeleteEntryUsecase {
+  constructor(private entryRepo: EntryRepositoryGateway) {}
+
+  async execute(entryId: string): Promise<void> {
+    const existing = await this.entryRepo.findById(entryId);
+    if (!existing) throw new EntryNotFoundError(entryId);
+
+    await this.entryRepo.delete(entryId);
+  }
+}

--- a/apps/server/src/contexts/entry/application/usecases/get-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/get-entry.usecase.ts
@@ -1,0 +1,25 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
+import type { BaseEntry } from '../../domain/models/entry';
+import type { EntrySnapshot } from '../../domain/models/entry-snapshot';
+
+interface GetEntryResult {
+  entry: BaseEntry;
+  latestSnapshot: EntrySnapshot | null;
+}
+
+export class GetEntryUsecase {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(entryId: string): Promise<GetEntryResult | null> {
+    const entry = await this.entryRepo.findById(entryId);
+    if (!entry) return null;
+
+    const latestSnapshot =
+      await this.snapshotRepo.findLatestByEntryId(entryId);
+    return { entry, latestSnapshot };
+  }
+}

--- a/apps/server/src/contexts/entry/application/usecases/list-entries.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/list-entries.usecase.ts
@@ -1,0 +1,14 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import type { BaseEntry } from '../../domain/models/entry';
+
+export class ListEntriesUsecase {
+  constructor(private entryRepo: EntryRepositoryGateway) {}
+
+  async execute(
+    userId: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<BaseEntry[]> {
+    return this.entryRepo.listByUserId(userId, cursor, limit);
+  }
+}

--- a/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
@@ -1,0 +1,45 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
+import type { BaseEntry } from '../../domain/models/entry';
+import { EntryNotFoundError } from '../errors/entry.errors';
+
+interface UpdateEntryInput {
+  content: string;
+  mediaUrls: string[];
+  editorType: string;
+  editorVersion: string;
+  extension: Record<string, unknown>;
+}
+
+export class UpdateEntryUsecase {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(
+    entryId: string,
+    input: UpdateEntryInput,
+  ): Promise<BaseEntry> {
+    const existing = await this.entryRepo.findById(entryId);
+    if (!existing) throw new EntryNotFoundError(entryId);
+
+    const updated: BaseEntry = {
+      ...existing,
+      content: input.content,
+      mediaUrls: input.mediaUrls,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.entryRepo.save(updated);
+    await this.snapshotRepo.append({
+      entryId,
+      content: input.content,
+      editorType: input.editorType,
+      editorVersion: input.editorVersion,
+      extension: input.extension,
+    });
+
+    return updated;
+  }
+}

--- a/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
@@ -1,0 +1,12 @@
+import type { BaseEntry } from '../models/entry';
+
+export interface EntryRepositoryGateway {
+  findById(id: string): Promise<BaseEntry | null>;
+  listByUserId(
+    userId: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<BaseEntry[]>;
+  save(entry: BaseEntry): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/apps/server/src/contexts/entry/domain/gateways/entry-snapshot-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-snapshot-repository.gateway.ts
@@ -1,0 +1,16 @@
+import type { EntrySnapshot } from '../models/entry-snapshot';
+
+export interface EntrySnapshotRepositoryGateway {
+  /**
+   * entry_snapshots に1行追記（immutable append-only）。
+   */
+  append(
+    snapshot: Omit<EntrySnapshot, 'id' | 'createdAt'>,
+  ): Promise<EntrySnapshot>;
+
+  /**
+   * entry_snapshots から最新の1行を取得。
+   * エディタスイッチ判定に使う。
+   */
+  findLatestByEntryId(entryId: string): Promise<EntrySnapshot | null>;
+}

--- a/apps/server/src/contexts/entry/domain/models/entry-snapshot.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry-snapshot.ts
@@ -1,0 +1,9 @@
+export interface EntrySnapshot {
+  id: string;
+  entryId: string;
+  content: string;
+  editorType: string;
+  editorVersion: string;
+  extension: Record<string, unknown>;
+  createdAt: string;
+}

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -1,0 +1,8 @@
+export interface BaseEntry {
+  id: string;
+  userId: string;
+  content: string;
+  mediaUrls: string[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.test.ts
+++ b/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { resolveExtension } from './snapshot-restoration.service';
+import type { EntrySnapshot } from '../models/entry-snapshot';
+
+describe('resolveExtension', () => {
+  const baseSnapshot: EntrySnapshot = {
+    id: 'snap-1',
+    entryId: 'entry-1',
+    content: 'test',
+    editorType: 'typetrace',
+    editorVersion: '1.0.0',
+    extension: { erasureTraces: [], averageWPM: 6.64 },
+    createdAt: '2026-03-15T10:30:00Z',
+  };
+
+  it('snapshot が null なら null を返す', () => {
+    expect(resolveExtension(null, 'typetrace')).toBeNull();
+  });
+
+  it('editorType が一致すれば extension を返す', () => {
+    const result = resolveExtension(baseSnapshot, 'typetrace');
+    expect(result).toEqual(baseSnapshot.extension);
+  });
+
+  it('editorType が不一致なら null を返す', () => {
+    const result = resolveExtension(baseSnapshot, 'minimal');
+    expect(result).toBeNull();
+  });
+});

--- a/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.ts
+++ b/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.ts
@@ -1,0 +1,18 @@
+import type { EntrySnapshot } from '../models/entry-snapshot';
+
+/**
+ * エディタスイッチ時の extension 復元判定。
+ *
+ * - 最新 snapshot の editorType が要求と一致 → extension を返す（復元可能）
+ * - 一致しない or snapshot がない → null（エディタ側が新規初期化する）
+ */
+export function resolveExtension(
+  latestSnapshot: EntrySnapshot | null,
+  requestedEditorType: string,
+): Record<string, unknown> | null {
+  if (!latestSnapshot) return null;
+  if (latestSnapshot.editorType === requestedEditorType) {
+    return latestSnapshot.extension;
+  }
+  return null;
+}

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry-snapshot.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry-snapshot.repository.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
+import type { EntrySnapshot } from '../../domain/models/entry-snapshot';
+
+export class SupabaseEntrySnapshotRepository
+  implements EntrySnapshotRepositoryGateway
+{
+  constructor(private supabase: SupabaseClient) {}
+
+  async append(
+    snapshot: Omit<EntrySnapshot, 'id' | 'createdAt'>,
+  ): Promise<EntrySnapshot> {
+    const { data, error } = await this.supabase
+      .from('entry_snapshots')
+      .insert({
+        entry_id: snapshot.entryId,
+        content: snapshot.content,
+        editor_type: snapshot.editorType,
+        editor_version: snapshot.editorVersion,
+        extension: snapshot.extension,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return this.toDomain(data);
+  }
+
+  async findLatestByEntryId(
+    entryId: string,
+  ): Promise<EntrySnapshot | null> {
+    const { data, error } = await this.supabase
+      .from('entry_snapshots')
+      .select('*')
+      .eq('entry_id', entryId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    return this.toDomain(data);
+  }
+
+  private toDomain(row: Record<string, unknown>): EntrySnapshot {
+    return {
+      id: row.id as string,
+      entryId: row.entry_id as string,
+      content: row.content as string,
+      editorType: row.editor_type as string,
+      editorVersion: row.editor_version as string,
+      extension: (row.extension as Record<string, unknown>) ?? {},
+      createdAt: row.created_at as string,
+    };
+  }
+}

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
+import type { BaseEntry } from '../../domain/models/entry';
+
+export class SupabaseEntryRepository implements EntryRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findById(id: string): Promise<BaseEntry | null> {
+    const { data, error } = await this.supabase
+      .from('entries')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) return null;
+    return this.toDomain(data);
+  }
+
+  async listByUserId(
+    userId: string,
+    cursor?: string,
+    limit = 20,
+  ): Promise<BaseEntry[]> {
+    let query = this.supabase
+      .from('entries')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (cursor) {
+      query = query.lt('created_at', cursor);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return (data ?? []).map((row) => this.toDomain(row));
+  }
+
+  async save(entry: BaseEntry): Promise<void> {
+    const { error } = await this.supabase.from('entries').upsert({
+      id: entry.id,
+      user_id: entry.userId,
+      content: entry.content,
+      media_urls: entry.mediaUrls,
+      created_at: entry.createdAt,
+      updated_at: entry.updatedAt,
+    });
+    if (error) throw error;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('entries')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+  }
+
+  private toDomain(row: Record<string, unknown>): BaseEntry {
+    return {
+      id: row.id as string,
+      userId: row.user_id as string,
+      content: row.content as string,
+      mediaUrls: (row.media_urls as string[]) ?? [],
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+}

--- a/apps/server/src/contexts/entry/presentation/routes/entries.ts
+++ b/apps/server/src/contexts/entry/presentation/routes/entries.ts
@@ -1,0 +1,85 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { CreateEntryUsecase } from '../../application/usecases/create-entry.usecase';
+import { GetEntryUsecase } from '../../application/usecases/get-entry.usecase';
+import { ListEntriesUsecase } from '../../application/usecases/list-entries.usecase';
+import { UpdateEntryUsecase } from '../../application/usecases/update-entry.usecase';
+import { DeleteEntryUsecase } from '../../application/usecases/delete-entry.usecase';
+import { SupabaseEntryRepository } from '../../infrastructure/repositories/supabase-entry.repository';
+import { SupabaseEntrySnapshotRepository } from '../../infrastructure/repositories/supabase-entry-snapshot.repository';
+
+type Env = {
+  Variables: {
+    userId: string;
+    supabase: import('@supabase/supabase-js').SupabaseClient;
+  };
+};
+
+const createEntrySchema = z.object({
+  content: z.string(),
+  mediaUrls: z.array(z.string()).default([]),
+  editorType: z.string(),
+  editorVersion: z.string(),
+  extension: z.record(z.unknown()).default({}),
+});
+
+const updateEntrySchema = createEntrySchema;
+
+export const entries = new Hono<Env>();
+
+entries.post('/', async (c) => {
+  const body = createEntrySchema.parse(await c.req.json());
+  const supabase = c.get('supabase');
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const snapshotRepo = new SupabaseEntrySnapshotRepository(supabase);
+  const usecase = new CreateEntryUsecase(entryRepo, snapshotRepo);
+
+  const entry = await usecase.execute(c.get('userId'), body);
+  return c.json(entry, 201);
+});
+
+entries.get('/', async (c) => {
+  const cursor = c.req.query('cursor');
+  const limit = c.req.query('limit');
+  const supabase = c.get('supabase');
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const usecase = new ListEntriesUsecase(entryRepo);
+
+  const result = await usecase.execute(
+    c.get('userId'),
+    cursor,
+    limit ? Number(limit) : undefined,
+  );
+  return c.json(result);
+});
+
+entries.get('/:id', async (c) => {
+  const supabase = c.get('supabase');
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const snapshotRepo = new SupabaseEntrySnapshotRepository(supabase);
+  const usecase = new GetEntryUsecase(entryRepo, snapshotRepo);
+
+  const result = await usecase.execute(c.req.param('id'));
+  if (!result) return c.json({ error: 'Not found' }, 404);
+  return c.json(result);
+});
+
+entries.put('/:id', async (c) => {
+  const body = updateEntrySchema.parse(await c.req.json());
+  const supabase = c.get('supabase');
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const snapshotRepo = new SupabaseEntrySnapshotRepository(supabase);
+  const usecase = new UpdateEntryUsecase(entryRepo, snapshotRepo);
+
+  const result = await usecase.execute(c.req.param('id'), body);
+  return c.json(result);
+});
+
+entries.delete('/:id', async (c) => {
+  const supabase = c.get('supabase');
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const usecase = new DeleteEntryUsecase(entryRepo);
+
+  await usecase.execute(c.req.param('id'));
+  return c.json({ ok: true });
+});

--- a/apps/server/src/contexts/shared/infrastructure/supabase-client.ts
+++ b/apps/server/src/contexts/shared/infrastructure/supabase-client.ts
@@ -1,0 +1,38 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (client) return client;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set',
+    );
+  }
+
+  client = createClient(url, key);
+  return client;
+}
+
+export function createSupabaseClientForUser(
+  accessToken: string,
+): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be set');
+  }
+
+  return createClient(url, anonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  });
+}

--- a/apps/server/src/contexts/shared/presentation/middleware/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/middleware/auth.ts
@@ -1,0 +1,37 @@
+import type { Context, Next } from 'hono';
+import { createClient } from '@supabase/supabase-js';
+
+export async function authMiddleware(c: Context, next: Next) {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return c.json({ error: 'Server configuration error' }, 500);
+  }
+
+  const supabase = createClient(url, anonKey, {
+    global: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return c.json({ error: 'Invalid or expired token' }, 401);
+  }
+
+  c.set('userId', user.id);
+  c.set('supabase', supabase);
+
+  await next();
+}

--- a/apps/server/src/contexts/shared/presentation/middleware/error-handler.ts
+++ b/apps/server/src/contexts/shared/presentation/middleware/error-handler.ts
@@ -1,0 +1,10 @@
+import type { Context } from 'hono';
+
+export function errorHandler(err: Error, c: Context) {
+  if (err.name === 'EntryNotFoundError') {
+    return c.json({ error: err.message }, 404);
+  }
+
+  console.error('Unhandled error:', err);
+  return c.json({ error: 'Internal server error' }, 500);
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+import { authMiddleware } from './contexts/shared/presentation/middleware/auth';
+import { errorHandler } from './contexts/shared/presentation/middleware/error-handler';
+import { entries } from './contexts/entry/presentation/routes/entries';
+
+const app = new Hono();
+
+app.onError(errorHandler);
+
+app.get('/health', (c) => c.json({ status: 'ok' }));
+
+app.use('/api/v1/*', authMiddleware);
+app.route('/api/v1/entries', entries);
+
+const port = Number(process.env.PORT ?? 3000);
+
+serve({ fetch: app.fetch, port }, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/EditorAPIInterfaceDesign.md
+++ b/docs/EditorAPIInterfaceDesign.md
@@ -1,0 +1,246 @@
+# Editor API Interface Design
+
+# Editor API Interface Design
+
+ジャーナルエントリの型を「基礎」と「エディタ固有」に分離し、エディタをスイッチ可能にする設計。
+
+---
+
+## 問い
+
+**何が基礎で、何がエディタ固有の型か？**
+
+---
+
+## 分離
+
+```
+┌─────────────────────────────────────────────────┐
+│  Editor Extension (エディタ固有 = opaque JSON)    │
+│                                                   │
+│  サーバーは中身を解釈しない。                       │
+│  保存して返すだけ。スキーマの責任はエディタ側。     │
+├─────────────────────────────────────────────────┤
+│  Base Entry (基礎 = typed JSON)                   │
+│                                                   │
+│  id, content, mediaUrls, createdAt, updatedAt     │
+└─────────────────────────────────────────────────┘
+```
+
+- **Base Entry**: エディタに依存しないジャーナルの本質。サーバーが理解し、AI分析・発酵・検索に使う。変更は全エディタに波及するため最小限に留める。
+- **Editor Extension**: エディタをそのエディタたらしめているもの全て。サーバーにとっては中身の見えないJSON（opaque JSON）。保存して返すだけ。
+
+---
+
+## Base Entry
+
+全フィールド必須。
+
+```tsx
+interface BaseEntry {
+  id: string              // 一意識別子
+  content: string         // プレーンテキスト。分析・発酵・検索の燃料
+  mediaUrls: string[]     // 添付メディアのURI群（順序のみ保持）
+  createdAt: string       // ISO 8601
+  updatedAt: string       // ISO 8601
+}
+```
+
+- title はサーバーが content から自動生成できる
+- メディアの caption, type, position 等はエディタ固有
+
+---
+
+## Editor Extension
+
+サーバーは `Record<string, unknown>` として保存・返却する。中身の解釈は `editorType` + `editorVersion` を知るクライアント側の責務。
+
+```tsx
+// バックエンド — 型を知らない
+extension: Record<string, unknown>
+
+// TypeTrace エディタ（フロント） — 自分だけが型を知っている
+extension: TypeTraceExtension
+```
+
+以下は TypeTrace エディタが extension に入れるデータの参考例。この型はバックエンドには存在せず、エディタのフロントエンドコードだけが持つ。
+
+### TypeTrace Editor (editorType: "typetrace")
+
+```tsx
+interface TypeTraceExtension {
+  // リッチテキスト・レイアウト
+  contentHTML: string
+  writingMode: 'vertical' | 'horizontal'
+  openedAt: string
+
+  // Writing Metrics
+  averageWPM: number
+  peakWPM: number
+  slowestWPM: number
+  totalDeletedCharCount: number
+  totalOpenTime: number
+
+  // 削除履歴
+  deletedBlocks: { text: string; time: string }[]
+
+  // 視覚演出
+  eraserTraceEnabled: boolean
+  erasureTraces: ErasureTrace[]
+  ghost: GhostConfig
+  timeInscription: { enabled: boolean; mode: string }
+  userFontSize: number
+  darkMode: boolean
+  voiceEnabled: boolean
+}
+```
+
+---
+
+## DB設計
+
+```sql
+-- 最新状態（typed JSON。サーバーが分析・検索に使う）
+entries
+  id, content, media_urls, created_at, updated_at
+
+-- 保存のたびに1行追記（immutable）
+entry_snapshots
+  id, entry_id, content, editor_type, editor_version, extension(jsonb), created_at
+```
+
+---
+
+## 運用の具体例
+
+### Case 1: TypeTrace で記事を書いて保存
+
+```
+entries
+  id: entry-001
+  content: "今日、カント君の展示に行った。"
+  updated_at: 2026-03-15T10:30
+
+entry_snapshots
+  ① entry-001, "今日、カント君の展示に行った。", typetrace, 1.0.0,
+     { erasureTraces: [...], ghost: {mode:"block",...}, averageWPM: 6.64, ... },
+     2026-03-15T10:30
+```
+
+### Case 2: Minimal エディタで同じ記事を編集して保存
+
+entries の content が更新され、snapshot が追記される。
+
+```
+entries
+  id: entry-001
+  content: "今日、カント君の展示に行った。すごく良かった。"  ← 更新
+  updated_at: 2026-03-16T20:00
+
+entry_snapshots
+  ① entry-001, "今日、カント君の展示に行った。",              typetrace, 1.0.0, { erasureTraces, ... },  2026-03-15T10:30
+  ② entry-001, "今日、カント君の展示に行った。すごく良かった。", minimal,   1.0.0, { darkMode: true },      2026-03-16T20:00  ← 追加
+```
+
+### Case 3: TypeTrace で再び開く
+
+最新の snapshot（②）は minimal → TypeTrace の extension は復元できない → **新規セッションとして開始**。
+
+content は entries から最新を取得:
+
+- content: "今日、カント君の展示に行った。すごく良かった。"
+- extension: 新規初期化（erasureTraces: [], averageWPM: 0, ...）
+
+### Case 4: TypeTrace で編集して保存
+
+```
+entries
+  id: entry-001
+  content: "今日、カント君の展示に行った。大きな発見があった。"  ← 更新
+  updated_at: 2026-03-17T09:00
+
+entry_snapshots
+  ① entry-001, "今日、カント君の...",              typetrace, 1.0.0, { erasureTraces(古), ... },  2026-03-15T10:30
+  ② entry-001, "今日、カント君の...すごく良かった。", minimal,   1.0.0, { darkMode: true },          2026-03-16T20:00
+  ③ entry-001, "今日、カント君の...大きな発見が...",  typetrace, 1.0.0, { erasureTraces(新), ... },  2026-03-17T09:00  ← 追加
+```
+
+### Case 5: TypeTrace で再び開く（今度は復元できる）
+
+最新の snapshot（③）は typetrace → **extension を復元**。
+
+- content: entries から最新
+- extension: ③の { erasureTraces(新), ... }
+
+### Case 6: TypeTrace がバージョンアップ（v1.0.0 → v1.1.0）
+
+最新の snapshot（③）は typetrace v1.0.0 → v1.1.0 のコードが読み込む。
+
+```tsx
+function loadExtension(snapshot) {
+  const ext = snapshot.extension
+  if (snapshot.editorVersion < "1.1.0") {
+    ext.soundEffect = { enabled: false, type: "typewriter" }  // デフォルト補完
+  }
+  return ext
+}
+```
+
+保存すると v1.1.0 の snapshot が追記される:
+
+```
+entry_snapshots
+  ① typetrace, 1.0.0, { ... },                          2026-03-15
+  ② minimal,   1.0.0, { darkMode: true },                2026-03-16
+  ③ typetrace, 1.0.0, { erasureTraces(新), ... },        2026-03-17
+  ④ typetrace, 1.1.0, { erasureTraces(新), soundEffect: {...}, ... },  2026-03-18  ← 追加
+```
+
+---
+
+## Extension のバージョニング
+
+サーバーは extension を opaque JSON として保存するため、DBマイグレーションは不要。スキーマが変わった時の整合性はエディタ側のコードが `editorVersion` を見て担保する。
+
+### エディタ側のマイグレーションコード
+
+```tsx
+function loadExtension(snapshot): TypeTraceExtension {
+  const ext = snapshot.extension
+
+  if (snapshot.editorVersion < "1.2.0") {
+    // ghost.blurStart/End → ghost.blur.start/end に構造変更
+    ext.ghost = {
+      ...ext.ghost,
+      blur: { start: ext.ghost.blurStart, end: ext.ghost.blurEnd }
+    }
+  }
+
+  if (snapshot.editorVersion < "1.1.0") {
+    ext.soundEffect = { enabled: false, type: "typewriter" }
+  }
+
+  return ext as TypeTraceExtension
+}
+```
+
+---
+
+## 現在の IndexedDB 型の分解
+
+| フィールド | → Base / Extension |
+| --- | --- |
+| id, content | Base |
+| createdAt, updatedAt | Base |
+| title | Extension（サーバーが content から自動生成） |
+| contentHTML, writingMode, openedAt | Extension (TypeTrace) |
+| averageWPM, peakWPM, slowestWPM | Extension (TypeTrace) |
+| totalDeletedCharCount, totalOpenTime | Extension (TypeTrace) |
+| deletedBlocks | Extension (TypeTrace) |
+| eraserTraceEnabled, erasureTraces | Extension (TypeTrace) |
+| ghost*, timeInscription* | Extension (TypeTrace) |
+| userFontSize, darkMode, voiceEnabled | Extension (TypeTrace) |
+
+---
+
+*作成: 2026-03-15*

--- a/docs/OryzaeArchitecture-2.md
+++ b/docs/OryzaeArchitecture-2.md
@@ -1,0 +1,440 @@
+# Oryzae Architecture - 2
+
+# Oryzae Architecture
+
+ジャーナリング支援アプリ「オリゼー」のサーバーサイドアーキテクチャ。
+Claude Code に渡して実装を進めるための指針ドキュメント。
+
+現在のスコープは **entry（ジャーナルエントリ）** に限定する。
+型設計の詳細は EDITOR_API_INTERFACE.md を正とする。
+
+設計思想は [video-processor](https://github.com/team-mirai-volunteer/video-processor/tree/develop) のレイヤードアーキテクチャに基づく。
+
+---
+
+## システム構成
+
+```
+┌─────────────────────────────────────────────────┐
+│  Client Layer                                    │
+│                                                   │
+│  macOS(RN) / iOS(Expo) / Web(Next) / Android(RN) │
+│       │                                           │
+│  packages/adapters  (OS差分吸収)                  │
+│  packages/core      (型, スキーマ)                │
+└───────────────────────┬─────────────────────────┘
+                        │ REST API (HTTPS)
+┌───────────────────────┴─────────────────────────┐
+│  Server Layer (Supabase Edge Functions)          │
+│                                                   │
+│  presentation → application → domain ← infrastructure │
+└──────────────────────────────────────────────────┘
+```
+
+MVP はサーバーサイドの API 配信を先に完成させる。
+クライアントは後続フェーズで接続する。
+
+---
+
+## 技術スタック
+
+| カテゴリ | 技術 | 選定理由 |
+| --- | --- | --- |
+| 言語 | TypeScript | 全レイヤー統一。LLM が最も得意な言語 |
+| ランタイム | Supabase Edge Functions (Deno) | DB/認証と同一基盤でクイックに MVP を立てる |
+| DB/認証/Storage | Supabase (PostgreSQL + Auth + RLS + Storage) | マネージドで MVP 向き |
+| モノレポ | pnpm workspaces | シンプルに始める |
+| リンター/フォーマッタ | Biome | 高速。ESLint + Prettier の代替 |
+| デッドコード検出 | Knip | 不要コードの蓄積を防ぐ |
+
+---
+
+## レイヤードアーキテクチャ
+
+### 依存方向（絶対ルール）
+
+```
+presentation → application → domain ← infrastructure
+```
+
+- **domain は何にも依存しない**（最内層）
+- infrastructure は domain の gateway インターフェースを実装する（依存性逆転）
+- presentation → infrastructure の直接依存は禁止
+- application → infrastructure の直接依存は禁止（gateway IF 経由のみ）
+
+### 各レイヤーの責務
+
+| レイヤー | 責務 | 知っていいもの | 知ってはいけないもの |
+| --- | --- | --- | --- |
+| **presentation** | HTTP ↔ ユースケース変換、バリデーション、認証 | フレームワーク（Hono等）、Zod | Supabase、外部SDK |
+| **application** | ユースケースごとの処理フロー | domain の全要素（models, services, gateways IF） | infrastructure の具体実装 |
+| **domain** | ビジネスルール | 自分自身のみ | 他の全レイヤー |
+| **infrastructure** | 外部依存の具体実装 | domain の gateways IF と models | application, presentation |
+
+### ドメイン層の3要素
+
+[video-processor](https://github.com/team-mirai-volunteer/video-processor/tree/develop) の実装パターンに基づく。
+
+```
+domain/
+├── models/       ドメインモデルの型定義とバリデーション
+├── services/     複数モデルをまたぐ純粋なドメインロジック
+└── gateways/     外部依存すべての抽象インターフェース
+```
+
+| ディレクトリ | 何を置くか | 外部依存 | video-processor での実例 |
+| --- | --- | --- | --- |
+| **models/** | 単一モデルの型、不変条件、ファクトリ | なし | `clip.ts`, `video.ts`, `transcription.ts` |
+| **services/** | 複数モデルをまたぐドメインロジック。純粋関数 | なし | `clip-analysis-prompt.service.ts`（プロンプト組立+パース） |
+| **gateways/** | DB、外部API、ファイルシステム等あらゆる外部依存の抽象IF | なし（IFのみ） | `clip-repository.gateway.ts`（DB）、`ai.gateway.ts`（AI API）、`storage.gateway.ts`（GCS） |
+
+**重要な区別:**
+
+- **gateways/** は DB 操作だけでなく、外部 API・ストレージ等すべての外部依存の抽象を置く場所
+- **services/** は外部依存を持たない。gateway を直接呼ばない。純粋なロジックのみ
+
+---
+
+## ディレクトリ構成
+
+Bounded Context 単位でディレクトリを完全に分離する。
+現在は entry コンテキストのみ。将来 fermentation 等を追加する際も同じ構造で拡張する。
+
+```
+apps/server/src/
+├── contexts/
+│   ├── entry/                                    # エントリ管理コンテキスト
+│   │   ├── presentation/
+│   │   │   └── routes/
+│   │   │       └── entries.ts                    # APIエンドポイント定義
+│   │   ├── application/
+│   │   │   ├── usecases/
+│   │   │   │   ├── create-entry.usecase.ts
+│   │   │   │   ├── update-entry.usecase.ts
+│   │   │   │   ├── get-entry.usecase.ts
+│   │   │   │   ├── list-entries.usecase.ts
+│   │   │   │   └── delete-entry.usecase.ts
+│   │   │   └── errors/
+│   │   │       └── entry.errors.ts
+│   │   ├── domain/
+│   │   │   ├── models/
+│   │   │   │   ├── entry.ts                      # BaseEntry ドメインモデル
+│   │   │   │   └── entry-snapshot.ts             # EntrySnapshot ドメインモデル
+│   │   │   ├── services/
+│   │   │   │   └── snapshot-restoration.service.ts
+│   │   │   └── gateways/
+│   │   │       ├── entry-repository.gateway.ts   # entries テーブル操作の抽象IF
+│   │   │       └── entry-snapshot-repository.gateway.ts
+│   │   └── infrastructure/
+│   │       └── repositories/
+│   │           ├── supabase-entry.repository.ts
+│   │           └── supabase-entry-snapshot.repository.ts
+│   │
+│   └── shared/                                   # コンテキスト間共有
+│       ├── domain/
+│       │   └── gateways/                         # 共通の外部依存IF（将来）
+│       ├── infrastructure/
+│       │   └── supabase-client.ts                # DB接続の共通設定
+│       └── presentation/
+│           └── middleware/
+│               ├── auth.ts                       # Supabase Auth 認証
+│               └── error-handler.ts
+│
+├── index.ts                                      # エントリーポイント
+│
+├── packages/
+│   └── shared/                                   # クライアント・サーバー共有の型定義
+│       └── types/
+│           ├── entry.ts                          # API リクエスト/レスポンス型
+│           └── index.ts
+│
+└── supabase/
+    └── migrations/                               # DBマイグレーション
+```
+
+### ファイル命名規則
+
+video-processor に準拠:
+
+| 種別 | 命名パターン | 例 |
+| --- | --- | --- |
+| ユースケース | `{動詞}-{対象}.usecase.ts` | `create-entry.usecase.ts` |
+| ドメインモデル | `{モデル名}.ts` | `entry.ts`, `entry-snapshot.ts` |
+| ドメインサービス | `{対象}.service.ts` | `snapshot-restoration.service.ts` |
+| gateway IF | `{対象}-repository.gateway.ts` (DB) | `entry-repository.gateway.ts` |
+| gateway IF | `{対象}.gateway.ts` (外部API等) | `ai.gateway.ts`, `storage.gateway.ts` |
+| infrastructure 実装 | `{具体技術}-{対象}.repository.ts` (DB) | `supabase-entry.repository.ts` |
+| infrastructure 実装 | `{対象}.client.ts` (外部API等) | `openai.client.ts` |
+| ルート | `{リソース名}.ts` | `entries.ts` |
+| エラー | `{対象}.errors.ts` | `entry.errors.ts` |
+
+---
+
+## Entry ドメイン設計
+
+### domain/models/entry.ts
+
+EDITOR_API_INTERFACE.md の Base Entry。サーバーが理解し、AI 分析・検索に使う。
+
+```tsx
+export interface BaseEntry {
+  id: string
+  content: string
+  mediaUrls: string[]
+  createdAt: string   // ISO 8601
+  updatedAt: string   // ISO 8601
+}
+```
+
+### domain/models/entry-snapshot.ts
+
+保存のたびに1行追記される immutable な履歴。
+`extension` は opaque JSON — ドメイン層はこの中身を解釈しない。
+
+```tsx
+export interface EntrySnapshot {
+  id: string
+  entryId: string
+  content: string
+  editorType: string
+  editorVersion: string
+  extension: Record<string, unknown>
+  createdAt: string
+}
+```
+
+### domain/gateways/entry-repository.gateway.ts
+
+```tsx
+import type { BaseEntry } from '../models/entry'
+
+export interface EntryRepositoryGateway {
+  findById(id: string): Promise<BaseEntry | null>
+  listByUserId(userId: string, cursor?: string, limit?: number): Promise<BaseEntry[]>
+  save(entry: BaseEntry): Promise<void>
+  delete(id: string): Promise<void>
+}
+```
+
+### domain/gateways/entry-snapshot-repository.gateway.ts
+
+```tsx
+import type { EntrySnapshot } from '../models/entry-snapshot'
+
+export interface EntrySnapshotRepositoryGateway {
+  /** immutable append-only */
+  append(snapshot: Omit<EntrySnapshot, 'id' | 'createdAt'>): Promise<EntrySnapshot>
+
+  /** 最新の1行を取得。エディタスイッチ判定に使う */
+  findLatestByEntryId(entryId: string): Promise<EntrySnapshot | null>
+}
+```
+
+### domain/services/snapshot-restoration.service.ts
+
+Entry × Snapshot をまたぐドメインロジック。外部依存なし。
+EDITOR_API_INTERFACE.md の Case 3（復元不可）/ Case 5（復元可能）を実装。
+
+```tsx
+import type { EntrySnapshot } from '../models/entry-snapshot'
+
+export function resolveExtension(
+  latestSnapshot: EntrySnapshot | null,
+  requestedEditorType: string
+): Record<string, unknown> | null {
+  if (!latestSnapshot) return null
+  if (latestSnapshot.editorType === requestedEditorType) {
+    return latestSnapshot.extension
+  }
+  return null
+}
+```
+
+---
+
+## REST API
+
+```
+POST   /api/v1/entries              新規作成
+GET    /api/v1/entries              一覧取得（カーソルページネーション）
+GET    /api/v1/entries/:id          詳細取得（最新 snapshot 含む）
+PUT    /api/v1/entries/:id          編集保存（entries 更新 + snapshot 追記）
+DELETE /api/v1/entries/:id          削除（cascade で snapshots も削除）
+```
+
+---
+
+## DB 設計
+
+EDITOR_API_INTERFACE.md に準拠。
+
+```sql
+create table public.entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  media_urls text[] default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.entry_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  content text not null,
+  editor_type text not null,
+  editor_version text not null,
+  extension jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index idx_entries_user on entries(user_id, created_at desc);
+create index idx_snapshots_entry on entry_snapshots(entry_id, created_at desc);
+
+alter table public.entries enable row level security;
+alter table public.entry_snapshots enable row level security;
+
+create policy "entries_own_data" on public.entries
+  for all using (user_id = auth.uid());
+
+create policy "snapshots_own_data" on public.entry_snapshots
+  for all using (
+    entry_id in (select id from public.entries where user_id = auth.uid())
+  );
+```
+
+---
+
+## 並列開発フロー
+
+video-processor の開発手法に倣う。
+gateway IF を「契約」として先に確定させ、以降のレイヤーを並列実装する。
+
+```
+Phase A: 契約を決める（直列）
+  domain/models/      → BaseEntry, EntrySnapshot の型定義
+  domain/gateways/    → EntryRepositoryGateway, EntrySnapshotRepositoryGateway の IF 定義
+  ↓ 契約確定。以降は触るファイルが完全に別なので並列実装可能
+
+Phase B: 並列実装
+  B1: domain/services/snapshot-restoration.service.ts     ← 純粋ロジック
+  B2: infrastructure/repositories/supabase-entry.repository.ts
+  B3: infrastructure/repositories/supabase-entry-snapshot.repository.ts
+  B4: presentation/routes/entries.ts + middleware/
+
+Phase C: 統合（直列）
+  application/usecases/ で全レイヤーを結合
+```
+
+Phase B は **4並列で同時実行可能**。
+
+### Claude Code への指示テンプレート
+
+```
+下記設計ドキュメントの Phase B2 を実装してください。
+設計書: docs/renewal/ARCHITECTURE.md
+並列で別のエージェントも別のタスクを作業しているので、他のタスクは着手しないでください。
+```
+
+---
+
+## ガードレール
+
+### 1. dependency-cruiser によるレイヤー依存の自動検証
+
+CI で PR ごとに検証。video-processor と同じルール体系。
+
+```
+domain/ → infrastructure/        ❌
+domain/ → presentation/          ❌
+domain/ → application/           ❌
+application/ → infrastructure/   ❌（gateway IF 経由のみ）
+presentation/ → infrastructure/  ❌
+コンテキスト間の直接依存          ❌（shared/ 経由のみ）
+循環依存                          ❌
+```
+
+### 2. レイヤーごとのテスト原則
+
+| レイヤー | テスト種別 | 方針 |
+| --- | --- | --- |
+| domain/models, domain/services | ユニットテスト | 全ロジックに必須。外部依存なし |
+| application/usecases | ユニットテスト | gateway をモックして処理フローを検証 |
+| infrastructure/repositories | インテグレーションテスト | 実際の Supabase に対して実行 |
+
+### 3. Git フック（品質チェックの3段構え）
+
+video-processor と同じ構成。
+
+| タイミング | チェック内容 |
+| --- | --- |
+| pre-commit | lint-staged で変更ファイルのみ Biome check |
+| pre-push | lint + typecheck（全体） |
+| CI | Biome + Knip + dependency-cruiser + テスト |
+- **`-no-verify` は原則禁止**。[CLAUDE.md](http://claude.md/) に明記する。
+
+### 4. コーディング規約
+
+| 項目 | ルール |
+| --- | --- |
+| フォーマッタ | Biome（シングルクォート、セミコロンあり、インデント2スペース） |
+| エラーハンドリング | domain 層は戻り値で表現、application/infrastructure 層は throw |
+| ユースケース | 1ユースケース = 1ファイル |
+
+---
+
+## [CLAUDE.md](http://claude.md/) + slash command 設計
+
+video-processor に倣い、[CLAUDE.md](http://claude.md/) は薄く保ち、slash command でタスク固有のガイドを注入する。
+
+### [CLAUDE.md](http://claude.md/) に書くもの（常に読まれる共通情報）
+
+- クイックコマンド一覧（dev, lint, typecheck, test）
+- ディレクトリ構成の概要
+- 依存方向ルール（1行）
+- コーディング規約（Biome 設定）
+- `-no-verify` 禁止
+- 機能別ガイドへのリンク
+
+### slash command
+
+```
+.claude/commands/
+├── plan.md              # 設計ドキュメント作成 → docs/tasks/ に保存
+├── review.md            # 設計ガイドライン違反チェック
+├── entry-backend.md     # entry バックエンド実装（アーキテクチャガイド読込）
+├── entry-frontend.md    # entry フロントエンド実装（将来）
+├── pr.md                # ブランチ作成 → 品質チェック → PR 作成
+└── sync.md              # develop を pull
+```
+
+---
+
+## 将来のコンテキスト拡張
+
+```
+contexts/
+├── entry/              # 現在のスコープ
+├── fermentation/       # AI分析・発酵（将来）
+└── shared/             # コンテキスト間共有
+```
+
+fermentation コンテキストは entry の content を使うが、entry を直接 import せず shared 経由で疎結合に接続する。
+新しいコンテキストを追加する際も同じレイヤー構成（presentation / application / domain / infrastructure）を踏襲する。
+
+---
+
+## 関連ドキュメント
+
+| ドキュメント | 内容 |
+| --- | --- |
+| EDITOR_API_INTERFACE.md | Base Entry / Editor Extension の型分離, DB設計, 運用例 (Case 1-6) |
+| [REQUIREMENTS.md](http://requirements.md/) | ビジョン, 設計原則, 機能要件, フェーズ計画 |
+| FERMENTATION_DESIGN.md | 多層発酵システム設計（将来） |
+
+## 参考
+
+| リソース | 内容 |
+| --- | --- |
+| [video-processor](https://github.com/team-mirai-volunteer/video-processor/tree/develop) | 本アーキテクチャの参考実装。DDD + レイヤードアーキテクチャの実プロジェクト |
+| [超並列LLMコーディングのハーネスエンジニアリング](https://note.com/jujunjun110/n/n66306cab294a) | 設計思想の元記事。並列開発フロー、ガードレールの考え方 |

--- a/docs/OryzaeArchitecture.md
+++ b/docs/OryzaeArchitecture.md
@@ -1,0 +1,654 @@
+# Oryzae Architecture
+
+# Oryzae Architecture
+
+Picklesを前身とするジャーナリング支援アプリ。フルリニューアル。
+現在のスコープは **entry（ジャーナルエントリ）の実装** に限定する。
+
+型設計の詳細は EDITOR_API_INTERFACE.md を正とする。
+
+参考実装: [team-mirai-volunteer/video-processor](https://github.com/team-mirai-volunteer/video-processor)（レイヤードアーキテクチャの実プロジェクト事例）
+
+---
+
+## システム構成
+
+```
+┌─────────────────────────────────────────────────┐
+│  Client Layer                                    │
+│                                                   │
+│  macOS(RN) / iOS(Expo) / Web(Next) / Android(RN) │
+│       │                                           │
+│  packages/adapters  (OS差分吸収)                  │
+│  packages/core      (型, スキーマ)                │
+└───────────────────────┬─────────────────────────┘
+                        │ REST API (HTTPS)
+┌───────────────────────┴─────────────────────────┐
+│  Server Layer (Hono on Supabase Edge Functions)  │
+│                                                   │
+│  presentation → application → domain ← infrastructure │
+└──────────────────────────────────────────────────┘
+```
+
+---
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+| --- | --- |
+| 言語 | TypeScript（全レイヤー） |
+| モノレポ | Turborepo + pnpm |
+| macOS | React Native for macOS（MVP） |
+| API | Hono + Zod + zod-to-openapi |
+| DB/認証 | Supabase (PostgreSQL + Auth + RLS) |
+
+---
+
+## レイヤードアーキテクチャ（Server Layer）
+
+### 依存方向（絶対ルール）
+
+```
+presentation → application → domain ← infrastructure
+```
+
+- domain は何も import しない（最内層）
+- infrastructure は domain の gateway IF を実装する（依存性逆転）
+- presentation が infrastructure を直接触ることはない
+
+### 各レイヤーの責務
+
+| レイヤー | 責務 | 何を知っているか |
+| --- | --- | --- |
+| **presentation** | HTTP ↔ ユースケース変換。バリデーション | Hono, Zod |
+| **application** | ユースケースごとの処理フロー | domain のモデル・サービス・gateway IF |
+| **domain** | ビジネスルール。外部依存なし | 自分自身のみ |
+| **infrastructure** | 外部依存（DB, 外部API等）の具体実装 | Supabase, 外部SDK |
+
+### ドメイン層の3要素
+
+video-processor リポジトリの実装に基づく設計:
+
+| ディレクトリ | 役割 | 外部依存 | 例 |
+| --- | --- | --- | --- |
+| **models/** | 単一ドメインモデルのロジック・バリデーション | なし | Entry の不変条件、Snapshot の型定義 |
+| **services/** | 複数のドメインモデルをまたぐ純粋なドメインロジック | なし | Entry × Snapshot のエディタスイッチ判定 |
+| **gateways/** | 外部依存すべての抽象インターフェース | なし（IFのみ） | DB操作、外部API呼び出しの契約 |
+
+**重要な区別:**
+
+- gateway はDB操作 **だけでなく** 、外部API・ファイルシステム等あらゆる外部依存の抽象を置く場所
+- services は外部依存を持たない純粋なドメインロジックの置き場。gateway を直接呼ばない
+
+### レイヤー構成
+
+```
+apps/server/src/
+├── contexts/
+│   └── entry/                              # エントリ管理コンテキスト
+│       ├── presentation/
+│       │   ├── routes/
+│       │   │   └── entries.ts              # APIエンドポイント定義
+│       │   └── middleware/
+│       │       └── auth.ts                 # 認証・バリデーション
+│       ├── application/
+│       │   └── usecases/
+│       │       ├── create-entry.ts
+│       │       ├── update-entry.ts
+│       │       ├── get-entry.ts
+│       │       ├── list-entries.ts
+│       │       └── delete-entry.ts
+│       ├── domain/
+│       │   ├── models/
+│       │   │   ├── entry.ts                # BaseEntry ドメインモデル
+│       │   │   └── entry-snapshot.ts       # EntrySnapshot ドメインモデル
+│       │   ├── services/
+│       │   │   └── snapshot-restoration.service.ts
+│       │   │       # Entry × Snapshot をまたぐドメインロジック
+│       │   │       # エディタスイッチ時の extension 復元判定
+│       │   └── gateways/
+│       │       ├── entry-repository.gateway.ts
+│       │       │   # entries テーブル操作の抽象IF
+│       │       └── entry-snapshot-repository.gateway.ts
+│       │           # entry_snapshots テーブル操作の抽象IF
+│       └── infrastructure/
+│           └── repositories/
+│               ├── supabase-entry.repository.ts
+│               │   # entry-repository.gateway の Supabase 実装
+│               └── supabase-entry-snapshot.repository.ts
+│                   # entry-snapshot-repository.gateway の Supabase 実装
+│
+├── shared/                                 # コンテキスト間共有コード（将来）
+│   └── infrastructure/
+│       └── supabase-client.ts              # DB接続の共通設定
+│
+└── index.ts                                # エントリーポイント
+```
+
+---
+
+## ドメイン層 詳細設計
+
+### domain/models/entry.ts
+
+EDITOR_API_INTERFACE.md の Base Entry をドメインモデルとして定義。
+
+```tsx
+export interface BaseEntry {
+  id: string
+  content: string
+  mediaUrls: string[]
+  createdAt: string
+  updatedAt: string
+}
+```
+
+### domain/models/entry-snapshot.ts
+
+entry_snapshots の1行を表すドメインモデル。
+
+```tsx
+export interface EntrySnapshot {
+  id: string
+  entryId: string
+  content: string
+  editorType: string
+  editorVersion: string
+  extension: Record<string, unknown>  // opaque JSON — Domain はこの中身を知らない
+  createdAt: string
+}
+```
+
+---
+
+### domain/gateways/entry-repository.gateway.ts
+
+entries テーブル操作の抽象インターフェース。
+
+```tsx
+import type { BaseEntry } from '../models/entry'
+
+export interface EntryRepositoryGateway {
+  findById(id: string): Promise<BaseEntry | null>
+  listByUserId(userId: string, cursor?: string, limit?: number): Promise<BaseEntry[]>
+  save(entry: BaseEntry): Promise<void>
+  delete(id: string): Promise<void>
+}
+```
+
+### domain/gateways/entry-snapshot-repository.gateway.ts
+
+entry_snapshots テーブル操作の抽象インターフェース。
+snapshot は immutable（append-only）。
+
+```tsx
+import type { EntrySnapshot } from '../models/entry-snapshot'
+
+export interface EntrySnapshotRepositoryGateway {
+  /**
+   * entry_snapshots に1行追記（immutable append-only）。
+   * @see EDITOR_API_INTERFACE.md DB設計
+   */
+  append(snapshot: Omit<EntrySnapshot, 'id' | 'createdAt'>): Promise<EntrySnapshot>
+
+  /**
+   * entry_snapshots から最新の1行を取得。
+   * エディタスイッチ判定（snapshot-restoration.service.ts）に使う。
+   * @see EDITOR_API_INTERFACE.md Case 3, Case 5
+   */
+  findLatestByEntryId(entryId: string): Promise<EntrySnapshot | null>
+}
+```
+
+---
+
+### domain/services/snapshot-restoration.service.ts
+
+EDITOR_API_INTERFACE.md の Case 3 / Case 5 のビジネスルールを実装。
+Entry と Snapshot の両方を知る必要があるドメインロジック。
+外部依存なし（純粋関数）。
+
+```tsx
+import type { EntrySnapshot } from '../models/entry-snapshot'
+
+/**
+ * エディタスイッチ時の extension 復元判定。
+ *
+ * - 最新 snapshot の editorType が要求と一致 → extension を返す（復元可能）
+ * - 一致しない or snapshot がない → null（エディタ側が新規初期化する）
+ *
+ * @see EDITOR_API_INTERFACE.md Case 3, Case 5
+ */
+export function resolveExtension(
+  latestSnapshot: EntrySnapshot | null,
+  requestedEditorType: string
+): Record<string, unknown> | null {
+  if (!latestSnapshot) return null
+  if (latestSnapshot.editorType === requestedEditorType) {
+    return latestSnapshot.extension
+  }
+  return null
+}
+```
+
+---
+
+## アプリケーション層 詳細設計
+
+gateway IF だけを知る。Supabase を知らない。
+
+### application/usecases/create-entry.ts
+
+```tsx
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway'
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway'
+import type { BaseEntry } from '../../domain/models/entry'
+
+interface CreateEntryInput {
+  content: string
+  mediaUrls: string[]
+  editorType: string
+  editorVersion: string
+  extension: Record<string, unknown>
+}
+
+export class CreateEntry {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(userId: string, input: CreateEntryInput): Promise<BaseEntry> {
+    const now = new Date().toISOString()
+    const entry: BaseEntry = {
+      id: crypto.randomUUID(),
+      content: input.content,
+      mediaUrls: input.mediaUrls,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await this.entryRepo.save(entry)
+    await this.snapshotRepo.append({
+      entryId: entry.id,
+      content: input.content,
+      editorType: input.editorType,
+      editorVersion: input.editorVersion,
+      extension: input.extension,
+    })
+    return entry
+  }
+}
+```
+
+### application/usecases/get-entry.ts
+
+エントリ取得時に最新 snapshot も返す。クライアントが editorType を見てスイッチ判定する。
+
+```tsx
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway'
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway'
+
+export class GetEntry {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(entryId: string) {
+    const entry = await this.entryRepo.findById(entryId)
+    if (!entry) return null
+    const latestSnapshot = await this.snapshotRepo.findLatestByEntryId(entryId)
+    return { entry, latestSnapshot }
+  }
+}
+```
+
+### application/usecases/update-entry.ts
+
+```tsx
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway'
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway'
+
+interface UpdateEntryInput {
+  content: string
+  mediaUrls: string[]
+  editorType: string
+  editorVersion: string
+  extension: Record<string, unknown>
+}
+
+export class UpdateEntry {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private snapshotRepo: EntrySnapshotRepositoryGateway,
+  ) {}
+
+  async execute(entryId: string, input: UpdateEntryInput) {
+    const existing = await this.entryRepo.findById(entryId)
+    if (!existing) return null
+
+    const updated = {
+      ...existing,
+      content: input.content,
+      mediaUrls: input.mediaUrls,
+      updatedAt: new Date().toISOString(),
+    }
+    await this.entryRepo.save(updated)
+    await this.snapshotRepo.append({
+      entryId: entryId,
+      content: input.content,
+      editorType: input.editorType,
+      editorVersion: input.editorVersion,
+      extension: input.extension,
+    })
+    return updated
+  }
+}
+```
+
+---
+
+## プレゼンテーション層 詳細設計
+
+### presentation/routes/entries.ts
+
+HTTP をユースケースに変換するだけ。ビジネスロジックを含まない。
+
+```tsx
+import { Hono } from 'hono'
+import { CreateEntry } from '../../application/usecases/create-entry'
+import { GetEntry } from '../../application/usecases/get-entry'
+import { UpdateEntry } from '../../application/usecases/update-entry'
+
+const entries = new Hono()
+
+entries.post('/', async (c) => {
+  const usecase = new CreateEntry(c.get('entryRepo'), c.get('snapshotRepo'))
+  const entry = await usecase.execute(c.get('userId'), await c.req.json())
+  return c.json(entry, 201)
+})
+
+entries.get('/:id', async (c) => {
+  const usecase = new GetEntry(c.get('entryRepo'), c.get('snapshotRepo'))
+  const result = await usecase.execute(c.req.param('id'))
+  if (!result) return c.json({ error: 'not found' }, 404)
+  return c.json(result)
+})
+
+entries.put('/:id', async (c) => {
+  const usecase = new UpdateEntry(c.get('entryRepo'), c.get('snapshotRepo'))
+  const result = await usecase.execute(c.req.param('id'), await c.req.json())
+  if (!result) return c.json({ error: 'not found' }, 404)
+  return c.json(result)
+})
+
+export { entries }
+```
+
+---
+
+## インフラストラクチャ層 詳細設計
+
+### infrastructure/repositories/supabase-entry.repository.ts
+
+entry-repository.gateway の Supabase 実装。
+
+```tsx
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway'
+import type { BaseEntry } from '../../domain/models/entry'
+
+export class SupabaseEntryRepository implements EntryRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findById(id: string): Promise<BaseEntry | null> {
+    const { data } = await this.supabase
+      .from('entries').select('*').eq('id', id).single()
+    return data ? this.toBaseEntry(data) : null
+  }
+
+  async save(entry: BaseEntry): Promise<void> {
+    const { error } = await this.supabase
+      .from('entries')
+      .upsert({
+        id: entry.id,
+        content: entry.content,
+        media_urls: entry.mediaUrls,
+        created_at: entry.createdAt,
+        updated_at: entry.updatedAt,
+      })
+    if (error) throw error
+  }
+
+  // ... listByUserId, delete, toBaseEntry
+}
+```
+
+### infrastructure/repositories/supabase-entry-snapshot.repository.ts
+
+entry-snapshot-repository.gateway の Supabase 実装。
+
+```tsx
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway'
+import type { EntrySnapshot } from '../../domain/models/entry-snapshot'
+
+export class SupabaseEntrySnapshotRepository implements EntrySnapshotRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async append(snapshot: Omit<EntrySnapshot, 'id' | 'createdAt'>): Promise<EntrySnapshot> {
+    const { data, error } = await this.supabase
+      .from('entry_snapshots')
+      .insert({
+        entry_id: snapshot.entryId,
+        content: snapshot.content,
+        editor_type: snapshot.editorType,
+        editor_version: snapshot.editorVersion,
+        extension: snapshot.extension,
+      })
+      .select()
+      .single()
+    if (error) throw error
+    return this.toEntrySnapshot(data)
+  }
+
+  async findLatestByEntryId(entryId: string): Promise<EntrySnapshot | null> {
+    const { data } = await this.supabase
+      .from('entry_snapshots')
+      .select('*')
+      .eq('entry_id', entryId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single()
+    if (!data) return null
+    return this.toEntrySnapshot(data)
+  }
+
+  // ... toEntrySnapshot
+}
+```
+
+---
+
+## リクエストの流れ（例: エントリ保存）
+
+```
+クライアント（TypeTrace エディタ）
+  │
+  │  PUT /api/v1/entries/:id
+  │  { content, mediaUrls, editorType, editorVersion, extension }
+  │
+  ▼
+presentation/routes/entries.ts
+  │  HTTP → UpdateEntryInput に変換
+  ▼
+application/usecases/update-entry.ts
+  │  entryRepo.save(entry) + snapshotRepo.append(snapshot)
+  ▼
+domain/gateways/ (IF)
+  │  entry-repository.gateway.ts
+  │  entry-snapshot-repository.gateway.ts
+  ▼
+infrastructure/repositories/
+  │  supabase-entry.repository.ts         → entries UPSERT
+  │  supabase-entry-snapshot.repository.ts → entry_snapshots INSERT
+  ▼
+Supabase (PostgreSQL)
+  │  entries テーブル: BaseEntry（typed JSON）
+  │  entry_snapshots テーブル: content + editorType + editorVersion + extension（opaque JSON）
+```
+
+---
+
+## 並列開発フェーズ
+
+gateway IF を「契約」として先に確定させ、以降のレイヤーを並列実装する。
+
+```
+Phase A: 契約を決める（直列）
+  1. domain/models/entry.ts, entry-snapshot.ts
+  2. domain/gateways/entry-repository.gateway.ts
+  3. domain/gateways/entry-snapshot-repository.gateway.ts
+  ↓ 契約確定
+
+Phase B: 並列実装（触るファイルが完全に別）
+  B1: domain/services/snapshot-restoration.service.ts  ← 純粋ドメインロジック
+  B2: infrastructure/repositories/supabase-entry.repository.ts
+  B3: infrastructure/repositories/supabase-entry-snapshot.repository.ts
+  B4: presentation/routes/entries.ts + middleware/
+
+Phase C: 統合（直列）
+  application/usecases/ でレイヤーを結合
+```
+
+Phase B の4タスクは触るファイルが完全に別なので **4並列で同時に実行可能**。
+
+---
+
+## ガードレール
+
+### 1. dependency-cruiser によるレイヤー間依存方向の自動検証
+
+```
+domain/ → infrastructure/        ❌ 禁止
+domain/ → presentation/          ❌ 禁止
+domain/ → application/           ❌ 禁止
+application/ → infrastructure/   ❌ 禁止（gateway IF 経由のみ）
+presentation/ → infrastructure/  ❌ 禁止
+コンテキスト間の直接依存          ❌ 禁止（shared/ 経由のみ）
+```
+
+CI で PR ごとに自動検証する。
+
+### 2. レイヤーごとのテスト原則
+
+| レイヤー | テスト種別 | 方針 |
+| --- | --- | --- |
+| domain/models, domain/services | ユニットテスト | 全ロジックに必須。外部依存なしなので高速 |
+| application/usecases | ユニットテスト | gateway をモックして処理フローを検証 |
+| infrastructure/repositories | インテグレーションテスト | 実際の Supabase に対して実行 |
+| presentation/routes | E2Eテスト | APIエンドポイントの結合テスト |
+
+### 3. Git フック（品質チェックの3段構え）
+
+| タイミング | チェック内容 |
+| --- | --- |
+| pre-commit | lint-staged で変更ファイルのみ Biome check |
+| pre-push | lint + typecheck（全体） |
+| CI | Biome + dependency-cruiser + テスト |
+- `-no-verify` は原則禁止（[CLAUDE.md](http://claude.md/) に明記）。
+
+### 4. 1ユースケース = 1ファイル
+
+### 5. [CLAUDE.md](http://claude.md/) + slash command による情報の構造化
+
+- [CLAUDE.md](http://claude.md/): 共通ルール（薄く保つ）
+- slash command: タスクに応じた専門情報を注入
+
+```
+.claude/commands/
+├── plan.md              # 設計ドキュメント作成
+├── review.md            # 設計ガイドライン違反チェック
+├── entry-backend.md     # entry バックエンド実装時のガイド
+└── entry-frontend.md    # entry フロントエンド実装時のガイド
+```
+
+---
+
+## DB設計
+
+EDITOR_API_INTERFACE.md に準拠。
+
+```sql
+create table public.entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  media_urls text[] default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.entry_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  content text not null,
+  editor_type text not null,
+  editor_version text not null,
+  extension jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index idx_entries_user on entries(user_id, created_at desc);
+create index idx_snapshots_entry on entry_snapshots(entry_id, created_at desc);
+
+alter table public.entries enable row level security;
+alter table public.entry_snapshots enable row level security;
+
+create policy "entries_own_data" on public.entries
+  for all using (user_id = auth.uid());
+
+create policy "snapshots_own_data" on public.entry_snapshots
+  for all using (
+    entry_id in (select id from public.entries where user_id = auth.uid())
+  );
+```
+
+---
+
+## REST API エンドポイント
+
+```
+POST   /api/v1/entries              # 新規作成
+GET    /api/v1/entries              # 一覧取得
+GET    /api/v1/entries/:id          # 詳細取得（最新snapshot含む）
+PUT    /api/v1/entries/:id          # 編集保存
+DELETE /api/v1/entries/:id          # 削除
+```
+
+---
+
+## 将来のコンテキスト拡張
+
+```
+contexts/
+├── entry/              # 現在のスコープ
+├── fermentation/       # AI分析・発酵（将来）
+└── shared/             # コンテキスト間共有
+```
+
+`fermentation/` は `entry/` の `content` を使うが、直接 import せず `shared/` 経由またはイベント駆動で疎結合に接続する。
+
+---
+
+## 関連ドキュメント
+
+| ドキュメント | 内容 |
+| --- | --- |
+| [REQUIREMENTS.md](http://requirements.md/) | ビジョン, 設計原則, 機能要件, フェーズ計画 |
+| EDITOR_API_INTERFACE.md | Base Entry / Editor Extension の型分離, DB設計, 運用例 (Case 1-6) |
+| FERMENTATION_DESIGN.md | 多層発酵システム設計（将来） |
+
+---
+
+*初版: 2026-02-03 / entry スコープ + レイヤードアーキテクチャ: 2026-03-20*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "oryzae",
+  "private": true,
+  "packageManager": "pnpm@10.26.2",
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1174 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/server:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.0
+        version: 1.19.11(hono@4.12.8)
+      '@supabase/supabase-js':
+        specifier: ^2.49.0
+        version: 2.99.3
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.8
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@supabase/auth-js@2.99.3':
+    resolution: {integrity: sha512-vMEVLA1kGGYd/kdsJSwtjiFUZM1nGfrz2DWmgMBZtocV48qL+L2+4QpIkueXyBEumMQZFEyhz57i/5zGHjvdBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.99.3':
+    resolution: {integrity: sha512-6tk2zrcBkzKaaBXPOG5nshn30uJNFGOH9LxOnE8i850eQmsX+jVm7vql9kTPyvUzEHwU4zdjSOkXS9M+9ukMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.99.3':
+    resolution: {integrity: sha512-8HxEf+zNycj7Z8+ONhhlu+7J7Ha+L6weyCtdEeK2mN5OWJbh6n4LPU4iuJ5UlCvvNnbSXMoutY7piITEEAgl2g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.99.3':
+    resolution: {integrity: sha512-c1azgZ2nZPczbY5k5u5iFrk1InpxN81IvNE+UBAkjrBz3yc5ALLJNkeTQwbJZT4PZBuYXEzqYGLMuh9fdTtTMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.99.3':
+    resolution: {integrity: sha512-lOfIm4hInNcd8x0i1LWphnLKxec42wwbjs+vhaVAvR801Vda0UAMbTooUY6gfqgQb8v29GofqKuQMMTAsl6w/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.99.3':
+    resolution: {integrity: sha512-GuPbzoEaI51AkLw9VGhLNvnzw4PHbS3p8j2/JlvLeZNQMKwZw4aEYQIDBRtFwL5Nv7/275n9m4DHtakY8nCvgg==}
+    engines: {node: '>=20.0.0'}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@supabase/auth-js@2.99.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.99.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.99.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.99.3':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.99.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.99.3':
+    dependencies:
+      '@supabase/auth-js': 2.99.3
+      '@supabase/functions-js': 2.99.3
+      '@supabase/postgrest-js': 2.99.3
+      '@supabase/realtime-js': 2.99.3
+      '@supabase/storage-js': 2.99.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/phoenix@1.6.7': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  hono@4.12.8: {}
+
+  iceberg-js@0.8.1: {}
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.19.0: {}
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/supabase/migrations/00001_create_entries.sql
+++ b/supabase/migrations/00001_create_entries.sql
@@ -1,0 +1,32 @@
+create table public.entries (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null,
+  media_urls text[] default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.entry_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  content text not null,
+  editor_type text not null,
+  editor_version text not null,
+  extension jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index idx_entries_user on entries(user_id, created_at desc);
+create index idx_snapshots_entry on entry_snapshots(entry_id, created_at desc);
+
+alter table public.entries enable row level security;
+alter table public.entry_snapshots enable row level security;
+
+create policy "entries_own_data" on public.entries
+  for all using (user_id = auth.uid());
+
+create policy "snapshots_own_data" on public.entry_snapshots
+  for all using (
+    entry_id in (select id from public.entries where user_id = auth.uid())
+  );


### PR DESCRIPTION
## Summary

- pnpm workspaces によるモノレポ構築
- Entry コンテキストをレイヤードアーキテクチャ（presentation → application → domain ← infrastructure）で実装
- Supabase (PostgreSQL + Auth + RLS) を使った Entry / EntrySnapshot の CRUD API
- DB マイグレーション、ドメインサービスのユニットテスト付き

### API エンドポイント

| メソッド | パス | 説明 |
|---|---|---|
| POST | `/api/v1/entries` | エントリ新規作成 |
| GET | `/api/v1/entries` | エントリ一覧 |
| GET | `/api/v1/entries/:id` | エントリ詳細（最新snapshot含む） |
| PUT | `/api/v1/entries/:id` | エントリ更新 + snapshot追記 |
| DELETE | `/api/v1/entries/:id` | エントリ削除 |

### アーキテクチャ

```
contexts/entry/
  presentation/   → HTTP ↔ ユースケース変換 (Hono + Zod)
  application/    → ユースケース (create, get, list, update, delete)
  domain/         → モデル, サービス, gateway IF
  infrastructure/ → Supabase リポジトリ実装
```

## Test plan

- [x] `snapshot-restoration.service` のユニットテスト（3ケース pass）
- [x] TypeScript 型チェック pass
- [ ] Supabase ローカル環境で curl による CRUD 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)