### PR TITLE
docs: README.md / CLAUDE.md を最新のモノレポ構成に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,16 +53,4 @@ Feature-Sliced Architecture:
 
 ## Design Docs (SSoT)
 
-設計判断の正はすべて `docs/` 配下にある。
-
-| ドキュメント | 内容 |
-| --- | --- |
-| `docs/backend-architecture-guide.md` | レイヤー依存、ドメインモデル、エラー処理、命名規則 |
-| `docs/backend-testing-guide.md` | テスト戦略、ガードレール、CI |
-| `docs/entry-backend-guide.md` | Entry コンテキスト実装ガイド |
-| `docs/question-backend-guide.md` | Question コンテキスト実装ガイド |
-| `docs/client-architecture-guide.md` | Feature-Sliced 構造、インポートルール、データフェッチング |
-| `docs/client-testing-guide.md` | フロントエンドテスト戦略、ガードレール |
-| `docs/shared-package-guide.md` | @oryzae/shared の使用ルール |
-| `docs/infra-guide.md` | Vercel + Supabase デプロイ |
-| `docs/archive/` | 過去の設計指示書 |
+設計判断の正はすべて `docs/` 配下にある。実装前に必ず該当ドキュメントを確認すること。一覧は `README.md` を参照。

--- a/README.md
+++ b/README.md
@@ -1,235 +1,66 @@
 # Oryzae
 
-ジャーナリング支援アプリ「オリゼー」のバックエンド。
-日記・日誌を通じて「問い」を育て、記録を「発酵」させるためのサーバーサイド API。
+ジャーナリング支援アプリ。問いを育て、振り返りを通じて思考を深める。
 
-## 技術スタック
+## Tech Stack
 
-| カテゴリ | 技術 |
+| 層 | 技術 |
 |---|---|
-| 言語 | TypeScript |
-| API フレームワーク | Hono |
-| DB / 認証 | Supabase (PostgreSQL + Auth + RLS) |
-| モノレポ | pnpm workspaces |
-| テスト | Vitest |
-| バリデーション | Zod |
+| Backend | Hono + TypeScript (DDD layered architecture) |
+| Frontend | Next.js + Tailwind CSS (Feature-Sliced Architecture) |
+| Database | Supabase (PostgreSQL + Auth + RLS) |
+| Shared | Zod schemas + constants (`packages/shared`) |
+| Deploy | Vercel |
+| Monorepo | pnpm workspaces |
 
-## 前提条件
-
-- **Node.js** v20 以上
-- **pnpm** v10 以上
-- **Docker Desktop** （Supabase ローカル環境に必要）
-
-## セットアップ
-
-### 1. 依存インストール
+## Getting Started
 
 ```bash
 pnpm install
-```
 
-### 2. Supabase CLI のインストール
-
-```bash
-brew install supabase/tap/supabase
-```
-
-### 3. Supabase ローカル環境の起動
-
-```bash
-supabase init     # 初回のみ（supabase/ ディレクトリが既にあればスキップ）
-supabase start    # Docker でローカル Supabase を起動
-```
-
-起動すると以下のような情報が表示されます:
-
-```
-API URL: http://127.0.0.1:54321
-anon key: eyJ...
-service_role key: eyJ...
-```
-
-### 4. 環境変数の設定
-
-```bash
-cp apps/server/.env.example apps/server/.env
-```
-
-`.env` を編集して、`supabase start` で表示された値を設定:
-
-```
-SUPABASE_URL=http://127.0.0.1:54321
-SUPABASE_ANON_KEY=（表示された anon key）
-SUPABASE_SERVICE_ROLE_KEY=（表示された service_role key）
-PORT=3000
-```
-
-### 5. DB マイグレーション
-
-ローカル Supabase を使う場合、`supabase start` 時に `supabase/migrations/` 配下の SQL が自動適用されます。
-
-手動で適用する場合:
-
-```bash
-supabase db reset
-```
-
-### 6. サーバー起動
-
-```bash
+# Backend (port 3000)
 pnpm --filter @oryzae/server dev
+
+# Frontend (port 3001)
+pnpm --filter @oryzae/client dev
 ```
 
-`Server running on http://localhost:3000` と表示されれば成功。
+各アプリの環境変数設定が必要です。`apps/server/.env.example` を参考に `.env` を作成してください。
 
-## 動作確認
-
-### ヘルスチェック
+## Quality Checks
 
 ```bash
-curl http://localhost:3000/health
+pnpm typecheck   # TypeScript strict mode (server + shared + client)
+pnpm lint        # Biome (format + lint)
+pnpm test        # Vitest (server + client)
+pnpm dep-cruise  # Architecture dependency rules (server + client)
+pnpm knip        # Dead code detection
 ```
 
-```json
-{"status":"ok"}
-```
+Git hooks (pre-commit / pre-push) で自動実行されます。`--no-verify` は禁止です。
 
