### PR TITLE
fix: polish questions timeline to match reference UI

### DIFF
--- a/apps/client/src/app/(protected)/questions/page.tsx
+++ b/apps/client/src/app/(protected)/questions/page.tsx
@@ -18,20 +18,32 @@ export default function QuestionsPage() {
   } = useQuestions(api, authLoading);
 
   return (
-    <div className="flex flex-col gap-6">
-      <QuestionCreateForm onSubmit={createQuestion} />
+    <div className="flex min-h-full flex-col">
+      <div className="flex-1">
+        <div className="flex flex-col gap-6">
+          <QuestionCreateForm onSubmit={createQuestion} />
 
-      {loading ? (
-        <p className="text-sm text-zinc-500">読み込み中...</p>
-      ) : (
-        <QuestionTimeline
-          questions={questions}
-          onArchive={archiveQuestion}
-          onUnarchive={unarchiveQuestion}
-          onAccept={acceptQuestion}
-          onReject={rejectQuestion}
-        />
-      )}
+          {loading ? (
+            <p className="text-sm text-[var(--date-color)]">読み込み中...</p>
+          ) : (
+            <QuestionTimeline
+              questions={questions}
+              onArchive={archiveQuestion}
+              onUnarchive={unarchiveQuestion}
+              onAccept={acceptQuestion}
+              onReject={rejectQuestion}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Footer matching reference UI */}
+      <footer className="sticky bottom-0 flex items-center justify-between border-t border-[var(--border-subtle)] bg-[var(--bg)] px-4 py-1.5 text-xs text-[var(--date-color)]">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--date-color)] opacity-30" />
+          <span>問い一覧</span>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/apps/client/src/features/questions/components/question-timeline-event.tsx
+++ b/apps/client/src/features/questions/components/question-timeline-event.tsx
@@ -60,8 +60,8 @@ export function QuestionTimelineEvent({
             <span className={`inline-block h-2.5 w-2.5 rounded-full ${config.dotColor}`} />
             <span className={`text-xs font-bold ${config.textColor}`}>{config.label}</span>
           </div>
-          <p className="text-base text-zinc-900 dark:text-zinc-100">→ {text}</p>
-          <p className="text-xs text-zinc-400">{config.attribution}</p>
+          <p className="text-base text-[var(--fg)]">→ {text}</p>
+          <p className="text-xs text-[var(--date-color)]">{config.attribution}</p>
         </div>
 
         <div className="flex shrink-0 gap-2 pt-1">

--- a/apps/client/src/features/questions/components/question-timeline.tsx
+++ b/apps/client/src/features/questions/components/question-timeline.tsx
@@ -61,9 +61,11 @@ export function QuestionTimeline({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="mb-6 text-center">
-        <h2 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">問いの変遷</h2>
-        <p className="mt-1 text-sm text-zinc-500">あなたの問いが生まれ、育ち、変化してきた記録</p>
+      <div className="mb-8 text-center">
+        <h2 className="text-2xl font-bold text-[var(--fg)]">問いの変遷</h2>
+        <p className="mt-2 text-sm text-[var(--date-color)]">
+          あなたの問いが生まれ、育ち、変化してきた記録
+        </p>
       </div>
 
       <div className="relative pl-4">
@@ -72,8 +74,8 @@ export function QuestionTimeline({
         {[...groups.entries()].map(([dateLabel, items]) => (
           <div key={dateLabel} className="mb-8">
             <div className="relative mb-3 flex items-center">
-              <div className="absolute left-1.5 h-3 w-3 rounded-full bg-zinc-900 dark:bg-zinc-300" />
-              <span className="ml-8 text-sm font-medium text-zinc-500">{dateLabel}</span>
+              <div className="absolute left-2 h-2.5 w-2.5 rounded-full bg-[var(--fg)]" />
+              <span className="ml-8 text-sm text-[var(--date-color)]">{dateLabel}</span>
             </div>
 
             <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- Larger title, proper CSS variable colors throughout
- Footer with ● 問い一覧 status (matching reference)
- Date dots and text proportions aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)