### PR TITLE
fix: Vercel デプロイ修正 — api/index.js + 型エラー解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.local
 *.tsbuildinfo
 .turbo/
+.mcp.json

--- a/apps/server/api/index.js
+++ b/apps/server/api/index.js
@@ -1,0 +1,6 @@
+// Vercel Serverless Function entry point
+// .js to bypass Vercel's TypeScript compiler (type safety is enforced by tsc in CI)
+import { handle } from 'hono/vercel';
+import app from '../src/app.js';
+
+export default handle(app);

--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,4 +1,0 @@
-import { handle } from 'hono/vercel';
-import app from '../src/app';
-
-export default handle(app);

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -26,7 +26,7 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
 
     const { data, error } = await query;
     if (error) throw error;
-    return (data ?? []).map((row) => this.toDomain(row));
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
   async save(entry: Entry): Promise<void> {

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
@@ -30,6 +30,8 @@ export class SupabaseEntryQuestionLinkRepository implements EntryQuestionLinkRep
       .eq('entry_id', entryId);
 
     if (error) throw error;
-    return (data ?? []).map((row) => (row as Record<string, unknown>).question_id as string);
+    return (data ?? []).map(
+      (row: Record<string, unknown>) => (row as Record<string, unknown>).question_id as string,
+    );
   }
 }

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
@@ -13,7 +13,7 @@ export class SupabaseQuestionTransactionRepository implements QuestionTransactio
       .order('question_version', { ascending: true });
 
     if (error) throw error;
-    return (data ?? []).map((row) => this.toDomain(row));
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
   async findLatestByQuestionId(questionId: string): Promise<QuestionTransaction | null> {

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
@@ -22,7 +22,7 @@ export class SupabaseQuestionRepository implements QuestionRepositoryGateway {
       .order('created_at', { ascending: true });
 
     if (error) throw error;
-    return (data ?? []).map((row) => this.toDomain(row));
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
   async listAllByUserId(userId: string): Promise<Question[]> {
@@ -33,7 +33,7 @@ export class SupabaseQuestionRepository implements QuestionRepositoryGateway {
       .order('created_at', { ascending: false });
 
     if (error) throw error;
-    return (data ?? []).map((row) => this.toDomain(row));
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
   async listPendingByUserId(userId: string): Promise<Question[]> {
@@ -45,7 +45,7 @@ export class SupabaseQuestionRepository implements QuestionRepositoryGateway {
       .order('created_at', { ascending: false });
 
     if (error) throw error;
-    return (data ?? []).map((row) => this.toDomain(row));
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
   async countActiveByUserId(userId: string): Promise<number> {

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -91,7 +91,7 @@ authRoutes.post('/refresh', async (c) => {
   });
 });
 
-// GET /auth/me (requires Authorization header)
+// GET /auth/me
 authRoutes.get('/me', async (c) => {
   const authHeader = c.req.header('Authorization');
   if (!authHeader?.startsWith('Bearer ')) {

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "",
+  "installCommand": "pnpm install --filter @oryzae/server...",
   "functions": {
     "api/**/*.ts": {
       "includeFiles": "src/**"

--- a/knip.json
+++ b/knip.json
@@ -2,8 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/server": {
-      "entry": ["api/index.ts"],
-      "project": ["src/**/*.ts", "api/**/*.ts"],
+      "entry": ["api/index.js"],
+      "project": ["src/**/*.ts", "api/**/*.js"],
       "ignore": ["src/contexts/shared/infrastructure/supabase-client.ts"],
       "vitest": true
     }


### PR DESCRIPTION
Vercel ncc の TypeScript コンパイラが Supabase v2 の型を解決できない問題。api/ を .js にして Vercel 側の型チェックを回避。型安全は tsc (ローカル + CI) で保証。