### PR TITLE
fix: NodeNext モジュール解決で Vercel ESM エラー解消

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
-import { entries } from './contexts/entry/presentation/routes/entries';
-import { entryQuestions } from './contexts/question/presentation/routes/entry-questions';
-import { questions } from './contexts/question/presentation/routes/questions';
-import { authMiddleware } from './contexts/shared/presentation/middleware/auth';
-import { errorHandler } from './contexts/shared/presentation/middleware/error-handler';
-import { authRoutes } from './contexts/shared/presentation/routes/auth';
+import { entries } from './contexts/entry/presentation/routes/entries.js';
+import { entryQuestions } from './contexts/question/presentation/routes/entry-questions.js';
+import { questions } from './contexts/question/presentation/routes/questions.js';
+import { authMiddleware } from './contexts/shared/presentation/middleware/auth.js';
+import { errorHandler } from './contexts/shared/presentation/middleware/error-handler.js';
+import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
 
 const app = new Hono();
 
@@ -17,8 +17,8 @@ app.route('/api/v1/auth', authRoutes);
 
 // Protected routes
 app.use('/api/v1/*', authMiddleware);
-app.route('/api/v1/entries', entries);
-app.route('/api/v1/questions', questions);
-app.route('/api/v1/entries/:entryId/questions', entryQuestions);
+app.route('/api/v1/entries.js', entries);
+app.route('/api/v1/questions.js', questions);
+app.route('/api/v1/entries/:entryId/questions.js', entryQuestions);
 
 export default app;

