### PR TITLE
fix: editor alongside sidebar + CSS variable conflicts

### DIFF
--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f9f8f4;
-  --foreground: #2d2d2d;
+  --bg: #f9f8f4;
+  --fg: #2d2d2d;
   --accent: #4a9e8e;
   --accent-light: rgba(74, 158, 142, 0.08);
   --border-subtle: rgba(0, 0, 0, 0.05);
@@ -10,19 +10,10 @@
   --date-color: #999;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-accent: var(--accent);
-  --color-accent-light: var(--accent-light);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #1a1a1a;
-    --foreground: #cccccc;
+    --bg: #1a1a1a;
+    --fg: #cccccc;
     --accent: #5ab8a6;
     --accent-light: rgba(90, 184, 166, 0.1);
     --border-subtle: rgba(255, 255, 255, 0.06);
@@ -32,8 +23,8 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--bg);
+  color: var(--fg);
   font-family: "Noto Serif JP", "Noto Sans JP", serif;
 }
 

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="min-h-full flex flex-col bg-background text-foreground">{children}</body>
+      <body className="min-h-full flex flex-col bg-[var(--bg)] text-[var(--fg)]">{children}</body>
     </html>
   );
 }

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -45,7 +45,7 @@ export function Sidebar() {
   }
 
   return (
-    <nav className="flex h-full w-14 shrink-0 flex-col items-center gap-1.5 border-r border-[var(--border-subtle)] bg-background px-0 py-4">
+    <nav className="flex h-full w-14 shrink-0 flex-col items-center gap-1.5 border-r border-[var(--border-subtle)] bg-[var(--bg)] px-0 py-4">
       {/* Logo */}
       <div
         className="mb-4 text-[9px] font-semibold tracking-[0.15em] text-[var(--accent)]"
@@ -70,7 +70,7 @@ export function Sidebar() {
             className={`group relative flex h-9 w-9 items-center justify-center rounded-lg transition-all ${
               isActive
                 ? 'bg-[var(--accent-light)] text-[var(--accent)]'
-                : 'text-[var(--date-color)] hover:bg-[var(--toolbar-hover)] hover:text-foreground'
+                : 'text-[var(--date-color)] hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]'
             }`}
           >
             <svg

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -160,7 +160,7 @@ export function EntryEditor({
   const charCount = content.length;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-background">
+    <div className="fixed top-0 right-0 bottom-0 left-14 z-50 flex flex-col bg-[var(--bg)]">
       {/* Top toolbar */}
       <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-2">
         <div className="flex items-center gap-2">
@@ -262,7 +262,7 @@ export function EntryEditor({
       {/* Ghost layer — must be above editor (z-50) */}
       <div
         ref={ghostLayerRef}
-        className="pointer-events-none fixed inset-0 z-[51] overflow-hidden"
+        className="pointer-events-none fixed top-0 right-0 bottom-0 left-14 z-[51] overflow-hidden"
       />
 
       {/* Editor area */}


### PR DESCRIPTION
## Summary
- Editor now shows alongside sidebar (left-14) instead of covering it
- Fix CSS variable naming conflict with Tailwind v4 @theme
- Ghost layer also respects sidebar offset

## Test plan
- [x] /entries/[id] shows sidebar + editor side by side
- [x] Background is warm beige (#f9f8f4), not white
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)