### PR TITLE
fix: rewrite 削除（パスが / に上書きされていた）

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,4 +1,3 @@
 {
-  "installCommand": "pnpm install --filter @oryzae/server...",
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "installCommand": "pnpm install --filter @oryzae/server..."
 }


### PR DESCRIPTION
rewrite で全パスが / になり /api/v1/* が 404。Hono ネイティブサポートでは rewrite 不要。