### PR TITLE
fix: Vercel に src/ を含める (includeFiles)

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,3 +1,8 @@
 {
+  "functions": {
+    "api/**/*.ts": {
+      "includeFiles": "src/**"
+    }
+  },
   "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
 }


### PR DESCRIPTION
Vercel Serverless Function が src/ をバンドルしないため FUNCTION_INVOCATION_FAILED。vercel.json に includeFiles 設定を追加。