### PR TITLE
fix: Vercel ネイティブ Hono サポートに移行

### DIFF
--- a/apps/server/api/index.js
+++ b/apps/server/api/index.js
@@ -1,6 +1,0 @@
-// Vercel Serverless Function entry point
-// .js to bypass Vercel's TypeScript compiler (type safety is enforced by tsc in CI)
-import { handle } from 'hono/vercel';
-import app from '../src/app.js';
-
-export default handle(app);

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,10 +1,3 @@
 {
-  "buildCommand": "",
-  "installCommand": "pnpm install --filter @oryzae/server...",
-  "functions": {
-    "api/**/*.js": {
-      "includeFiles": "src/**"
-    }
-  },
-  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+  "installCommand": "pnpm install --filter @oryzae/server..."
 }

--- a/knip.json
+++ b/knip.json
@@ -2,8 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/server": {
-      "entry": ["api/index.js"],
-      "project": ["src/**/*.ts", "api/**/*.js"],
+      "entry": ["src/app.ts"],
+      "project": ["src/**/*.ts"],
       "ignore": ["src/contexts/shared/infrastructure/supabase-client.ts"],
       "vitest": true
     }


### PR DESCRIPTION
legacy api/ パターンを廃止し、Vercel の Hono ネイティブサポートを使用。src/app.ts の export default app を自動検出。