### PR TITLE
fix: Vercel デプロイ修正 — hono/vercel アダプターに切り替え

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,4 +1,4 @@
-import { handle } from '@hono/node-server/vercel';
+import { handle } from 'hono/vercel';
 import app from '../src/app';
 
 export default handle(app);


### PR DESCRIPTION
## Summary

Vercel デプロイで `FUNCTION_INVOCATION_FAILED` が発生。
`@hono/node-server/vercel` → `hono/vercel`（Hono 公式アダプター）に切り替え。

## Test plan

- [ ] `https://oryzae-server.vercel.app/health` が `{"status":"ok"}` を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)