### PR TITLE
feat: Question バックエンド実装（レイヤードアーキテクチャ）

### DIFF
--- a/apps/server/src/contexts/question/application/errors/question.errors.ts
+++ b/apps/server/src/contexts/question/application/errors/question.errors.ts
@@ -1,0 +1,28 @@
+import {
+  NotFoundError,
+  ValidationError,
+} from '../../../shared/application/errors/application.errors';
+
+export class QuestionNotFoundError extends NotFoundError {
+  constructor(questionId: string) {
+    super(`Question not found: ${questionId}`);
+  }
+}
+
+export class QuestionValidationError extends ValidationError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class QuestionLimitExceededError extends ValidationError {
+  constructor() {
+    super('Maximum of 3 active questions per user');
+  }
+}
+
+export class QuestionNotPendingError extends ValidationError {
+  constructor(questionId: string) {
+    super(`Question is not a pending proposal: ${questionId}`);
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/accept-question-proposal.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/accept-question-proposal.usecase.ts
@@ -1,0 +1,55 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+import {
+  QuestionNotFoundError,
+  QuestionNotPendingError,
+  QuestionLimitExceededError,
+} from '../errors/question.errors';
+
+export class AcceptQuestionProposalUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(
+    questionId: string,
+  ): Promise<QuestionProps & { currentText: string }> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    if (!question.isValidatedByUser) {
+      // New question proposal — validate the question itself
+      const activeCount = await this.questionRepo.countActiveByUserId(
+        question.userId,
+      );
+      if (activeCount >= 3) throw new QuestionLimitExceededError();
+
+      const validated = question.withValidated();
+      await this.questionRepo.save(validated);
+
+      const unvalidatedTx =
+        await this.transactionRepo.findLatestUnvalidatedByQuestionId(
+          questionId,
+        );
+      if (unvalidatedTx) {
+        const validatedTx = unvalidatedTx.withValidated();
+        await this.transactionRepo.save(validatedTx);
+        return { ...validated.toProps(), currentText: validatedTx.string };
+      }
+
+      return { ...validated.toProps(), currentText: '' };
+    }
+
+    // Existing question text update proposal
+    const unvalidatedTx =
+      await this.transactionRepo.findLatestUnvalidatedByQuestionId(questionId);
+    if (!unvalidatedTx) throw new QuestionNotPendingError(questionId);
+
+    const validatedTx = unvalidatedTx.withValidated();
+    await this.transactionRepo.save(validatedTx);
+
+    return { ...question.toProps(), currentText: validatedTx.string };
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/archive-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/archive-question.usecase.ts
@@ -1,0 +1,17 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+import { QuestionNotFoundError } from '../errors/question.errors';
+
+export class ArchiveQuestionUsecase {
+  constructor(private questionRepo: QuestionRepositoryGateway) {}
+
+  async execute(questionId: string): Promise<QuestionProps> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    const archived = question.withArchived();
+    await this.questionRepo.save(archived);
+
+    return archived.toProps();
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/create-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/create-question.usecase.ts
@@ -1,0 +1,51 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import { Question, type QuestionProps } from '../../domain/models/question';
+import { QuestionTransaction } from '../../domain/models/question-transaction';
+import {
+  QuestionLimitExceededError,
+  QuestionValidationError,
+} from '../errors/question.errors';
+
+interface CreateQuestionInput {
+  string: string;
+}
+
+export class CreateQuestionUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(
+    userId: string,
+    input: CreateQuestionInput,
+  ): Promise<QuestionProps & { currentText: string }> {
+    const activeCount = await this.questionRepo.countActiveByUserId(userId);
+    if (activeCount >= 3) throw new QuestionLimitExceededError();
+
+    const question = Question.create(
+      { userId, isProposedByOryzae: false },
+      this.generateId,
+    );
+
+    const txResult = QuestionTransaction.create(
+      {
+        questionId: question.id,
+        string: input.string,
+        questionVersion: 1,
+        isProposedByOryzae: false,
+      },
+      this.generateId,
+    );
+    if (!txResult.success) {
+      throw new QuestionValidationError(txResult.error.message);
+    }
+
+    await this.questionRepo.save(question);
+    await this.transactionRepo.append(txResult.value);
+
+    return { ...question.toProps(), currentText: txResult.value.string };
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/edit-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/edit-question.usecase.ts
@@ -1,0 +1,49 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+import { QuestionTransaction } from '../../domain/models/question-transaction';
+import {
+  QuestionNotFoundError,
+  QuestionValidationError,
+} from '../errors/question.errors';
+
+interface EditQuestionInput {
+  string: string;
+}
+
+export class EditQuestionUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(
+    questionId: string,
+    input: EditQuestionInput,
+  ): Promise<QuestionProps & { currentText: string }> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    const latest =
+      await this.transactionRepo.findLatestByQuestionId(questionId);
+    const nextVersion = latest ? latest.questionVersion + 1 : 1;
+
+    const txResult = QuestionTransaction.create(
+      {
+        questionId,
+        string: input.string,
+        questionVersion: nextVersion,
+        isProposedByOryzae: false,
+      },
+      this.generateId,
+    );
+    if (!txResult.success) {
+      throw new QuestionValidationError(txResult.error.message);
+    }
+
+    await this.transactionRepo.append(txResult.value);
+
+    return { ...question.toProps(), currentText: txResult.value.string };
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/get-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/get-question.usecase.ts
@@ -1,0 +1,33 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+import type { QuestionTransactionProps } from '../../domain/models/question-transaction';
+
+interface GetQuestionResult {
+  question: QuestionProps;
+  currentText: string | null;
+  transactions: QuestionTransactionProps[];
+}
+
+export class GetQuestionUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(questionId: string): Promise<GetQuestionResult | null> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) return null;
+
+    const transactions =
+      await this.transactionRepo.listByQuestionId(questionId);
+    const latestValidated =
+      await this.transactionRepo.findLatestValidatedByQuestionId(questionId);
+
+    return {
+      question: question.toProps(),
+      currentText: latestValidated?.string ?? null,
+      transactions: transactions.map((tx) => tx.toProps()),
+    };
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/link-question-to-entry.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/link-question-to-entry.usecase.ts
@@ -1,0 +1,22 @@
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway';
+import { QuestionNotFoundError } from '../errors/question.errors';
+
+export class LinkQuestionToEntryUsecase {
+  constructor(
+    private linkRepo: EntryQuestionLinkRepositoryGateway,
+    private questionRepo: QuestionRepositoryGateway,
+    private entryRepo: EntryRepositoryGateway,
+  ) {}
+
+  async execute(entryId: string, questionId: string): Promise<void> {
+    const entry = await this.entryRepo.findById(entryId);
+    if (!entry) throw new Error(`Entry not found: ${entryId}`);
+
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    await this.linkRepo.link(entryId, questionId);
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/list-active-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-active-questions.usecase.ts
@@ -1,0 +1,23 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+
+export class ListActiveQuestionsUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(
+    userId: string,
+  ): Promise<Array<QuestionProps & { currentText: string | null }>> {
+    const questions = await this.questionRepo.listActiveByUserId(userId);
+    const results = [];
+    for (const q of questions) {
+      const tx =
+        await this.transactionRepo.findLatestValidatedByQuestionId(q.id);
+      results.push({ ...q.toProps(), currentText: tx?.string ?? null });
+    }
+    return results;
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/list-all-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-all-questions.usecase.ts
@@ -1,0 +1,23 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+
+export class ListAllQuestionsUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(
+    userId: string,
+  ): Promise<Array<QuestionProps & { currentText: string | null }>> {
+    const questions = await this.questionRepo.listAllByUserId(userId);
+    const results = [];
+    for (const q of questions) {
+      const tx =
+        await this.transactionRepo.findLatestValidatedByQuestionId(q.id);
+      results.push({ ...q.toProps(), currentText: tx?.string ?? null });
+    }
+    return results;
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/list-entry-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-entry-questions.usecase.ts
@@ -1,0 +1,28 @@
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+
+export class ListEntryQuestionsUsecase {
+  constructor(
+    private linkRepo: EntryQuestionLinkRepositoryGateway,
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(
+    entryId: string,
+  ): Promise<Array<QuestionProps & { currentText: string | null }>> {
+    const questionIds =
+      await this.linkRepo.listQuestionIdsByEntryId(entryId);
+    const results = [];
+    for (const qId of questionIds) {
+      const question = await this.questionRepo.findById(qId);
+      if (!question) continue;
+      const tx =
+        await this.transactionRepo.findLatestValidatedByQuestionId(qId);
+      results.push({ ...question.toProps(), currentText: tx?.string ?? null });
+    }
+    return results;
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/list-pending-proposals.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-pending-proposals.usecase.ts
@@ -1,0 +1,57 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+
+interface PendingProposal {
+  question: QuestionProps;
+  proposedText: string;
+  currentText: string | null;
+  proposalType: 'new' | 'update';
+}
+
+export class ListPendingProposalsUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(userId: string): Promise<PendingProposal[]> {
+    const results: PendingProposal[] = [];
+
+    // New question proposals (question itself is unvalidated)
+    const pendingQuestions =
+      await this.questionRepo.listPendingByUserId(userId);
+    for (const q of pendingQuestions) {
+      const tx =
+        await this.transactionRepo.findLatestByQuestionId(q.id);
+      if (tx) {
+        results.push({
+          question: q.toProps(),
+          proposedText: tx.string,
+          currentText: null,
+          proposalType: 'new',
+        });
+      }
+    }
+
+    // Text update proposals (question is validated, but has unvalidated transaction)
+    const activeQuestions =
+      await this.questionRepo.listActiveByUserId(userId);
+    for (const q of activeQuestions) {
+      const unvalidatedTx =
+        await this.transactionRepo.findLatestUnvalidatedByQuestionId(q.id);
+      if (unvalidatedTx) {
+        const currentTx =
+          await this.transactionRepo.findLatestValidatedByQuestionId(q.id);
+        results.push({
+          question: q.toProps(),
+          proposedText: unvalidatedTx.string,
+          currentText: currentTx?.string ?? null,
+          proposalType: 'update',
+        });
+      }
+    }
+
+    return results;
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/reject-question-proposal.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/reject-question-proposal.usecase.ts
@@ -1,0 +1,31 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import {
+  QuestionNotFoundError,
+  QuestionNotPendingError,
+} from '../errors/question.errors';
+
+export class RejectQuestionProposalUsecase {
+  constructor(
+    private questionRepo: QuestionRepositoryGateway,
+    private transactionRepo: QuestionTransactionRepositoryGateway,
+  ) {}
+
+  async execute(questionId: string): Promise<void> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    if (!question.isValidatedByUser) {
+      // Entire question is an unvalidated proposal — delete it (cascades transactions)
+      await this.questionRepo.delete(questionId);
+      return;
+    }
+
+    // Text update proposal — delete only the unvalidated transaction
+    const unvalidatedTx =
+      await this.transactionRepo.findLatestUnvalidatedByQuestionId(questionId);
+    if (!unvalidatedTx) throw new QuestionNotPendingError(questionId);
+
+    await this.transactionRepo.delete(unvalidatedTx.id);
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/unarchive-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/unarchive-question.usecase.ts
@@ -1,0 +1,25 @@
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import type { QuestionProps } from '../../domain/models/question';
+import {
+  QuestionNotFoundError,
+  QuestionLimitExceededError,
+} from '../errors/question.errors';
+
+export class UnarchiveQuestionUsecase {
+  constructor(private questionRepo: QuestionRepositoryGateway) {}
+
+  async execute(questionId: string): Promise<QuestionProps> {
+    const question = await this.questionRepo.findById(questionId);
+    if (!question) throw new QuestionNotFoundError(questionId);
+
+    const activeCount = await this.questionRepo.countActiveByUserId(
+      question.userId,
+    );
+    if (activeCount >= 3) throw new QuestionLimitExceededError();
+
+    const unarchived = question.withUnarchived();
+    await this.questionRepo.save(unarchived);
+
+    return unarchived.toProps();
+  }
+}

--- a/apps/server/src/contexts/question/application/usecases/unlink-question-from-entry.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/unlink-question-from-entry.usecase.ts
@@ -1,0 +1,9 @@
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+
+export class UnlinkQuestionFromEntryUsecase {
+  constructor(private linkRepo: EntryQuestionLinkRepositoryGateway) {}
+
+  async execute(entryId: string, questionId: string): Promise<void> {
+    await this.linkRepo.unlink(entryId, questionId);
+  }
+}

--- a/apps/server/src/contexts/question/domain/gateways/entry-question-link-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/entry-question-link-repository.gateway.ts
@@ -1,0 +1,5 @@
+export interface EntryQuestionLinkRepositoryGateway {
+  link(entryId: string, questionId: string): Promise<void>;
+  unlink(entryId: string, questionId: string): Promise<void>;
+  listQuestionIdsByEntryId(entryId: string): Promise<string[]>;
+}

--- a/apps/server/src/contexts/question/domain/gateways/question-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/question-repository.gateway.ts
@@ -1,0 +1,11 @@
+import type { Question } from '../models/question';
+
+export interface QuestionRepositoryGateway {
+  findById(id: string): Promise<Question | null>;
+  listActiveByUserId(userId: string): Promise<Question[]>;
+  listAllByUserId(userId: string): Promise<Question[]>;
+  listPendingByUserId(userId: string): Promise<Question[]>;
+  countActiveByUserId(userId: string): Promise<number>;
+  save(question: Question): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/apps/server/src/contexts/question/domain/gateways/question-transaction-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/question-transaction-repository.gateway.ts
@@ -1,0 +1,11 @@
+import type { QuestionTransaction } from '../models/question-transaction';
+
+export interface QuestionTransactionRepositoryGateway {
+  listByQuestionId(questionId: string): Promise<QuestionTransaction[]>;
+  findLatestByQuestionId(questionId: string): Promise<QuestionTransaction | null>;
+  findLatestValidatedByQuestionId(questionId: string): Promise<QuestionTransaction | null>;
+  findLatestUnvalidatedByQuestionId(questionId: string): Promise<QuestionTransaction | null>;
+  append(transaction: QuestionTransaction): Promise<void>;
+  save(transaction: QuestionTransaction): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/apps/server/src/contexts/question/domain/models/question-transaction.ts
+++ b/apps/server/src/contexts/question/domain/models/question-transaction.ts
@@ -1,0 +1,113 @@
+import {
+  type Result,
+  ok,
+  err,
+} from '../../../shared/domain/types/result';
+
+export type QuestionTransactionError =
+  | { type: 'EMPTY_STRING'; message: string }
+  | { type: 'STRING_TOO_LONG'; message: string };
+
+export interface QuestionTransactionProps {
+  id: string;
+  questionId: string;
+  string: string;
+  questionVersion: number;
+  isValidatedByUser: boolean;
+  isProposedByOryzae: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateQuestionTransactionParams {
+  questionId: string;
+  string: string;
+  questionVersion: number;
+  isProposedByOryzae: boolean;
+}
+
+const MAX_STRING_LENGTH = 64;
+
+export class QuestionTransaction {
+  readonly id: string;
+  readonly questionId: string;
+  readonly string: string;
+  readonly questionVersion: number;
+  readonly isValidatedByUser: boolean;
+  readonly isProposedByOryzae: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  private constructor(props: QuestionTransactionProps) {
+    this.id = props.id;
+    this.questionId = props.questionId;
+    this.string = props.string;
+    this.questionVersion = props.questionVersion;
+    this.isValidatedByUser = props.isValidatedByUser;
+    this.isProposedByOryzae = props.isProposedByOryzae;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static create(
+    params: CreateQuestionTransactionParams,
+    generateId: () => string,
+  ): Result<QuestionTransaction, QuestionTransactionError> {
+    const validationError = QuestionTransaction.validateString(params.string);
+    if (validationError) return err(validationError);
+
+    const now = new Date().toISOString();
+    return ok(
+      new QuestionTransaction({
+        id: generateId(),
+        questionId: params.questionId,
+        string: params.string,
+        questionVersion: params.questionVersion,
+        isValidatedByUser: !params.isProposedByOryzae,
+        isProposedByOryzae: params.isProposedByOryzae,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  static fromProps(props: QuestionTransactionProps): QuestionTransaction {
+    return new QuestionTransaction(props);
+  }
+
+  withValidated(): QuestionTransaction {
+    return new QuestionTransaction({
+      ...this.toProps(),
+      isValidatedByUser: true,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  toProps(): QuestionTransactionProps {
+    return {
+      id: this.id,
+      questionId: this.questionId,
+      string: this.string,
+      questionVersion: this.questionVersion,
+      isValidatedByUser: this.isValidatedByUser,
+      isProposedByOryzae: this.isProposedByOryzae,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  private static validateString(
+    str: string,
+  ): QuestionTransactionError | null {
+    if (str.trim().length === 0) {
+      return { type: 'EMPTY_STRING', message: 'Question text must not be empty' };
+    }
+    if (str.length > MAX_STRING_LENGTH) {
+      return {
+        type: 'STRING_TOO_LONG',
+        message: `Question text exceeds maximum length of ${MAX_STRING_LENGTH}`,
+      };
+    }
+    return null;
+  }
+}

--- a/apps/server/src/contexts/question/domain/models/question.ts
+++ b/apps/server/src/contexts/question/domain/models/question.ts
@@ -1,0 +1,94 @@
+export interface QuestionProps {
+  id: string;
+  userId: string;
+  isArchived: boolean;
+  isValidatedByUser: boolean;
+  isProposedByOryzae: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateQuestionParams {
+  userId: string;
+  isProposedByOryzae: boolean;
+}
+
+export class Question {
+  readonly id: string;
+  readonly userId: string;
+  readonly isArchived: boolean;
+  readonly isValidatedByUser: boolean;
+  readonly isProposedByOryzae: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  private constructor(props: QuestionProps) {
+    this.id = props.id;
+    this.userId = props.userId;
+    this.isArchived = props.isArchived;
+    this.isValidatedByUser = props.isValidatedByUser;
+    this.isProposedByOryzae = props.isProposedByOryzae;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static create(
+    params: CreateQuestionParams,
+    generateId: () => string,
+  ): Question {
+    const now = new Date().toISOString();
+    return new Question({
+      id: generateId(),
+      userId: params.userId,
+      isArchived: false,
+      isValidatedByUser: !params.isProposedByOryzae,
+      isProposedByOryzae: params.isProposedByOryzae,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  static fromProps(props: QuestionProps): Question {
+    return new Question(props);
+  }
+
+  get isActive(): boolean {
+    return !this.isArchived && this.isValidatedByUser;
+  }
+
+  withArchived(): Question {
+    return new Question({
+      ...this.toProps(),
+      isArchived: true,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  withUnarchived(): Question {
+    return new Question({
+      ...this.toProps(),
+      isArchived: false,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  withValidated(): Question {
+    return new Question({
+      ...this.toProps(),
+      isValidatedByUser: true,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  toProps(): QuestionProps {
+    return {
+      id: this.id,
+      userId: this.userId,
+      isArchived: this.isArchived,
+      isValidatedByUser: this.isValidatedByUser,
+      isProposedByOryzae: this.isProposedByOryzae,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/apps/server/src/contexts/question/domain/services/current-question-text.service.test.ts
+++ b/apps/server/src/contexts/question/domain/services/current-question-text.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCurrentText } from './current-question-text.service';
+import { QuestionTransaction } from '../models/question-transaction';
+
+describe('resolveCurrentText', () => {
+  const makeTx = (version: number, validated: boolean) =>
+    QuestionTransaction.fromProps({
+      id: `tx-${version}`,
+      questionId: 'q-1',
+      string: `version ${version}`,
+      questionVersion: version,
+      isValidatedByUser: validated,
+      isProposedByOryzae: !validated,
+      createdAt: '2026-04-01T00:00:00Z',
+      updatedAt: '2026-04-01T00:00:00Z',
+    });
+
+  it('空配列なら null を返す', () => {
+    expect(resolveCurrentText([])).toBeNull();
+  });
+
+  it('validated な transaction のうち最大 version を返す', () => {
+    const txs = [makeTx(1, true), makeTx(2, true), makeTx(3, false)];
+    const result = resolveCurrentText(txs);
+    expect(result?.questionVersion).toBe(2);
+    expect(result?.string).toBe('version 2');
+  });
+
+  it('全て unvalidated なら null を返す', () => {
+    const txs = [makeTx(1, false), makeTx(2, false)];
+    expect(resolveCurrentText(txs)).toBeNull();
+  });
+
+  it('単一の validated transaction を正しく返す', () => {
+    const txs = [makeTx(1, true)];
+    const result = resolveCurrentText(txs);
+    expect(result?.questionVersion).toBe(1);
+  });
+});

--- a/apps/server/src/contexts/question/domain/services/current-question-text.service.ts
+++ b/apps/server/src/contexts/question/domain/services/current-question-text.service.ts
@@ -1,0 +1,18 @@
+import type { QuestionTransaction } from '../models/question-transaction';
+
+/**
+ * validated な transaction のうち question_version 最大のものを返す。
+ * 有効な transaction がなければ null。
+ */
+export function resolveCurrentText(
+  transactions: QuestionTransaction[],
+): QuestionTransaction | null {
+  let latest: QuestionTransaction | null = null;
+  for (const tx of transactions) {
+    if (!tx.isValidatedByUser) continue;
+    if (!latest || tx.questionVersion > latest.questionVersion) {
+      latest = tx;
+    }
+  }
+  return latest;
+}

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+
+export class SupabaseEntryQuestionLinkRepository
+  implements EntryQuestionLinkRepositoryGateway
+{
+  constructor(private supabase: SupabaseClient) {}
+
+  async link(entryId: string, questionId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('entry_question_links')
+      .upsert(
+        { entry_id: entryId, question_id: questionId },
+        { onConflict: 'entry_id,question_id' },
+      );
+    if (error) throw error;
+  }
+
+  async unlink(entryId: string, questionId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('entry_question_links')
+      .delete()
+      .eq('entry_id', entryId)
+      .eq('question_id', questionId);
+    if (error) throw error;
+  }
+
+  async listQuestionIdsByEntryId(entryId: string): Promise<string[]> {
+    const { data, error } = await this.supabase
+      .from('entry_question_links')
+      .select('question_id')
+      .eq('entry_id', entryId);
+
+    if (error) throw error;
+    return (data ?? []).map(
+      (row) => (row as Record<string, unknown>).question_id as string,
+    );
+  }
+}

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
@@ -1,0 +1,129 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
+import { QuestionTransaction } from '../../domain/models/question-transaction';
+
+export class SupabaseQuestionTransactionRepository
+  implements QuestionTransactionRepositoryGateway
+{
+  constructor(private supabase: SupabaseClient) {}
+
+  async listByQuestionId(
+    questionId: string,
+  ): Promise<QuestionTransaction[]> {
+    const { data, error } = await this.supabase
+      .from('question_transactions')
+      .select('*')
+      .eq('question_id', questionId)
+      .order('question_version', { ascending: true });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => this.toDomain(row));
+  }
+
+  async findLatestByQuestionId(
+    questionId: string,
+  ): Promise<QuestionTransaction | null> {
+    const { data, error } = await this.supabase
+      .from('question_transactions')
+      .select('*')
+      .eq('question_id', questionId)
+      .order('question_version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    return this.toDomain(data);
+  }
+
+  async findLatestValidatedByQuestionId(
+    questionId: string,
+  ): Promise<QuestionTransaction | null> {
+    const { data, error } = await this.supabase
+      .from('question_transactions')
+      .select('*')
+      .eq('question_id', questionId)
+      .eq('is_validated_by_user', true)
+      .order('question_version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    return this.toDomain(data);
+  }
+
+  async findLatestUnvalidatedByQuestionId(
+    questionId: string,
+  ): Promise<QuestionTransaction | null> {
+    const { data, error } = await this.supabase
+      .from('question_transactions')
+      .select('*')
+      .eq('question_id', questionId)
+      .eq('is_validated_by_user', false)
+      .order('question_version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    return this.toDomain(data);
+  }
+
+  async append(transaction: QuestionTransaction): Promise<void> {
+    const props = transaction.toProps();
+    const { error } = await this.supabase
+      .from('question_transactions')
+      .insert({
+        id: props.id,
+        question_id: props.questionId,
+        string: props.string,
+        question_version: props.questionVersion,
+        is_validated_by_user: props.isValidatedByUser,
+        is_proposed_by_oryzae: props.isProposedByOryzae,
+        created_at: props.createdAt,
+        updated_at: props.updatedAt,
+      });
+
+    if (error) throw error;
+  }
+
+  async save(transaction: QuestionTransaction): Promise<void> {
+    const props = transaction.toProps();
+    const { error } = await this.supabase
+      .from('question_transactions')
+      .upsert({
+        id: props.id,
+        question_id: props.questionId,
+        string: props.string,
+        question_version: props.questionVersion,
+        is_validated_by_user: props.isValidatedByUser,
+        is_proposed_by_oryzae: props.isProposedByOryzae,
+        created_at: props.createdAt,
+        updated_at: props.updatedAt,
+      });
+
+    if (error) throw error;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('question_transactions')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+  }
+
+  private toDomain(row: Record<string, unknown>): QuestionTransaction {
+    return QuestionTransaction.fromProps({
+      id: row.id as string,
+      questionId: row.question_id as string,
+      string: row.string as string,
+      questionVersion: row.question_version as number,
+      isValidatedByUser: row.is_validated_by_user as boolean,
+      isProposedByOryzae: row.is_proposed_by_oryzae as boolean,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    });
+  }
+}

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
@@ -1,0 +1,100 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
+import { Question } from '../../domain/models/question';
+
+export class SupabaseQuestionRepository implements QuestionRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findById(id: string): Promise<Question | null> {
+    const { data, error } = await this.supabase
+      .from('questions')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) return null;
+    return this.toDomain(data);
+  }
+
+  async listActiveByUserId(userId: string): Promise<Question[]> {
+    const { data, error } = await this.supabase
+      .from('questions')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('is_archived', false)
+      .eq('is_validated_by_user', true)
+      .order('created_at', { ascending: true });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => this.toDomain(row));
+  }
+
+  async listAllByUserId(userId: string): Promise<Question[]> {
+    const { data, error } = await this.supabase
+      .from('questions')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => this.toDomain(row));
+  }
+
+  async listPendingByUserId(userId: string): Promise<Question[]> {
+    const { data, error } = await this.supabase
+      .from('questions')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('is_validated_by_user', false)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => this.toDomain(row));
+  }
+
+  async countActiveByUserId(userId: string): Promise<number> {
+    const { count, error } = await this.supabase
+      .from('questions')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('is_archived', false)
+      .eq('is_validated_by_user', true);
+
+    if (error) throw error;
+    return count ?? 0;
+  }
+
+  async save(question: Question): Promise<void> {
+    const props = question.toProps();
+    const { error } = await this.supabase.from('questions').upsert({
+      id: props.id,
+      user_id: props.userId,
+      is_archived: props.isArchived,
+      is_validated_by_user: props.isValidatedByUser,
+      is_proposed_by_oryzae: props.isProposedByOryzae,
+      created_at: props.createdAt,
+      updated_at: props.updatedAt,
+    });
+    if (error) throw error;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('questions')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+  }
+
+  private toDomain(row: Record<string, unknown>): Question {
+    return Question.fromProps({
+      id: row.id as string,
+      userId: row.user_id as string,
+      isArchived: row.is_archived as boolean,
+      isValidatedByUser: row.is_validated_by_user as boolean,
+      isProposedByOryzae: row.is_proposed_by_oryzae as boolean,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    });
+  }
+}

--- a/apps/server/src/contexts/question/presentation/routes/entry-questions.ts
+++ b/apps/server/src/contexts/question/presentation/routes/entry-questions.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono';
+import { LinkQuestionToEntryUsecase } from '../../application/usecases/link-question-to-entry.usecase';
+import { UnlinkQuestionFromEntryUsecase } from '../../application/usecases/unlink-question-from-entry.usecase';
+import { ListEntryQuestionsUsecase } from '../../application/usecases/list-entry-questions.usecase';
+import { SupabaseEntryQuestionLinkRepository } from '../../infrastructure/repositories/supabase-entry-question-link.repository';
+import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository';
+import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository';
+import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository';
+
+type Env = {
+  Variables: {
+    userId: string;
+    supabase: import('@supabase/supabase-js').SupabaseClient;
+  };
+};
+
+export const entryQuestions = new Hono<Env>();
+
+entryQuestions.get('/', async (c) => {
+  const supabase = c.get('supabase');
+  const linkRepo = new SupabaseEntryQuestionLinkRepository(supabase);
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new ListEntryQuestionsUsecase(linkRepo, qRepo, txRepo);
+
+  const entryId = c.req.param('entryId')!;
+  const result = await usecase.execute(entryId);
+  return c.json(result);
+});
+
+entryQuestions.post('/:questionId', async (c) => {
+  const supabase = c.get('supabase');
+  const linkRepo = new SupabaseEntryQuestionLinkRepository(supabase);
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const entryRepo = new SupabaseEntryRepository(supabase);
+  const usecase = new LinkQuestionToEntryUsecase(linkRepo, qRepo, entryRepo);
+
+  const entryId = c.req.param('entryId')!;
+  const questionId = c.req.param('questionId')!;
+  await usecase.execute(entryId, questionId);
+  return c.json({ ok: true }, 201);
+});
+
+entryQuestions.delete('/:questionId', async (c) => {
+  const supabase = c.get('supabase');
+  const linkRepo = new SupabaseEntryQuestionLinkRepository(supabase);
+  const usecase = new UnlinkQuestionFromEntryUsecase(linkRepo);
+
+  const entryId = c.req.param('entryId')!;
+  const questionId = c.req.param('questionId')!;
+  await usecase.execute(entryId, questionId);
+  return c.json({ ok: true });
+});

--- a/apps/server/src/contexts/question/presentation/routes/questions.ts
+++ b/apps/server/src/contexts/question/presentation/routes/questions.ts
@@ -1,0 +1,131 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { CreateQuestionUsecase } from '../../application/usecases/create-question.usecase';
+import { ListActiveQuestionsUsecase } from '../../application/usecases/list-active-questions.usecase';
+import { ListAllQuestionsUsecase } from '../../application/usecases/list-all-questions.usecase';
+import { ListPendingProposalsUsecase } from '../../application/usecases/list-pending-proposals.usecase';
+import { GetQuestionUsecase } from '../../application/usecases/get-question.usecase';
+import { EditQuestionUsecase } from '../../application/usecases/edit-question.usecase';
+import { ArchiveQuestionUsecase } from '../../application/usecases/archive-question.usecase';
+import { UnarchiveQuestionUsecase } from '../../application/usecases/unarchive-question.usecase';
+import { AcceptQuestionProposalUsecase } from '../../application/usecases/accept-question-proposal.usecase';
+import { RejectQuestionProposalUsecase } from '../../application/usecases/reject-question-proposal.usecase';
+import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository';
+import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository';
+
+type Env = {
+  Variables: {
+    userId: string;
+    supabase: import('@supabase/supabase-js').SupabaseClient;
+  };
+};
+
+const questionStringSchema = z.object({
+  string: z.string().min(1).max(64),
+});
+
+const generateId = () => crypto.randomUUID();
+
+export const questions = new Hono<Env>();
+
+// Static routes BEFORE /:id
+questions.get('/all', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new ListAllQuestionsUsecase(qRepo, txRepo);
+
+  const result = await usecase.execute(c.get('userId'));
+  return c.json(result);
+});
+
+questions.get('/pending', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new ListPendingProposalsUsecase(qRepo, txRepo);
+
+  const result = await usecase.execute(c.get('userId'));
+  return c.json(result);
+});
+
+questions.post('/', async (c) => {
+  const body = questionStringSchema.parse(await c.req.json());
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new CreateQuestionUsecase(qRepo, txRepo, generateId);
+
+  const result = await usecase.execute(c.get('userId'), body);
+  return c.json(result, 201);
+});
+
+questions.get('/', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new ListActiveQuestionsUsecase(qRepo, txRepo);
+
+  const result = await usecase.execute(c.get('userId'));
+  return c.json(result);
+});
+
+questions.get('/:id', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new GetQuestionUsecase(qRepo, txRepo);
+
+  const result = await usecase.execute(c.req.param('id'));
+  if (!result) return c.json({ error: 'Not found' }, 404);
+  return c.json(result);
+});
+
+questions.put('/:id', async (c) => {
+  const body = questionStringSchema.parse(await c.req.json());
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new EditQuestionUsecase(qRepo, txRepo, generateId);
+
+  const result = await usecase.execute(c.req.param('id'), body);
+  return c.json(result);
+});
+
+questions.post('/:id/archive', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const usecase = new ArchiveQuestionUsecase(qRepo);
+
+  const result = await usecase.execute(c.req.param('id'));
+  return c.json(result);
+});
+
+questions.post('/:id/unarchive', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const usecase = new UnarchiveQuestionUsecase(qRepo);
+
+  const result = await usecase.execute(c.req.param('id'));
+  return c.json(result);
+});
+
+questions.post('/:id/accept', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new AcceptQuestionProposalUsecase(qRepo, txRepo);
+
+  const result = await usecase.execute(c.req.param('id'));
+  return c.json(result);
+});
+
+questions.post('/:id/reject', async (c) => {
+  const supabase = c.get('supabase');
+  const qRepo = new SupabaseQuestionRepository(supabase);
+  const txRepo = new SupabaseQuestionTransactionRepository(supabase);
+  const usecase = new RejectQuestionProposalUsecase(qRepo, txRepo);
+
+  await usecase.execute(c.req.param('id'));
+  return c.json({ ok: true });
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,6 +3,8 @@ import { serve } from '@hono/node-server';
 import { authMiddleware } from './contexts/shared/presentation/middleware/auth';
 import { errorHandler } from './contexts/shared/presentation/middleware/error-handler';
 import { entries } from './contexts/entry/presentation/routes/entries';
+import { questions } from './contexts/question/presentation/routes/questions';
+import { entryQuestions } from './contexts/question/presentation/routes/entry-questions';
 
 const app = new Hono();
 
@@ -12,6 +14,8 @@ app.get('/health', (c) => c.json({ status: 'ok' }));
 
 app.use('/api/v1/*', authMiddleware);
 app.route('/api/v1/entries', entries);
+app.route('/api/v1/questions', questions);
+app.route('/api/v1/entries/:entryId/questions', entryQuestions);
 
 const port = Number(process.env.PORT ?? 3000);
 

--- a/docs/oryzae-data-schema.html
+++ b/docs/oryzae-data-schema.html
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Oryzae Data Schema</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Helvetica Neue', 'Noto Sans JP', sans-serif;
+    background: #faf9f6; color: #2d2d2d;
+    padding: 48px; line-height: 1.7;
+  }
+  h1 {
+    font-size: 22px; font-weight: 500; letter-spacing: 0.08em;
+    color: #8b2020; margin-bottom: 8px;
+  }
+  .subtitle {
+    font-size: 13px; color: #999; margin-bottom: 40px; letter-spacing: 0.05em;
+  }
+  .schema-section { margin-bottom: 40px; }
+  .table-title {
+    font-size: 14px; font-weight: 600; color: #d97706;
+    letter-spacing: 0.1em; margin-bottom: 4px;
+  }
+  .table-desc {
+    font-size: 12px; color: #888; margin-bottom: 12px;
+  }
+  table {
+    width: 100%; border-collapse: collapse;
+    background: #fff; border-radius: 8px; overflow: hidden;
+    box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+  }
+  th {
+    background: #f5f0e8; text-align: left;
+    padding: 10px 16px; font-size: 11px; font-weight: 600;
+    color: #6b5c3e; letter-spacing: 0.1em; text-transform: uppercase;
+    border-bottom: 2px solid #e8dcc8;
+  }
+  td {
+    padding: 10px 16px; font-size: 13px; border-bottom: 1px solid #f0ede6;
+    vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+  .col-name { font-weight: 600; color: #2d2d2d; font-family: 'SF Mono', 'Consolas', monospace; font-size: 12px; }
+  .col-type { color: #d97706; font-family: 'SF Mono', 'Consolas', monospace; font-size: 11px; }
+  .col-pk { color: #8b2020; font-size: 10px; font-weight: 600; }
+  .col-fk { color: #4a9e8e; font-size: 10px; font-weight: 600; }
+  .badge { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 10px; font-weight: 500; margin-left: 4px; }
+  .badge-pk { background: #fde8e8; color: #8b2020; }
+  .badge-fk { background: #e0f5f0; color: #2a7a6a; }
+  .badge-unique { background: #fef3cd; color: #856404; }
+  .badge-default { background: #e8ecf0; color: #555; }
+  .relation-diagram {
+    margin: 32px 0 48px;
+    padding: 24px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 1px 6px rgba(0,0,0,0.06);
+  }
+  .relation-diagram svg { width: 100%; height: auto; }
+  .helper-section { margin-top: 40px; }
+  .helper-table td:first-child {
+    font-family: 'SF Mono', 'Consolas', monospace; font-size: 12px; color: #4a9e8e; white-space: nowrap;
+  }
+  .storage-note {
+    margin-top: 12px; padding: 12px 16px;
+    background: #f8f5ef; border-left: 3px solid #d97706;
+    border-radius: 0 6px 6px 0; font-size: 12px; color: #6b5c3e;
+  }
+  .storage-note strong { color: #d97706; }
+  .section-divider {
+    margin: 48px 0 32px;
+    border: none; border-top: 1px solid #e8dcc8;
+  }
+  .section-heading {
+    font-size: 16px; font-weight: 500; color: #6b5c3e;
+    letter-spacing: 0.06em; margin-bottom: 24px;
+  }
+</style>
+</head>
+<body>
+
+<h1>Oryzae データスキーマ</h1>
+<p class="subtitle">board-jar-integration テーブル定義一覧 — 2026-03-27 更新</p>
+
+<!-- ER Diagram -->
+<div class="relation-diagram">
+  <svg viewBox="0 0 960 380" xmlns="http://www.w3.org/2000/svg">
+    <!-- Entry -->
+    <rect x="10" y="10" width="110" height="50" rx="6" fill="#fff" stroke="#7c5cbf" stroke-width="1.5"/>
+    <text x="65" y="40" text-anchor="middle" font-size="11" font-weight="600" fill="#7c5cbf">Entry</text>
+
+    <!-- Question -->
+    <rect x="10" y="100" width="130" height="50" rx="6" fill="#fff" stroke="#8b2020" stroke-width="1.5"/>
+    <text x="75" y="130" text-anchor="middle" font-size="11" font-weight="600" fill="#8b2020">Question</text>
+
+    <!-- EntryQuestionLink -->
+    <rect x="180" y="10" width="170" height="50" rx="6" fill="#fff" stroke="#999" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text x="265" y="40" text-anchor="middle" font-size="11" font-weight="600" fill="#999">EntryQuestionLink</text>
+
+    <!-- QuestionTransaction -->
+    <rect x="220" y="100" width="170" height="50" rx="6" fill="#fff" stroke="#d97706" stroke-width="1.5"/>
+    <text x="305" y="130" text-anchor="middle" font-size="11" font-weight="600" fill="#d97706">QuestionTransaction</text>
+
+    <!-- FermentationResult -->
+    <rect x="10" y="200" width="170" height="50" rx="6" fill="#fff" stroke="#4a9e8e" stroke-width="1.5"/>
+    <text x="95" y="230" text-anchor="middle" font-size="11" font-weight="600" fill="#4a9e8e">FermentationResult</text>
+
+    <!-- AnalysisWorksheet -->
+    <rect x="250" y="200" width="160" height="50" rx="6" fill="#fff" stroke="#6b5c3e" stroke-width="1.5"/>
+    <text x="330" y="230" text-anchor="middle" font-size="11" font-weight="600" fill="#6b5c3e">AnalysisWorksheet</text>
+
+    <!-- CategoryRelation -->
+    <rect x="470" y="200" width="140" height="50" rx="6" fill="#fff" stroke="#6b5c3e" stroke-width="1.5"/>
+    <text x="540" y="230" text-anchor="middle" font-size="11" font-weight="600" fill="#6b5c3e">CategoryRelation</text>
+
+    <!-- ExtractedSnippet -->
+    <rect x="250" y="310" width="140" height="50" rx="6" fill="#fff" stroke="#6b5c3e" stroke-width="1.5"/>
+    <text x="320" y="340" text-anchor="middle" font-size="11" font-weight="600" fill="#6b5c3e">ExtractedSnippet</text>
+
+    <!-- Letter -->
+    <rect x="440" y="310" width="100" height="50" rx="6" fill="#fff" stroke="#6b5c3e" stroke-width="1.5"/>
+    <text x="490" y="340" text-anchor="middle" font-size="11" font-weight="600" fill="#6b5c3e">Letter</text>
+
+    <!-- Keyword -->
+    <rect x="590" y="310" width="110" height="50" rx="6" fill="#fff" stroke="#6b5c3e" stroke-width="1.5"/>
+    <text x="645" y="340" text-anchor="middle" font-size="11" font-weight="600" fill="#6b5c3e">Keyword</text>
+
+    <!-- Arrows -->
+    <!-- Entry → EntryQuestionLink -->
+    <line x1="120" y1="35" x2="180" y2="35" stroke="#999" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#arrow-grey)"/>
+    <text x="150" y="28" text-anchor="middle" font-size="9" fill="#999">1:N</text>
+
+    <!-- Question → EntryQuestionLink -->
+    <line x1="75" y1="100" x2="220" y2="60" stroke="#999" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#arrow-grey)"/>
+    <text x="170" y="72" text-anchor="middle" font-size="9" fill="#999">1:N</text>
+
+    <!-- Question → QuestionTransaction -->
+    <line x1="140" y1="125" x2="220" y2="125" stroke="#d97706" stroke-width="1.2" marker-end="url(#arrow-d)"/>
+    <text x="180" y="118" text-anchor="middle" font-size="9" fill="#999">1:N</text>
+
+    <!-- Question → FermentationResult -->
+    <line x1="75" y1="150" x2="75" y2="200" stroke="#4a9e8e" stroke-width="1.2" marker-end="url(#arrow-g)"/>
+    <text x="85" y="178" font-size="9" fill="#999">1:N</text>
+
+    <!-- FermentationResult → AnalysisWorksheet -->
+    <line x1="180" y1="225" x2="250" y2="225" stroke="#6b5c3e" stroke-width="1.2" marker-end="url(#arrow-b)"/>
+    <text x="215" y="218" text-anchor="middle" font-size="9" fill="#999">1:N</text>
+
+    <!-- FermentationResult → CategoryRelation -->
+    <line x1="180" y1="235" x2="470" y2="225" stroke="#6b5c3e" stroke-width="1" marker-end="url(#arrow-b)"/>
+
+    <!-- FermentationResult → ExtractedSnippet -->
+    <line x1="95" y1="250" x2="280" y2="310" stroke="#6b5c3e" stroke-width="1" marker-end="url(#arrow-b)"/>
+
+    <!-- FermentationResult → Letter -->
+    <line x1="120" y1="250" x2="470" y2="310" stroke="#6b5c3e" stroke-width="1" marker-end="url(#arrow-b)"/>
+
+    <!-- FermentationResult → Keyword -->
+    <line x1="150" y1="250" x2="620" y2="310" stroke="#6b5c3e" stroke-width="1" marker-end="url(#arrow-b)"/>
+
+    <!-- Storage labels -->
+    <rect x="760" y="5" width="185" height="60" rx="6" fill="#f8f5ef" stroke="#e8dcc8" stroke-width="1"/>
+    <text x="852" y="22" text-anchor="middle" font-size="9" font-weight="600" fill="#d97706">ストレージ</text>
+    <text x="852" y="36" text-anchor="middle" font-size="9" fill="#6b5c3e">Entry → IndexedDB</text>
+    <text x="852" y="50" text-anchor="middle" font-size="9" fill="#6b5c3e">Question 系 → localStorage</text>
+    <text x="852" y="64" text-anchor="middle" font-size="9" fill="#6b5c3e">発酵系 → インメモリ (静的)</text>
+
+    <!-- Arrow markers -->
+    <defs>
+      <marker id="arrow-d" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#d97706" stroke-width="1"/>
+      </marker>
+      <marker id="arrow-g" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a9e8e" stroke-width="1"/>
+      </marker>
+      <marker id="arrow-b" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#6b5c3e" stroke-width="1"/>
+      </marker>
+      <marker id="arrow-grey" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+        <path d="M0,0 L8,3 L0,6" fill="none" stroke="#999" stroke-width="1"/>
+      </marker>
+    </defs>
+  </svg>
+</div>
+
+
+<hr class="section-divider">
+<div class="section-heading">コアモデル</div>
+
+<!-- 1. Entry -->
+<div class="schema-section">
+  <div class="table-title">1. Entry（エントリ）</div>
+  <div class="table-desc">ユーザーが書く日記・テキストエントリ。IndexedDB（oryzae_board / entries）に永続化される。問いと N:M で紐づく。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（genId() で生成）</td></tr>
+    <tr><td class="col-name">title</td><td class="col-type">string</td><td>NOT NULL</td><td>エントリのタイトル</td></tr>
+    <tr><td class="col-name">toi</td><td class="col-type">string</td><td></td><td>書き出し時の「問い」テキスト（ToiManager 経由）</td></tr>
+    <tr><td class="col-name">content</td><td class="col-type">text</td><td></td><td>エントリのプレーンテキスト本文</td></tr>
+    <tr><td class="col-name">contentHTML</td><td class="col-type">text</td><td></td><td>エントリの HTML 本文（Quill エディタ出力）</td></tr>
+    <tr><td class="col-name">createdAt</td><td class="col-type">datetime</td><td>NOT NULL</td><td>作成日時（ISO 8601）</td></tr>
+    <tr><td class="col-name">updatedAt</td><td class="col-type">datetime</td><td>NOT NULL <span class="badge badge-unique">INDEX</span></td><td>更新日時（一覧のソートキー）</td></tr>
+    <tr><td class="col-name">writingMode</td><td class="col-type">string</td><td></td><td>執筆時の縦書き/横書きモード</td></tr>
+    <tr><td class="col-name">font</td><td class="col-type">string</td><td></td><td>使用フォント名</td></tr>
+    <tr><td class="col-name">meta</td><td class="col-type">object</td><td></td><td>メタデータ（後述）</td></tr>
+  </table>
+  <div class="storage-note">
+    <strong>meta オブジェクトの主要フィールド：</strong>
+    openedAt, darkMode, userFontSize, timeInscriptionEnabled, timeInscriptionMode, eraserTraceEnabled, erasureTraces, ghostEnabled, ghostMode, ghostSize, ghostScatter, ghostBlurStart, ghostBlurEnd, ghostDuration — および MetadataTracker が記録する執筆統計（WPM サンプル、文字数推移など）。
+  </div>
+</div>
+
+<!-- 2. Question -->
+<div class="schema-section">
+  <div class="table-title">2. Question（問い）</div>
+  <div class="table-desc">ユーザーが設定する問い。最大3つまで。問いの文面は QuestionTransaction で版管理される。アーカイブ・Oryzae提案フラグを持つ。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "q1"、新規は "q" + Date.now()）</td></tr>
+    <tr><td class="col-name">user_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → User</span></td><td>所有ユーザー</td></tr>
+    <tr><td class="col-name">created_at</td><td class="col-type">datetime</td><td>NOT NULL</td><td>作成日時</td></tr>
+    <tr><td class="col-name">updated_at</td><td class="col-type">datetime</td><td>NOT NULL</td><td>最終更新日時（アーカイブ・復活操作でも更新）</td></tr>
+    <tr><td class="col-name">is_archived</td><td class="col-type">boolean</td><td><span class="badge badge-default">DEFAULT false</span></td><td>アーカイブ済みかどうか。true の場合、jar 画面に非表示</td></tr>
+    <tr><td class="col-name">is_validated_by_user</td><td class="col-type">boolean</td><td><span class="badge badge-default">DEFAULT true</span></td><td>ユーザーが承認済みか。Oryzae 提案で未承認の場合 false</td></tr>
+    <tr><td class="col-name">is_proposed_by_oryzae</td><td class="col-type">boolean</td><td><span class="badge badge-default">DEFAULT false</span></td><td>Oryzae（発酵プロセス）によって提案された問いか</td></tr>
+  </table>
+  <div class="storage-note">
+    <strong>アクティブな問い</strong> = <code>is_archived === false</code> かつ <code>is_validated_by_user !== false</code>。<br>
+    jar 画面・エディタドロップダウンには <code>getActiveQuestions()</code> でフィルタした問いのみ表示される。
+  </div>
+</div>
+
+<!-- 3. QuestionTransaction -->
+<div class="schema-section">
+  <div class="table-title">3. QuestionTransaction（問いトランザクション）</div>
+  <div class="table-desc">問いの文面の版管理。ユーザー編集・発酵プロセスによる提案のたびに新バージョンが追加される。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "qt1"、新規は "qt" + Date.now()）</td></tr>
+    <tr><td class="col-name">question_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → Question</span></td><td>対応する問い</td></tr>
+    <tr><td class="col-name">string</td><td class="col-type">text</td><td>NOT NULL</td><td>問いの文面（最大64文字）</td></tr>
+    <tr><td class="col-name">question_version</td><td class="col-type">integer</td><td><span class="badge badge-unique">UNIQUE (question_id, ver)</span></td><td>バージョン番号（1始まり、単調増加）</td></tr>
+    <tr><td class="col-name">created_at</td><td class="col-type">datetime</td><td>NOT NULL</td><td>作成日時</td></tr>
+    <tr><td class="col-name">updated_at</td><td class="col-type">datetime</td><td>NOT NULL</td><td>更新日時</td></tr>
+    <tr><td class="col-name">is_validated_by_user</td><td class="col-type">boolean</td><td><span class="badge badge-default">DEFAULT true</span></td><td>ユーザーが承認済みか</td></tr>
+    <tr><td class="col-name">is_proposed_by_oryzae</td><td class="col-type">boolean</td><td><span class="badge badge-default">DEFAULT false</span></td><td>Oryzae による提案トランザクションか</td></tr>
+  </table>
+  <div class="storage-note">
+    <strong>最新文面の取得ロジック：</strong><code>getQuestionString()</code> は <code>is_validated_by_user !== false</code> のトランザクションのうち最大バージョンの <code>string</code> を返す。<br>
+    <strong>タイムライン表示：</strong>全バージョン履歴が問いの変遷タイムラインに時系列で可視化される。
+  </div>
+</div>
+
+<!-- 4. EntryQuestionLink -->
+<div class="schema-section">
+  <div class="table-title">4. EntryQuestionLink（エントリ-問い紐付け）</div>
+  <div class="table-desc">エントリと問いの多対多の関連付け。エディタ画面で問いをエントリにリンクする際に使用。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">entry_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → Entry</span> <span class="badge badge-unique">UNIQUE (entry, question)</span></td><td>エントリの ID</td></tr>
+    <tr><td class="col-name">question_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → Question</span></td><td>問いの ID</td></tr>
+  </table>
+</div>
+
+<hr class="section-divider">
+<div class="section-heading">発酵プロセスモデル</div>
+
+<!-- 5. FermentationResult -->
+<div class="schema-section">
+  <div class="table-title">5. FermentationResult（発酵結果）</div>
+  <div class="table-desc">問いに対する一定期間の発酵分析結果。AnalysisWorksheet・Snippet・Letter・Keyword の親レコード。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "fr1"）</td></tr>
+    <tr><td class="col-name">question_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → Question</span></td><td>対応する問い</td></tr>
+    <tr><td class="col-name">target_period</td><td class="col-type">string</td><td>NOT NULL</td><td>分析対象期間（例: "2025-11-30〜2025-12-06"）</td></tr>
+    <tr><td class="col-name">created_at</td><td class="col-type">datetime</td><td>NOT NULL</td><td>発酵完了日時</td></tr>
+  </table>
+</div>
+
+<!-- 6. AnalysisWorksheet -->
+<div class="schema-section">
+  <div class="table-title">6. AnalysisWorksheet（分析ワークシート）</div>
+  <div class="table-desc">M-GTA に基づく概念分析。1回の発酵結果に複数の概念（ワークシート）が紐づく。UIには直接表示しないがデータとして保持。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "aw1"）</td></tr>
+    <tr><td class="col-name">fermentation_result_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → FermentationResult</span></td><td>対応する発酵結果</td></tr>
+    <tr><td class="col-name">concept_name</td><td class="col-type">text</td><td>NOT NULL</td><td>概念名（例: "夢における一時的な邂逅と離別"）</td></tr>
+    <tr><td class="col-name">definition</td><td class="col-type">text</td><td>NOT NULL</td><td>概念の定義</td></tr>
+    <tr><td class="col-name">examples</td><td class="col-type">text</td><td></td><td>具体例（番号付きテキスト）</td></tr>
+    <tr><td class="col-name">theoretical_memo</td><td class="col-type">text</td><td></td><td>理論的メモ</td></tr>
+  </table>
+</div>
+
+<!-- 7. CategoryRelation -->
+<div class="schema-section">
+  <div class="table-title">7. CategoryRelation（カテゴリ関係）</div>
+  <div class="table-desc">複数の概念（AnalysisWorksheet）をまとめる上位カテゴリとストーリーライン。UIには直接表示しないがデータとして保持。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "cat1"）</td></tr>
+    <tr><td class="col-name">fermentation_result_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → FermentationResult</span></td><td>対応する発酵結果</td></tr>
+    <tr><td class="col-name">category_name</td><td class="col-type">text</td><td>NOT NULL</td><td>カテゴリ名（例: "生死の境界の溶解"）</td></tr>
+    <tr><td class="col-name">related_concepts</td><td class="col-type">array&lt;string&gt;</td><td></td><td>関連する AnalysisWorksheet の ID 配列</td></tr>
+    <tr><td class="col-name">storyline</td><td class="col-type">text</td><td></td><td>カテゴリのストーリーライン</td></tr>
+  </table>
+</div>
+
+<!-- 8. ExtractedSnippet -->
+<div class="schema-section">
+  <div class="table-title">8. ExtractedSnippet（抽出スニペット）</div>
+  <div class="table-desc">発酵プロセスで抽出されたユーザーのエントリからの引用断片。jar 画面の円内にカードとして表示。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "snip1"）</td></tr>
+    <tr><td class="col-name">fermentation_result_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → FermentationResult</span></td><td>対応する発酵結果</td></tr>
+    <tr><td class="col-name">snippet_type</td><td class="col-type">enum</td><td></td><td>種別: "new_perspective" / "deepen" / "core"</td></tr>
+    <tr><td class="col-name">original_text</td><td class="col-type">text</td><td>NOT NULL</td><td>抽出された原文テキスト</td></tr>
+    <tr><td class="col-name">source_date</td><td class="col-type">string</td><td></td><td>出典日付（例: "12/4"）</td></tr>
+    <tr><td class="col-name">selection_reason</td><td class="col-type">text</td><td></td><td>選出理由の説明</td></tr>
+  </table>
+</div>
+
+<!-- 9. Letter -->
+<div class="schema-section">
+  <div class="table-title">9. Letter（手紙）</div>
+  <div class="table-desc">Lab（分析AI）がユーザーに宛てて書く手紙。1回の発酵結果に対して1通。jar 画面で手紙アイコンとして表示。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "letter1"）</td></tr>
+    <tr><td class="col-name">fermentation_result_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → FermentationResult</span> <span class="badge badge-unique">UNIQUE</span></td><td>対応する発酵結果（1:1）</td></tr>
+    <tr><td class="col-name">body_text</td><td class="col-type">text</td><td>NOT NULL</td><td>手紙の本文</td></tr>
+  </table>
+</div>
+
+<!-- 10. Keyword -->
+<div class="schema-section">
+  <div class="table-title">10. Keyword（キーワード）</div>
+  <div class="table-desc">Yeast（生成AI）がエントリから抽出・生成したキーワード。jar 画面の円内にタグとして表示。</div>
+  <table>
+    <tr><th>カラム名</th><th>型</th><th>制約</th><th>説明</th></tr>
+    <tr><td class="col-name">id</td><td class="col-type">string</td><td><span class="badge badge-pk">PK</span></td><td>一意識別子（例: "kw1"）</td></tr>
+    <tr><td class="col-name">fermentation_result_id</td><td class="col-type">string</td><td><span class="badge badge-fk">FK → FermentationResult</span></td><td>対応する発酵結果</td></tr>
+    <tr><td class="col-name">keyword</td><td class="col-type">text</td><td>NOT NULL</td><td>キーワード文字列（例: "沈黙の忠実さ"）</td></tr>
+    <tr><td class="col-name">description</td><td class="col-type">text</td><td></td><td>キーワードの説明文</td></tr>
+  </table>
+</div>
+
+<hr class="section-divider">
+<div class="section-heading">永続化</div>
+
+<div class="schema-section">
+  <table>
+    <tr><th>データ</th><th>ストレージ</th><th>キー / DB名</th><th>備考</th></tr>
+    <tr><td class="col-name">Entry</td><td>IndexedDB</td><td><code>oryzae_board</code> / store: <code>entries</code></td><td>keyPath: "id"、index: "updatedAt"</td></tr>
+    <tr><td class="col-name">Question, QuestionTransaction, EntryQuestionLink</td><td>localStorage</td><td><code>oryzae_data</code></td><td>JSON シリアライズ。saveToStorage() / loadFromStorage() で管理</td></tr>
+    <tr><td class="col-name">FermentationResult 以下の発酵系テーブル</td><td>インメモリ（静的）</td><td>—</td><td>oryzae-data.js にハードコードされたサンプルデータ。将来的にはサーバーサイドから取得予定</td></tr>
+  </table>
+</div>
+
+<hr class="section-divider">
+<div class="section-heading">ヘルパーメソッド一覧</div>
+
+<!-- Helper Methods -->
+<div class="schema-section helper-section">
+  <div class="table-desc">OryzaeData オブジェクトに定義されたデータアクセスメソッド</div>
+  <table class="helper-table">
+    <tr><th>メソッド</th><th>引数</th><th>戻り値</th><th>説明</th></tr>
+    <tr><td class="col-name">getQuestionString()</td><td>questionId</td><td>string | null</td><td>問いの最新バージョン（validated のみ）の文面を取得</td></tr>
+    <tr><td class="col-name">getActiveQuestions()</td><td>—</td><td>array</td><td>アクティブな問い一覧（非アーカイブ・承認済み）</td></tr>
+    <tr><td class="col-name">getTransactionsForQuestion()</td><td>questionId</td><td>array</td><td>問いの全トランザクションをバージョン昇順で取得</td></tr>
+    <tr><td class="col-name">getLatestTransaction()</td><td>questionId</td><td>object | null</td><td>問いの最新承認済みトランザクションを取得</td></tr>
+    <tr><td class="col-name">getAllQuestions()</td><td>—</td><td>array</td><td>全アクティブ問い（current_string 付き）を取得</td></tr>
+    <tr><td class="col-name">getAllQuestionsIncludingArchived()</td><td>—</td><td>array</td><td>アーカイブ含む全問い（タイムライン用）</td></tr>
+    <tr><td class="col-name">addQuestion()</td><td>questionString</td><td>object</td><td>新しい問いを追加（Question + Transaction を生成）</td></tr>
+    <tr><td class="col-name">updateQuestion()</td><td>questionId, newString</td><td>object</td><td>問いの文面を更新（新トランザクションを生成、version+1）</td></tr>
+    <tr><td class="col-name">archiveQuestion()</td><td>questionId</td><td>void</td><td>問いをアーカイブ（is_archived = true）</td></tr>
+    <tr><td class="col-name">unarchiveQuestion()</td><td>questionId</td><td>void</td><td>問いを復活（is_archived = false）</td></tr>
+    <tr><td class="col-name">getFermentationForQuestion()</td><td>questionId</td><td>object | null</td><td>問いに対応する発酵結果を取得</td></tr>
+    <tr><td class="col-name">getSnippetsForFermentation()</td><td>fermentationResultId</td><td>array</td><td>発酵結果の抽出スニペット一覧を取得</td></tr>
+    <tr><td class="col-name">getKeywordsForFermentation()</td><td>fermentationResultId</td><td>array</td><td>発酵結果のキーワード一覧を取得</td></tr>
+    <tr><td class="col-name">getLetterForFermentation()</td><td>fermentationResultId</td><td>object | null</td><td>発酵結果の手紙を取得</td></tr>
+    <tr><td class="col-name">getWorksheetsForFermentation()</td><td>fermentationResultId</td><td>array</td><td>発酵結果の分析ワークシート一覧を取得</td></tr>
+    <tr><td class="col-name">getCategoriesForFermentation()</td><td>fermentationResultId</td><td>array</td><td>発酵結果のカテゴリ関係一覧を取得</td></tr>
+    <tr><td class="col-name">linkQuestionToEntry()</td><td>entryId, questionId</td><td>void</td><td>エントリに問いを紐付け</td></tr>
+    <tr><td class="col-name">unlinkQuestionFromEntry()</td><td>entryId, questionId</td><td>void</td><td>エントリから問いの紐付けを解除</td></tr>
+    <tr><td class="col-name">getQuestionsForEntry()</td><td>entryId</td><td>array</td><td>エントリに紐づく問い一覧を取得</td></tr>
+    <tr><td class="col-name">saveToStorage()</td><td>—</td><td>void</td><td>Question 系データを localStorage に保存</td></tr>
+    <tr><td class="col-name">loadFromStorage()</td><td>—</td><td>void</td><td>localStorage から Question 系データを復元</td></tr>
+  </table>
+</div>
+
+</body>
+</html>

--- a/docs/question_proposal.md
+++ b/docs/question_proposal.md
@@ -1,0 +1,80 @@
+# Oryzaeにおける問い
+
+Oryzaeでは「問い」は使用者自ら作成・更新・削除できる。
+他にも、「発酵」プロセスによって新規の問いの作成や従来の問いの更新の提案がなされる。使用者は提案を受け容れるか、却下することができる。
+
+## 問いモデルの扱い
+
+jar画面で表示されている問いモデルは以下の2つのテーブルのリレーションで定義される。
+Questionテーブルは、使用者に紐づいた「問い」の大元のレコードである。
+QuestionTransactionテーブルには、Question.idとリレーションとなっているquestion_idカラムがあり、その時々の「問い」の内容が保存されている。
+問いの内容が更新される度に、同じquestion_idを保持した新しいQuestionTransactionレコードが生成される。
+
+Question
+id	INT (not null)
+user_id	INT (not null)
+created_at	DATETIME (not null)
+updated_at	DATETIME (not null)
+is_archived	FALSE
+is_validated_by_user	TRUE
+is_proposed_by_oryzae	TRUE or FALSE
+
+QuestionTransaction	
+id	INT (not null)
+question_id	`Question.id`
+string	VARCHAR(64)
+question_version	INT (not null)
+created_at	DATETIME (not null)
+updated_at	DATETIME (not null)
+is_validated_by_user	TRUE
+is_proposed_by_oryzae	TRUE or FALSE
+
+以上の条件を満たす問いデータが、使用者のアプリにおいて有効化されている問いである。
+有効な`Question`レコードに関連する`QuestionTransaction`テーブル内の`is_validated_by_user`が`TRUE`のもののうち`question_version`値が最大の一件が、有効な「問い」の内容としてみなされる。
+
+有効化された問いを対象に、発酵プロセスが特定のタイミングで実行され、その結果のデータが関連テーブルに記録される。
+有効化されていない問いは、データは保存されるが、発酵プロセスの対象外となり、jar画面にもエディタ画面にも表示されなくなる。
+有効化されていない問いには以下の種類がある。
+
+- 使用者がアーカイブした問い：`Question.is_archived`が`TRUE`になったもの。
+- アプリが提案したもので、使用者が承認していない新しい問い：`Question.is_proposed_by_oryzae`が`TRUE`であり、`Question.is_validated_by_user`が`FALSE`のもの。この場合、`Question.id`と同じ`QuestionTransaction.question_id`値を持つ`QuestionTransaction`のレコードがあったとしても、その`is_validated_by_user`も`FALSE`にセットされる。
+- アプリが提案したもので、使用者が承認していない問いの更新：`Question.is_proposed_by_oryzae`が`TRUE`であり、`Question.is_validated_by_user`が`TRUE`だが、関連する`QuestionTransaction`レコードの`is_validated_by_user`が`FALSE`のもの。
+
+## 使用者自身による問いの作成・更新・アーカイブ
+
+使用者は、jar画面にて、任意のタイミングで問いを追加したり、編集することができる。
+
+- 新しい問いを作成した場合は、Questionに新しいレコードが追加される。user_idは使用者のID、archivedは`FALSE`。同時に、QuestionTransactionに新しいレコードが追加される。question_idは作成したQuestion.id、stringは新しい問いの文字列、question_versionは`1`、is_validated_by_userは`1`を入れる。
+
+- 既存の問いを編集（文言を変化）した場合は、QuestionTransactionに新しいレコードが追加される。そのquestion_idは元々の問いと同じもの、is_validated_by_userは`1`、question_versionは同じquestion_idを持つ最新レコードの値に+1された値を入れる。GUI
+
+- 既存の問いをアーカイブする場合は、Question.is_archivedを`TRUE`にする。アーカイブされた問いは、jar画面からは非表示になるが、問い一覧画面では閲覧でき、「復活」させることができる。
+
+## 発酵プロセスによる問いの作成・更新の提案
+
+Oryzaeでは「発酵」（日記テキストの分析）プロセスが行われる度に、既存の問いの更新、もしくは新しい問いの提案が行われれる。
+
+## 問いが設定されている場合
+
+設定された「問い」毎に、`ferment_with_question.md`の内容をプロンプトとして実行し、結果を関連DBテーブルに記録する。
+この際、当該の「問い」をより良くする提案が行われる場合がある（提案の有無はプロンプト実行時にLLMが判断する）。
+提案が行われた場合、それを使用者がjar画面上で承諾すれば、当該`QuestionTransaction`レコードの`is_validated_by_user`は`TRUE`となるが、無視すれば`FALSE`（デフォルト）となる。
+
+## 問いが設定されていない場合
+
+`ferment_without_question.md`の内容をプロンプトとして実行し、結果を関連DBテーブルに記録する。
+この際、新しい「問い」が提案される。
+それを使用者がjar画面上で承諾すれば、当該`Question`レコードと`QuestionTransaction`レコードの`is_validated_by_user`は`TRUE`となるが、無視すれば`FALSE`（デフォルト）となる。
+
+#### 新しい問いの提案のUI
+発酵プロセスの分析が終わり、新しい問いの提案がある場合には、画面左側ペインのグローバルナビゲーション中のjar画面リンクアイコンに、更新の存在を示す赤いバッジが表示される。
+jar画面が開かれると、新しい問いの提案があることを示すモーダルウィンドウが開かれる。
+モーダルウィンドウ内には、提案された問いの文言が表示され、その下に「Oryzaeがあなたのテキストを基に新しい問いを生成しました。」というテキストを表示し、その下に「受け容れる」ボタンと「無視する」ボタンを配置する。
+
+#### 既存の問いの更新の提案のUI
+発酵プロセスの分析が終わり、新しい問いの提案がある場合には、画面左側ペインのグローバルナビゲーション中のjar画面リンクアイコンに、更新の存在を示す赤いバッジが表示される。
+jar画面が開かれると、新しい問いの提案があることを示すモーダルウィンドウが開かれる。
+モーダルウィンドウ内には、最新の有効化されている問いの文言と、提案された問いの文言が併置されて表示され、「Oryzaeがあなたの問いに対して更新の提案を生成しました。」というテキストを表示し、その下に「受け容れる」ボタンと「無視する」ボタンを配置する。
+
+#### 使用者が既存の問いを更新もしくはアーカイブするUI
+jar画面で、瓶の直下に表示されている問いのグラフィック要素をクリックすると、モーダルウィンドウが開き、その中に問いの文言を編集できるフォーム、「保存」ボタン（更新を保存）、「キャンセル」ボタン（変更を保存せずにモーダルウィンドウを閉じる）、「アーカイブ」ボタンを配置する。

--- a/supabase/migrations/00002_create_questions.sql
+++ b/supabase/migrations/00002_create_questions.sql
@@ -1,0 +1,66 @@
+-- Questions: ユーザーの「問い」の親レコード
+create table public.questions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  is_archived boolean not null default false,
+  is_validated_by_user boolean not null default true,
+  is_proposed_by_oryzae boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- QuestionTransactions: 問いの文面の版管理（append-only）
+create table public.question_transactions (
+  id uuid primary key default gen_random_uuid(),
+  question_id uuid not null references public.questions(id) on delete cascade,
+  string text not null,
+  question_version integer not null,
+  is_validated_by_user boolean not null default true,
+  is_proposed_by_oryzae boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (question_id, question_version),
+  constraint chk_string_length check (char_length(string) <= 64)
+);
+
+-- EntryQuestionLinks: Entry と Question の N:M 紐付け
+create table public.entry_question_links (
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  question_id uuid not null references public.questions(id) on delete cascade,
+  primary key (entry_id, question_id)
+);
+
+-- Indexes
+create index idx_questions_user_active
+  on questions(user_id)
+  where is_archived = false and is_validated_by_user = true;
+
+create index idx_questions_user_all
+  on questions(user_id, created_at desc);
+
+create index idx_question_transactions_question
+  on question_transactions(question_id, question_version desc);
+
+create index idx_entry_question_links_entry
+  on entry_question_links(entry_id);
+
+create index idx_entry_question_links_question
+  on entry_question_links(question_id);
+
+-- RLS
+alter table public.questions enable row level security;
+alter table public.question_transactions enable row level security;
+alter table public.entry_question_links enable row level security;
+
+create policy "questions_own_data" on public.questions
+  for all using (user_id = auth.uid());
+
+create policy "question_transactions_own_data" on public.question_transactions
+  for all using (
+    question_id in (select id from public.questions where user_id = auth.uid())
+  );
+
+create policy "entry_question_links_own_data" on public.entry_question_links
+  for all using (
+    entry_id in (select id from public.entries where user_id = auth.uid())
+  );


### PR DESCRIPTION
## Summary

- **Question bounded context** を entry と同じリッチドメインモデルパターンで新規実装
- 問いの CRUD、アーカイブ/復活、Oryzae AI 提案ワークフロー、Entry との N:M 紐付けを全てカバー
- DB マイグレーション (3テーブル + RLS) と設計ドキュメントを追加

## API エンドポイント (13個)

| Method | Path | 説明 |
|---|---|---|
| POST | `/api/v1/questions` | 問い新規作成 |
| GET | `/api/v1/questions` | アクティブな問い一覧 |
| GET | `/api/v1/questions/all` | 全問い一覧（アーカイブ含む） |
| GET | `/api/v1/questions/pending` | 未承認の提案一覧 |
| GET | `/api/v1/questions/:id` | 問い詳細（版履歴含む） |
| PUT | `/api/v1/questions/:id` | 問い文面を編集 |
| POST | `/api/v1/questions/:id/archive` | アーカイブ |
| POST | `/api/v1/questions/:id/unarchive` | 復活 |
| POST | `/api/v1/questions/:id/accept` | 提案を承認 |
| POST | `/api/v1/questions/:id/reject` | 提案を却下 |
| POST | `/api/v1/entries/:entryId/questions/:questionId` | 紐付け |
| DELETE | `/api/v1/entries/:entryId/questions/:questionId` | 紐付け解除 |
| GET | `/api/v1/entries/:entryId/questions` | 紐付き問い一覧 |

## ビジネスルール

- ユーザーあたりアクティブ問い最大3つ
- 問いの文面は QuestionTransaction で版管理（append-only、max 64文字）
- Oryzae 提案: 新規問い提案 + 既存問い更新提案の2パターン
- 承認/却下ワークフロー対応

## Test plan

- [x] `pnpm --filter @oryzae/server typecheck` パス
- [x] `pnpm --filter @oryzae/server test` パス (7 tests: entry 3 + question 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)