--- a/apps/server/src/contexts/entry/application/errors/entry.errors.ts
+++ b/apps/server/src/contexts/entry/application/errors/entry.errors.ts
@@ -1,7 +1,7 @@
 import {
   NotFoundError,
   ValidationError,
-} from '../../../shared/application/errors/application.errors';
+} from '../../../shared/application/errors/application.errors.js';
 
 export class EntryNotFoundError extends NotFoundError {
   constructor(entryId: string) {

--- a/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
@@ -1,8 +1,8 @@
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
-import { Entry, type EntryProps } from '../../domain/models/entry';
-import { EntrySnapshot } from '../../domain/models/entry-snapshot';
-import { EntryValidationError } from '../errors/entry.errors';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
+import { Entry, type EntryProps } from '../../domain/models/entry.js';
+import { EntrySnapshot } from '../../domain/models/entry-snapshot.js';
+import { EntryValidationError } from '../errors/entry.errors.js';
 
 interface CreateEntryInput {
   content: string;

--- a/apps/server/src/contexts/entry/application/usecases/delete-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/delete-entry.usecase.ts
@@ -1,5 +1,5 @@
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import { EntryNotFoundError } from '../errors/entry.errors';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import { EntryNotFoundError } from '../errors/entry.errors.js';
 
 export class DeleteEntryUsecase {
   constructor(private entryRepo: EntryRepositoryGateway) {}

--- a/apps/server/src/contexts/entry/application/usecases/get-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/get-entry.usecase.ts
@@ -1,7 +1,7 @@
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
-import type { EntryProps } from '../../domain/models/entry';
-import type { EntrySnapshotProps } from '../../domain/models/entry-snapshot';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
+import type { EntryProps } from '../../domain/models/entry.js';
+import type { EntrySnapshotProps } from '../../domain/models/entry-snapshot.js';
 
 interface GetEntryResult {
   entry: EntryProps;

--- a/apps/server/src/contexts/entry/application/usecases/list-entries.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/list-entries.usecase.ts
@@ -1,5 +1,5 @@
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import type { EntryProps } from '../../domain/models/entry';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import type { EntryProps } from '../../domain/models/entry.js';
 
 export class ListEntriesUsecase {
   constructor(private entryRepo: EntryRepositoryGateway) {}

--- a/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
@@ -1,8 +1,8 @@
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
-import type { EntryProps } from '../../domain/models/entry';
-import { EntrySnapshot } from '../../domain/models/entry-snapshot';
-import { EntryNotFoundError, EntryValidationError } from '../errors/entry.errors';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
+import type { EntryProps } from '../../domain/models/entry.js';
+import { EntrySnapshot } from '../../domain/models/entry-snapshot.js';
+import { EntryNotFoundError, EntryValidationError } from '../errors/entry.errors.js';
 
 interface UpdateEntryInput {
   content: string;

--- a/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
@@ -1,4 +1,4 @@
-import type { Entry } from '../models/entry';
+import type { Entry } from '../models/entry.js';
 
 export interface EntryRepositoryGateway {
   findById(id: string): Promise<Entry | null>;

--- a/apps/server/src/contexts/entry/domain/gateways/entry-snapshot-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-snapshot-repository.gateway.ts
@@ -1,4 +1,4 @@
-import type { EntrySnapshot } from '../models/entry-snapshot';
+import type { EntrySnapshot } from '../models/entry-snapshot.js';
 
 export interface EntrySnapshotRepositoryGateway {
   /**

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -1,4 +1,4 @@
-import { err, ok, type Result } from '../../../shared/domain/types/result';
+import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
 type EntryError =
   | { type: 'EMPTY_CONTENT'; message: string }

--- a/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.ts
+++ b/apps/server/src/contexts/entry/domain/services/snapshot-restoration.service.ts
@@ -1,5 +1,5 @@
-import { err, ok, type Result } from '../../../shared/domain/types/result';
-import type { EntrySnapshot } from '../models/entry-snapshot';
+import { err, ok, type Result } from '../../../shared/domain/types/result.js';
+import type { EntrySnapshot } from '../models/entry-snapshot.js';
 
 type SnapshotRestorationError = 'no-snapshot' | 'editor-mismatch';
 

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry-snapshot.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry-snapshot.repository.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway';
-import { EntrySnapshot } from '../../domain/models/entry-snapshot';
+import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
+import { EntrySnapshot } from '../../domain/models/entry-snapshot.js';
 
 export class SupabaseEntrySnapshotRepository implements EntrySnapshotRepositoryGateway {
   constructor(private supabase: SupabaseClient) {}

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway';
-import { Entry } from '../../domain/models/entry';
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import { Entry } from '../../domain/models/entry.js';
 
 export class SupabaseEntryRepository implements EntryRepositoryGateway {
   constructor(private supabase: SupabaseClient) {}

--- a/apps/server/src/contexts/entry/presentation/routes/entries.ts
+++ b/apps/server/src/contexts/entry/presentation/routes/entries.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { CreateEntryUsecase } from '../../application/usecases/create-entry.usecase';
-import { DeleteEntryUsecase } from '../../application/usecases/delete-entry.usecase';
-import { GetEntryUsecase } from '../../application/usecases/get-entry.usecase';
-import { ListEntriesUsecase } from '../../application/usecases/list-entries.usecase';
-import { UpdateEntryUsecase } from '../../application/usecases/update-entry.usecase';
-import { SupabaseEntryRepository } from '../../infrastructure/repositories/supabase-entry.repository';
-import { SupabaseEntrySnapshotRepository } from '../../infrastructure/repositories/supabase-entry-snapshot.repository';
+import { CreateEntryUsecase } from '../../application/usecases/create-entry.usecase.js';
+import { DeleteEntryUsecase } from '../../application/usecases/delete-entry.usecase.js';
+import { GetEntryUsecase } from '../../application/usecases/get-entry.usecase.js';
+import { ListEntriesUsecase } from '../../application/usecases/list-entries.usecase.js';
+import { UpdateEntryUsecase } from '../../application/usecases/update-entry.usecase.js';
+import { SupabaseEntryRepository } from '../../infrastructure/repositories/supabase-entry.repository.js';
+import { SupabaseEntrySnapshotRepository } from '../../infrastructure/repositories/supabase-entry-snapshot.repository.js';
 
 type Env = {
   Variables: {

--- a/apps/server/src/contexts/question/application/errors/question.errors.ts
+++ b/apps/server/src/contexts/question/application/errors/question.errors.ts
@@ -1,7 +1,7 @@
 import {
   NotFoundError,
   ValidationError,
-} from '../../../shared/application/errors/application.errors';
+} from '../../../shared/application/errors/application.errors.js';
 
 export class QuestionNotFoundError extends NotFoundError {
   constructor(questionId: string) {

--- a/apps/server/src/contexts/question/application/usecases/accept-question-proposal.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/accept-question-proposal.usecase.ts
@@ -1,11 +1,11 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
 import {
   QuestionLimitExceededError,
   QuestionNotFoundError,
   QuestionNotPendingError,
-} from '../errors/question.errors';
+} from '../errors/question.errors.js';
 
 export class AcceptQuestionProposalUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/archive-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/archive-question.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
-import { QuestionNotFoundError } from '../errors/question.errors';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
+import { QuestionNotFoundError } from '../errors/question.errors.js';
 
 export class ArchiveQuestionUsecase {
   constructor(private questionRepo: QuestionRepositoryGateway) {}

--- a/apps/server/src/contexts/question/application/usecases/create-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/create-question.usecase.ts
@@ -1,8 +1,8 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import { Question, type QuestionProps } from '../../domain/models/question';
-import { QuestionTransaction } from '../../domain/models/question-transaction';
-import { QuestionLimitExceededError, QuestionValidationError } from '../errors/question.errors';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import { Question, type QuestionProps } from '../../domain/models/question.js';
+import { QuestionTransaction } from '../../domain/models/question-transaction.js';
+import { QuestionLimitExceededError, QuestionValidationError } from '../errors/question.errors.js';
 
 interface CreateQuestionInput {
   string: string;

--- a/apps/server/src/contexts/question/application/usecases/edit-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/edit-question.usecase.ts
@@ -1,8 +1,8 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
-import { QuestionTransaction } from '../../domain/models/question-transaction';
-import { QuestionNotFoundError, QuestionValidationError } from '../errors/question.errors';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
+import { QuestionTransaction } from '../../domain/models/question-transaction.js';
+import { QuestionNotFoundError, QuestionValidationError } from '../errors/question.errors.js';
 
 interface EditQuestionInput {
   string: string;

--- a/apps/server/src/contexts/question/application/usecases/get-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/get-question.usecase.ts
@@ -1,7 +1,7 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
-import type { QuestionTransactionProps } from '../../domain/models/question-transaction';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
+import type { QuestionTransactionProps } from '../../domain/models/question-transaction.js';
 
 interface GetQuestionResult {
   question: QuestionProps;

--- a/apps/server/src/contexts/question/application/usecases/link-question-to-entry.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/link-question-to-entry.usecase.ts
@@ -1,7 +1,7 @@
-import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway';
-import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import { QuestionNotFoundError } from '../errors/question.errors';
+import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway.js';
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway.js';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import { QuestionNotFoundError } from '../errors/question.errors.js';
 
 export class LinkQuestionToEntryUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/list-active-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-active-questions.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
 
 export class ListActiveQuestionsUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/list-all-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-all-questions.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
 
 export class ListAllQuestionsUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/list-entry-questions.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-entry-questions.usecase.ts
@@ -1,7 +1,7 @@
-import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway.js';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
 
 export class ListEntryQuestionsUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/list-pending-proposals.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/list-pending-proposals.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
 
 interface PendingProposal {
   question: QuestionProps;

--- a/apps/server/src/contexts/question/application/usecases/reject-question-proposal.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/reject-question-proposal.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import { QuestionNotFoundError, QuestionNotPendingError } from '../errors/question.errors';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import { QuestionNotFoundError, QuestionNotPendingError } from '../errors/question.errors.js';
 
 export class RejectQuestionProposalUsecase {
   constructor(

--- a/apps/server/src/contexts/question/application/usecases/unarchive-question.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/unarchive-question.usecase.ts
@@ -1,6 +1,6 @@
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import type { QuestionProps } from '../../domain/models/question';
-import { QuestionLimitExceededError, QuestionNotFoundError } from '../errors/question.errors';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import type { QuestionProps } from '../../domain/models/question.js';
+import { QuestionLimitExceededError, QuestionNotFoundError } from '../errors/question.errors.js';
 
 export class UnarchiveQuestionUsecase {
   constructor(private questionRepo: QuestionRepositoryGateway) {}

--- a/apps/server/src/contexts/question/application/usecases/unlink-question-from-entry.usecase.ts
+++ b/apps/server/src/contexts/question/application/usecases/unlink-question-from-entry.usecase.ts
@@ -1,4 +1,4 @@
-import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway.js';
 
 export class UnlinkQuestionFromEntryUsecase {
   constructor(private linkRepo: EntryQuestionLinkRepositoryGateway) {}

--- a/apps/server/src/contexts/question/domain/gateways/question-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/question-repository.gateway.ts
@@ -1,4 +1,4 @@
-import type { Question } from '../models/question';
+import type { Question } from '../models/question.js';
 
 export interface QuestionRepositoryGateway {
   findById(id: string): Promise<Question | null>;

--- a/apps/server/src/contexts/question/domain/gateways/question-transaction-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/question-transaction-repository.gateway.ts
@@ -1,4 +1,4 @@
-import type { QuestionTransaction } from '../models/question-transaction';
+import type { QuestionTransaction } from '../models/question-transaction.js';
 
 export interface QuestionTransactionRepositoryGateway {
   listByQuestionId(questionId: string): Promise<QuestionTransaction[]>;

--- a/apps/server/src/contexts/question/domain/models/question-transaction.ts
+++ b/apps/server/src/contexts/question/domain/models/question-transaction.ts
@@ -1,4 +1,4 @@
-import { err, ok, type Result } from '../../../shared/domain/types/result';
+import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
 type QuestionTransactionError =
   | { type: 'EMPTY_STRING'; message: string }

--- a/apps/server/src/contexts/question/domain/services/current-question-text.service.ts
+++ b/apps/server/src/contexts/question/domain/services/current-question-text.service.ts
@@ -1,4 +1,4 @@
-import type { QuestionTransaction } from '../models/question-transaction';
+import type { QuestionTransaction } from '../models/question-transaction.js';
 
 /**
  * validated な transaction のうち question_version 最大のものを返す。

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway';
+import type { EntryQuestionLinkRepositoryGateway } from '../../domain/gateways/entry-question-link-repository.gateway.js';
 
 export class SupabaseEntryQuestionLinkRepository implements EntryQuestionLinkRepositoryGateway {
   constructor(private supabase: SupabaseClient) {}

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question-transaction.repository.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway';
-import { QuestionTransaction } from '../../domain/models/question-transaction';
+import type { QuestionTransactionRepositoryGateway } from '../../domain/gateways/question-transaction-repository.gateway.js';
+import { QuestionTransaction } from '../../domain/models/question-transaction.js';
 
 export class SupabaseQuestionTransactionRepository implements QuestionTransactionRepositoryGateway {
   constructor(private supabase: SupabaseClient) {}

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-question.repository.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway';
-import { Question } from '../../domain/models/question';
+import type { QuestionRepositoryGateway } from '../../domain/gateways/question-repository.gateway.js';
+import { Question } from '../../domain/models/question.js';
 
 export class SupabaseQuestionRepository implements QuestionRepositoryGateway {
   constructor(private supabase: SupabaseClient) {}

--- a/apps/server/src/contexts/question/presentation/routes/entry-questions.ts
+++ b/apps/server/src/contexts/question/presentation/routes/entry-questions.ts
@@ -1,11 +1,11 @@
 import { Hono } from 'hono';
-import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository';
-import { LinkQuestionToEntryUsecase } from '../../application/usecases/link-question-to-entry.usecase';
-import { ListEntryQuestionsUsecase } from '../../application/usecases/list-entry-questions.usecase';
-import { UnlinkQuestionFromEntryUsecase } from '../../application/usecases/unlink-question-from-entry.usecase';
-import { SupabaseEntryQuestionLinkRepository } from '../../infrastructure/repositories/supabase-entry-question-link.repository';
-import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository';
-import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository';
+import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
+import { LinkQuestionToEntryUsecase } from '../../application/usecases/link-question-to-entry.usecase.js';
+import { ListEntryQuestionsUsecase } from '../../application/usecases/list-entry-questions.usecase.js';
+import { UnlinkQuestionFromEntryUsecase } from '../../application/usecases/unlink-question-from-entry.usecase.js';
+import { SupabaseEntryQuestionLinkRepository } from '../../infrastructure/repositories/supabase-entry-question-link.repository.js';
+import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository.js';
+import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository.js';
 
 type Env = {
   Variables: {

--- a/apps/server/src/contexts/question/presentation/routes/questions.ts
+++ b/apps/server/src/contexts/question/presentation/routes/questions.ts
@@ -1,17 +1,17 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { AcceptQuestionProposalUsecase } from '../../application/usecases/accept-question-proposal.usecase';
-import { ArchiveQuestionUsecase } from '../../application/usecases/archive-question.usecase';
-import { CreateQuestionUsecase } from '../../application/usecases/create-question.usecase';
-import { EditQuestionUsecase } from '../../application/usecases/edit-question.usecase';
-import { GetQuestionUsecase } from '../../application/usecases/get-question.usecase';
-import { ListActiveQuestionsUsecase } from '../../application/usecases/list-active-questions.usecase';
-import { ListAllQuestionsUsecase } from '../../application/usecases/list-all-questions.usecase';
-import { ListPendingProposalsUsecase } from '../../application/usecases/list-pending-proposals.usecase';
-import { RejectQuestionProposalUsecase } from '../../application/usecases/reject-question-proposal.usecase';
-import { UnarchiveQuestionUsecase } from '../../application/usecases/unarchive-question.usecase';
-import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository';
-import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository';
+import { AcceptQuestionProposalUsecase } from '../../application/usecases/accept-question-proposal.usecase.js';
+import { ArchiveQuestionUsecase } from '../../application/usecases/archive-question.usecase.js';
+import { CreateQuestionUsecase } from '../../application/usecases/create-question.usecase.js';
+import { EditQuestionUsecase } from '../../application/usecases/edit-question.usecase.js';
+import { GetQuestionUsecase } from '../../application/usecases/get-question.usecase.js';
+import { ListActiveQuestionsUsecase } from '../../application/usecases/list-active-questions.usecase.js';
+import { ListAllQuestionsUsecase } from '../../application/usecases/list-all-questions.usecase.js';
+import { ListPendingProposalsUsecase } from '../../application/usecases/list-pending-proposals.usecase.js';
+import { RejectQuestionProposalUsecase } from '../../application/usecases/reject-question-proposal.usecase.js';
+import { UnarchiveQuestionUsecase } from '../../application/usecases/unarchive-question.usecase.js';
+import { SupabaseQuestionRepository } from '../../infrastructure/repositories/supabase-question.repository.js';
+import { SupabaseQuestionTransactionRepository } from '../../infrastructure/repositories/supabase-question-transaction.repository.js';
 
 type Env = {
   Variables: {

--- a/apps/server/src/contexts/shared/presentation/middleware/error-handler.ts
+++ b/apps/server/src/contexts/shared/presentation/middleware/error-handler.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import { ApplicationError } from '../../application/errors/application.errors';
+import { ApplicationError } from '../../application/errors/application.errors.js';
 
 export function errorHandler(err: Error, c: Context) {
   if (err instanceof ApplicationError) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from '@hono/node-server';
-import app from './app';
+import app from './app.js';
 
 const port = Number(process.env.PORT ?? 3000);
 

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
tsc が拡張子なし import を出力→Vercel ランタイムで ERR_MODULE_NOT_FOUND。module を NodeNext に変更し、全相対 import に .js 拡張子を追加。