### PR TITLE
fix: use Vercel native Hono framework support

### DIFF
--- a/apps/server/api/index.js
+++ b/apps/server/api/index.js
@@ -1,7 +1,0 @@
-// Vercel Serverless Function entry point
-// Import from tsc output (dist/) to bypass Vercel ncc's TypeScript compilation
-// which fails on Supabase v2 types. Type safety is enforced by tsc in CI.
-import { handle } from 'hono/vercel';
-import app from '../dist/app.js';
-
-export default handle(app);

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,10 +1,3 @@
 {
-  "buildCommand": "pnpm run build",
-  "installCommand": "pnpm install --filter @oryzae/server...",
-  "functions": {
-    "api/**/*.js": {
-      "includeFiles": "dist/**"
-    }
-  },
-  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+  "installCommand": "pnpm install --filter @oryzae/server..."
 }

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/server": {
-      "entry": ["src/app.ts", "api/index.js"],
+      "entry": ["src/app.ts"],
       "project": ["src/**/*.ts"],
       "ignore": ["src/contexts/shared/infrastructure/supabase-client.ts"],
       "vitest": true


### PR DESCRIPTION
## Summary
- Remove `api/index.js` entry point and `hono/vercel` adapter — conflicts with Vercel's native Hono framework detection (`framework: "hono"`)
- Remove `functions`, `rewrites`, `buildCommand` from `vercel.json`
- Let Vercel auto-detect `src/app.ts` `export default app` and handle routing natively

Previous approach (api/ + handle() + rewrites) created two competing Lambda functions and caused 500 errors.

## Test plan
- [ ] Verify `/health` returns `{"status":"ok"}`
- [ ] Verify `/api/v1/entries` returns 401 (auth required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)