-### テストユーザーの作成
-
-Supabase ローカルダッシュボード（http://127.0.0.1:54323）にアクセスし、
-Authentication > Users から手動でユーザーを作成するか、以下のコマンドで作成:
-
-```bash
-# ユーザー登録
-curl -X POST http://127.0.0.1:54321/auth/v1/signup \
-  -H "apikey: YOUR_ANON_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "test@example.com", "password": "password123"}'
-```
-
-### アクセストークンの取得
-
-```bash
-# ログイン → access_token を取得
-curl -X POST http://127.0.0.1:54321/auth/v1/token?grant_type=password \
-  -H "apikey: YOUR_ANON_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "test@example.com", "password": "password123"}'
-```
-
-レスポンスの `access_token` を以降のリクエストで使います。
-以下のコマンドで変数に保存しておくと便利です:
-
-```bash
-TOKEN="取得した access_token をここに貼り付け"
-```
-
-### エントリの CRUD 操作
-
-**新規作成**
-
-```bash
-curl -X POST http://localhost:3000/api/v1/entries \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "今日、カント君の展示に行った。",
-    "mediaUrls": [],
-    "editorType": "typetrace",
-    "editorVersion": "1.0.0",
-    "extension": {"averageWPM": 6.64, "erasureTraces": []}
-  }'
-```
-
-**一覧取得**
-
-```bash
-curl http://localhost:3000/api/v1/entries \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**詳細取得**（最新 snapshot 含む）
-
-```bash
-curl http://localhost:3000/api/v1/entries/{id} \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-**更新**
-
-```bash
-curl -X PUT http://localhost:3000/api/v1/entries/{id} \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "今日、カント君の展示に行った。すごく良かった。",
-    "mediaUrls": [],
-    "editorType": "typetrace",
-    "editorVersion": "1.0.0",
-    "extension": {"averageWPM": 7.2, "erasureTraces": []}
-  }'
-```
-
-**削除**
-
-```bash
-curl -X DELETE http://localhost:3000/api/v1/entries/{id} \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-## テスト
-
-```bash
-# ユニットテスト実行
-pnpm --filter @oryzae/server test
-
-# ウォッチモード
-pnpm --filter @oryzae/server test:watch
-
-# 型チェック
-pnpm --filter @oryzae/server typecheck
-```
-
-## API エンドポイント
-
-| メソッド | パス | 説明 |
-|---|---|---|
-| GET | `/health` | ヘルスチェック |
-| POST | `/api/v1/entries` | エントリ新規作成 |
-| GET | `/api/v1/entries` | エントリ一覧（`?cursor=&limit=` でページネーション） |
-| GET | `/api/v1/entries/:id` | エントリ詳細（最新 snapshot 含む） |
-| PUT | `/api/v1/entries/:id` | エントリ更新（entries 更新 + snapshot 追記） |
-| DELETE | `/api/v1/entries/:id` | エントリ削除（cascade で snapshots も削除） |
-
-## ディレクトリ構成
+## Project Structure
 
 ```
-apps/server/src/
-├── index.ts                              # エントリーポイント
-└── contexts/
-    ├── entry/                            # エントリ管理コンテキスト
-    │   ├── presentation/routes/          # HTTP ↔ ユースケース変換
-    │   ├── application/usecases/         # 1 ユースケース = 1 ファイル
-    │   ├── domain/
-    │   │   ├── models/                   # BaseEntry, EntrySnapshot
-    │   │   ├── services/                 # 純粋ドメインロジック
-    │   │   └── gateways/                 # 外部依存の抽象 IF
-    │   └── infrastructure/repositories/  # Supabase 実装
-    └── shared/                           # コンテキスト間共有
-        ├── infrastructure/               # Supabase クライアント
-        └── presentation/middleware/      # 認証, エラーハンドリング
-
-supabase/migrations/                      # DB マイグレーション
+apps/
+  server/         # Hono backend (@oryzae/server)
+  client/         # Next.js frontend (@oryzae/client)
+packages/
+  shared/         # Shared Zod schemas & constants (@oryzae/shared)
+docs/             # Design docs (Single Source of Truth)
 ```
 
-## アーキテクチャ
+## Design Docs
 
-レイヤードアーキテクチャを採用。依存方向は:
+設計判断の正はすべて `docs/` 配下にあります。
 
-```
-presentation → application → domain ← infrastructure
-```
-
-- **domain** は何にも依存しない（最内層）
-- **infrastructure** は domain の gateway IF を実装する（依存性逆転）
-- 詳細は `OryzaeArchitecture-2.md` を参照
+| ドキュメント | 内容 |
+|---|---|
+| `docs/backend-architecture-guide.md` | DDD レイヤー依存、ドメインモデル、エラー処理 |
+| `docs/backend-testing-guide.md` | バックエンドテスト戦略、ガードレール |
+| `docs/client-architecture-guide.md` | Feature-Sliced 構造、インポートルール |
+| `docs/client-testing-guide.md` | フロントエンドテスト戦略 |
+| `docs/shared-package-guide.md` | `@oryzae/shared` の使用ルール |
+| `docs/entry-backend-guide.md` | Entry コンテキスト実装ガイド |
+| `docs/question-backend-guide.md` | Question コンテキスト実装ガイド |
+| `docs/infra-guide.md` | Vercel + Supabase デプロイ |


### PR DESCRIPTION
## Summary
- README.md をフルスタックモノレポの現状に合わせて書き直し
- CLAUDE.md の docs テーブル重複を解消（README.md に一元化）

## 腐敗防止の方針
- curl コマンド例、エンドポイント一覧、環境変数の値例など**変わりやすい情報を削除**
- 代わりに `docs/` へのポインタで済ませる
- docs テーブルは README.md のみに持ち、CLAUDE.md は「docs/ が SSoT」とだけ記載
  - 新しい docs 追加時に1箇所の更新で済む

## Test plan
- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — 通過
- [x] `pnpm knip` — 通過
- [x] コード内に旧パス (`@/components/`, `@/hooks/use-auth`) の参照が残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)