### PR TITLE
feat: Hono API を Next.js に統合、単一デプロイに

### DIFF
--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@oryzae/shared'],
+  turbopack: {},
 };
 
 export default nextConfig;

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -12,6 +12,7 @@
     "dep-cruise": "depcruise src --config .dependency-cruiser.cjs"
   },
   "dependencies": {
+    "@oryzae/server": "workspace:*",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/apps/client/src/app/api/[...path]/route.ts
+++ b/apps/client/src/app/api/[...path]/route.ts
@@ -1,0 +1,5 @@
+import app from '@oryzae/server';
+
+const handler = (req: Request) => app.fetch(req);
+
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH };

--- a/apps/client/src/app/health/route.ts
+++ b/apps/client/src/app/health/route.ts
@@ -1,0 +1,5 @@
+import app from '@oryzae/server';
+
+const handler = (req: Request) => app.fetch(req);
+
+export { handler as GET };

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -1,5 +1,3 @@
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
-
 export interface ApiClient {
   baseUrl: string;
   headers: Record<string, string>;
@@ -15,10 +13,10 @@ export function createApiClient(accessToken?: string): ApiClient {
   }
 
   return {
-    baseUrl: BASE_URL,
+    baseUrl: '',
     headers,
     fetch(path: string, init?: RequestInit) {
-      return fetch(`${BASE_URL}${path}`, {
+      return fetch(path, {
         ...init,
         headers: { ...headers, ...init?.headers },
       });

--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -1,0 +1,4 @@
+{
+  "installCommand": "pnpm install --filter @oryzae/client...",
+  "buildCommand": "pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/client build"
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "main": "./dist/app.js",
   "exports": {
-    ".": "./dist/app.js"
+    ".": {
+      "types": "./src/app.ts",
+      "default": "./dist/app.js"
+    }
   },
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "main": "./dist/app.js",
+  "exports": {
+    ".": "./dist/app.js"
+  },
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono';
-import { cors } from 'hono/cors';
 import { entries } from './contexts/entry/presentation/routes/entries.js';
 import { entryQuestions } from './contexts/question/presentation/routes/entry-questions.js';
 import { questions } from './contexts/question/presentation/routes/questions.js';
@@ -7,12 +6,7 @@ import { authMiddleware } from './contexts/shared/presentation/middleware/auth.j
 import { errorHandler } from './contexts/shared/presentation/middleware/error-handler.js';
 import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
 
-const allowedOrigins = process.env.CLIENT_URL
-  ? [process.env.CLIENT_URL, 'http://localhost:3001']
-  : ['http://localhost:3001'];
-
 const app = new Hono()
-  .use('*', cors({ origin: allowedOrigins, credentials: true }))
   .onError(errorHandler)
   .get('/health', (c) => c.json({ status: 'ok' }))
   .route('/api/v1/auth', authRoutes)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "tsc",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@oryzae/server':
+        specifier: workspace:*
+        version: link:../server
       next:
         specifier: 16.2.2
         version: 16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## 概要

Hono バックエンド API を Next.js の Route Handler に埋め込み、単一の Vercel プロジェクトでフロントエンド + API を同時にデプロイできるようにする。

## Before → After

```
Before: ブラウザ → (CORS) → oryzae-server.vercel.app (Hono)
                             + oryzae-client (未デプロイ)

After:  ブラウザ → oryzae-client.vercel.app
                   ├── /login, /entries, /questions  (Next.js ページ)
                   └── /api/v1/*, /health            (Hono API, 内部実行)
```

## 変更内容

### Next.js Route Handler
- `src/app/api/[...path]/route.ts` — 全 `/api/*` リクエストを Hono の `app.fetch()` に転送
- `src/app/health/route.ts` — ヘルスチェック

### API クライアント
- `NEXT_PUBLIC_API_URL` 不要に（同一オリジン）
- `lib/api.ts` の baseUrl を空文字に変更

### サーバー
- CORS ミドルウェア削除（同一オリジン、不要に）
- `package.json` に `exports` フィールド追加（`dist/app.js`）

### 共有パッケージ
- `package.json` の `main`/`types` を `dist/` に変更

### Vercel デプロイ
- `apps/client/vercel.json` — shared → server → client の順にビルド
- Vercel ダッシュボードで Root Directory を `apps/client` に設定すればデプロイ可能

## デプロイ手順

1. Vercel ダッシュボードで既存の `oryzae-server` プロジェクトの Root Directory を `apps/client` に変更（または新規プロジェクト作成）
2. 環境変数 `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` を設定
3. デプロイ

## Test plan
- [x] `curl http://localhost:3001/health` → `{"status":"ok"}`
- [x] `curl http://localhost:3001/api/v1/auth/me` → `{"error":"Missing token"}`
- [x] ブラウザで `/login` が正常表示
- [x] `pnpm typecheck` — 通過
- [x] `pnpm dep-cruise` — 通過
- [x] `pnpm knip` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)