### PR TITLE
fix: Vercel Function が dist/ を参照するよう修正

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,4 +1,4 @@
 import { handle } from 'hono/vercel';
-import app from '../src/app';
+import app from '../dist/app.js';
 
 export default handle(app);

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "includeFiles": "src/**"
+      "includeFiles": "dist/**"
     }
   },
   "rewrites": [{ "source": "/(.*)", "destination": "/api" }]


### PR DESCRIPTION
api/index.ts が ../src/app を参照→ランタイムで module not found。tsc ビルド後の ../dist/app.js を参照するよう修正。