### PR TITLE
feat: Vercel deploy support + auth endpoints

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,0 +1,4 @@
+import { handle } from '@hono/node-server/vercel';
+import app from '../src/app';
+
+export default handle(app);

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono';
+import { authMiddleware } from './contexts/shared/presentation/middleware/auth';
+import { errorHandler } from './contexts/shared/presentation/middleware/error-handler';
+import { entries } from './contexts/entry/presentation/routes/entries';
+import { questions } from './contexts/question/presentation/routes/questions';
+import { entryQuestions } from './contexts/question/presentation/routes/entry-questions';
+import { authRoutes } from './contexts/shared/presentation/routes/auth';
+
+const app = new Hono();
+
+app.onError(errorHandler);
+
+app.get('/health', (c) => c.json({ status: 'ok' }));
+
+// Auth routes (no auth middleware)
+app.route('/api/v1/auth', authRoutes);
+
+// Protected routes
+app.use('/api/v1/*', authMiddleware);
+app.route('/api/v1/entries', entries);
+app.route('/api/v1/questions', questions);
+app.route('/api/v1/entries/:entryId/questions', entryQuestions);
+
+export default app;

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { createClient } from '@supabase/supabase-js';
+
+const authRoutes = new Hono();
+
+const credentialsSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+function getSupabaseAuthClient() {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) throw new Error('Supabase env vars not set');
+  return createClient(url, anonKey);
+}
+
+// POST /auth/signup
+authRoutes.post('/signup', async (c) => {
+  const body = credentialsSchema.parse(await c.req.json());
+  const supabase = getSupabaseAuthClient();
+
+  const { data, error } = await supabase.auth.signUp({
+    email: body.email,
+    password: body.password,
+  });
+
+  if (error) {
+    return c.json({ error: error.message }, 400);
+  }
+
+  return c.json(
+    {
+      user: { id: data.user?.id, email: data.user?.email },
+      session: data.session
+        ? {
+            accessToken: data.session.access_token,
+            refreshToken: data.session.refresh_token,
+            expiresAt: data.session.expires_at,
+          }
+        : null,
+    },
+    201,
+  );
+});
+
+// POST /auth/login
+authRoutes.post('/login', async (c) => {
+  const body = credentialsSchema.parse(await c.req.json());
+  const supabase = getSupabaseAuthClient();
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: body.email,
+    password: body.password,
+  });
+
+  if (error) {
+    return c.json({ error: error.message }, 401);
+  }
+
+  return c.json({
+    user: { id: data.user.id, email: data.user.email },
+    session: {
+      accessToken: data.session.access_token,
+      refreshToken: data.session.refresh_token,
+      expiresAt: data.session.expires_at,
+    },
+  });
+});
+
+// POST /auth/refresh
+authRoutes.post('/refresh', async (c) => {
+  const { refreshToken } = z
+    .object({ refreshToken: z.string() })
+    .parse(await c.req.json());
+  const supabase = getSupabaseAuthClient();
+
+  const { data, error } = await supabase.auth.refreshSession({
+    refresh_token: refreshToken,
+  });
+
+  if (error) {
+    return c.json({ error: error.message }, 401);
+  }
+
+  return c.json({
+    session: {
+      accessToken: data.session!.access_token,
+      refreshToken: data.session!.refresh_token,
+      expiresAt: data.session!.expires_at,
+    },
+  });
+});
+
+// GET /auth/me (requires Authorization header)
+authRoutes.get('/me', async (c) => {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Missing token' }, 401);
+  }
+
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return c.json({ error: 'Server config error' }, 500);
+
+  const supabase = createClient(url, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return c.json({ error: 'Invalid token' }, 401);
+  }
+
+  return c.json({ user: { id: user.id, email: user.email } });
+});
+
+export { authRoutes };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,21 +1,5 @@
-import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
-import { authMiddleware } from './contexts/shared/presentation/middleware/auth';
-import { errorHandler } from './contexts/shared/presentation/middleware/error-handler';
-import { entries } from './contexts/entry/presentation/routes/entries';
-import { questions } from './contexts/question/presentation/routes/questions';
-import { entryQuestions } from './contexts/question/presentation/routes/entry-questions';
-
-const app = new Hono();
-
-app.onError(errorHandler);
-
-app.get('/health', (c) => c.json({ status: 'ok' }));
-
-app.use('/api/v1/*', authMiddleware);
-app.route('/api/v1/entries', entries);
-app.route('/api/v1/questions', questions);
-app.route('/api/v1/entries/:entryId/questions', entryQuestions);
+import app from './app';
 
 const port = Number(process.env.PORT ?? 3000);
 

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api" }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Vercel Serverless 対応**: Hono アプリを `src/app.ts` に分離し、`api/index.ts` で Vercel Serverless Function として公開
- **Auth エンドポイント追加**: signup / login / refresh / me の4エンドポイント
- **.env 読み込み**: dev スクリプトに `--env-file=.env` を追加

## 前提 PR

- #3 (feat/question-backend) のマージが必要

## 構成

```
apps/server/
  src/app.ts         ← Hono アプリ定義（共通）
  src/index.ts       ← ローカル開発用（@hono/node-server）
  api/index.ts       ← Vercel 用（@hono/node-server/vercel）
  vercel.json        ← 全リクエストを /api に rewrite
```

## デプロイ手順

1. Vercel で GitHub リポジトリを接続
2. Root Directory を `apps/server` に設定
3. 環境変数: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
4. デプロイ

## Test plan

- [x] `pnpm --filter @oryzae/server typecheck` パス
- [x] `pnpm --filter @oryzae/server test` パス (7 tests)
- [x] ローカルで login → accessToken → entries/questions API 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)