### PR TITLE
fix: align visual design with reference UI

### DIFF
--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -1,26 +1,43 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f9f8f4;
+  --foreground: #2d2d2d;
+  --accent: #4a9e8e;
+  --accent-light: rgba(74, 158, 142, 0.08);
+  --border-subtle: rgba(0, 0, 0, 0.05);
+  --toolbar-hover: rgba(0, 0, 0, 0.04);
+  --date-color: #999;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
+  --color-accent-light: var(--accent-light);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #1a1a1a;
+    --foreground: #cccccc;
+    --accent: #5ab8a6;
+    --accent-light: rgba(90, 184, 166, 0.1);
+    --border-subtle: rgba(255, 255, 255, 0.06);
+    --toolbar-hover: rgba(255, 255, 255, 0.06);
+    --date-color: #666;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Noto Serif JP", "Noto Sans JP", serif;
+}
+
+::selection {
+  background: rgba(74, 158, 142, 0.2);
+  color: inherit;
 }

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -24,6 +24,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+      <head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&family=Noto+Sans+JP:wght@200..900&family=Inter:wght@300;400;500;600&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body className="min-h-full flex flex-col bg-background text-foreground">{children}</body>
     </html>
   );

--- a/apps/client/src/features/entries/components/editor-status-bar.tsx
+++ b/apps/client/src/features/entries/components/editor-status-bar.tsx
@@ -13,7 +13,7 @@ export function EditorStatusBar({ status, charCount }: EditorStatusBarProps) {
   }[status];
 
   return (
-    <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-1.5 text-xs text-zinc-400 dark:border-zinc-800">
+    <div className="flex items-center justify-between border-t border-[var(--border-subtle)] px-4 py-1.5 text-xs text-[var(--date-color)]">
       <div className="flex items-center gap-2">
         <span
           className={`inline-block h-1.5 w-1.5 rounded-full ${

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -160,9 +160,9 @@ export function EntryEditor({
   const charCount = content.length;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-white dark:bg-zinc-950">
+    <div className="fixed inset-0 z-50 flex flex-col bg-background">
       {/* Top toolbar */}
-      <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+      <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -235,7 +235,7 @@ export function EntryEditor({
       </div>
 
       {/* Question linker */}
-      <div className="border-b border-zinc-200 px-4 py-2 dark:border-zinc-800">
+      <div className="border-b border-[var(--border-subtle)] px-4 py-2">
         <QuestionLinker
           activeQuestions={activeQuestions}
           linkedQuestionIds={linkedIds}
@@ -285,7 +285,7 @@ export function EntryEditor({
       </div>
 
       {/* Bottom toolbar */}
-      <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-2 dark:border-zinc-800">
+      <div className="flex items-center justify-between border-t border-[var(--border-subtle)] px-4 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/apps/client/src/features/questions/components/question-timeline-event.tsx
+++ b/apps/client/src/features/questions/components/question-timeline-event.tsx
@@ -52,7 +52,7 @@ export function QuestionTimelineEvent({
 
   return (
     <div
-      className={`ml-6 rounded-lg border-l-4 ${config.borderColor} bg-zinc-50 px-5 py-4 dark:bg-zinc-900/50`}
+      className={`ml-6 rounded-lg border-l-4 ${config.borderColor} bg-[rgba(200,180,140,0.08)] px-5 py-4`}
     >
       <div className="flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1.5">

--- a/apps/client/src/features/questions/components/question-timeline.tsx
+++ b/apps/client/src/features/questions/components/question-timeline.tsx
@@ -67,7 +67,7 @@ export function QuestionTimeline({
       </div>
 
       <div className="relative pl-4">
-        <div className="absolute left-6 top-0 bottom-0 w-0.5 bg-zinc-200 dark:bg-zinc-700" />
+        <div className="absolute left-6 top-0 bottom-0 w-0.5 bg-[rgba(200,180,140,0.15)]" />
 
         {[...groups.entries()].map(([dateLabel, items]) => (
           <div key={dateLabel} className="mb-8">


### PR DESCRIPTION
## Summary
Match the warm, natural color palette and typography of the reference UI:
- Background: warm off-white #F9F8F4 (was pure white)
- Font: Noto Serif JP + Noto Sans JP (was system-ui)
- Border colors: subtle rgba instead of zinc grays
- Timeline cards: warm beige tint
- Dark mode colors aligned

## Screenshots
Before: white background, system font, zinc borders
After: warm beige background, Noto Serif JP, subtle borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)