### PR TITLE
fix: restore Vercel serverless entry point and fix route paths

### DIFF
--- a/apps/server/api/index.js
+++ b/apps/server/api/index.js
@@ -1,0 +1,6 @@
+// Vercel Serverless Function entry point
+// .js to bypass Vercel's TypeScript compiler (type safety is enforced by tsc in CI)
+import { handle } from 'hono/vercel';
+import app from '../src/app.js';
+
+export default handle(app);

--- a/apps/server/api/index.js
+++ b/apps/server/api/index.js
@@ -1,6 +1,7 @@
 // Vercel Serverless Function entry point
-// .js to bypass Vercel's TypeScript compiler (type safety is enforced by tsc in CI)
+// Import from tsc output (dist/) to bypass Vercel ncc's TypeScript compilation
+// which fails on Supabase v2 types. Type safety is enforced by tsc in CI.
 import { handle } from 'hono/vercel';
-import app from '../src/app.js';
+import app from '../dist/app.js';
 
 export default handle(app);

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -17,8 +17,8 @@ app.route('/api/v1/auth', authRoutes);
 
 // Protected routes
 app.use('/api/v1/*', authMiddleware);
-app.route('/api/v1/entries.js', entries);
-app.route('/api/v1/questions.js', questions);
-app.route('/api/v1/entries/:entryId/questions.js', entryQuestions);
+app.route('/api/v1/entries', entries);
+app.route('/api/v1/questions', questions);
+app.route('/api/v1/entries/:entryId/questions', entryQuestions);
 
 export default app;

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "",
   "installCommand": "pnpm install --filter @oryzae/server...",
   "functions": {
     "api/**/*.js": {

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,4 +1,3 @@
 {
-  "installCommand": "pnpm install --filter @oryzae/server...",
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "installCommand": "pnpm install --filter @oryzae/server..."
 }

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,9 +1,9 @@
 {
-  "buildCommand": "",
+  "buildCommand": "pnpm run build",
   "installCommand": "pnpm install --filter @oryzae/server...",
   "functions": {
     "api/**/*.js": {
-      "includeFiles": "src/**"
+      "includeFiles": "dist/**"
     }
   },
   "rewrites": [{ "source": "/(.*)", "destination": "/api" }]

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,3 +1,9 @@
 {
-  "installCommand": "pnpm install --filter @oryzae/server..."
+  "installCommand": "pnpm install --filter @oryzae/server...",
+  "functions": {
+    "api/**/*.js": {
+      "includeFiles": "src/**"
+    }
+  },
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
 }

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/server": {
-      "entry": ["src/app.ts"],
+      "entry": ["src/app.ts", "api/index.js"],
       "project": ["src/**/*.ts"],
       "ignore": ["src/contexts/shared/infrastructure/supabase-client.ts"],
       "vitest": true


### PR DESCRIPTION
## Summary
- Restore `api/index.js` entry point with `hono/vercel` adapter (Vercel does not auto-detect Hono apps)
- Restore `functions` and `rewrites` config in `vercel.json`
- Remove erroneous `.js` suffixes from route paths in `app.ts` that caused `/api/v1/*` to 404
- Add `api/index.js` to knip entry points

## Test plan
- [ ] Verify `/health` returns 200
- [ ] Verify `/api/v1/auth/callback` is reachable
- [ ] Verify `/api/v1/entries` returns 401 (auth required)
- [ ] Verify `/api/v1/questions` returns 401 (auth required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)