### PR TITLE
chore: .claude/ スキル全体更新 + pre-push レビューフック追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "agent",
+            "if": "Bash(git push:*)",
+            "prompt": "Push 前のコードレビュー。git diff main...HEAD の差分を確認し、以下を検証してください:\n1. .claude/rules/ のルール違反がないか（as キャスト禁止、hooks テスト必須、feature 隔離）\n2. 明らかなバグや型安全性の問題がないか\n3. 不要なファイル（.DS_Store, console.log 等）が含まれていないか\n\n問題がなければ何も出力せず通過。問題があれば具体的に指摘してください。",
+            "timeout": 120,
+            "statusMessage": "Push 前コードレビュー実行中..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/auto-qa/SKILL.md
+++ b/.claude/skills/auto-qa/SKILL.md
@@ -11,7 +11,8 @@ description: >
 
 # Auto QA Skill
 
-localhost:3001（フロントエンド）+ localhost:3000（バックエンド）に対し、Chrome DevTools MCP で自動QAを実行する。
+localhost:3001 に対し、Chrome DevTools MCP で自動QAを実行する。
+Hono API は Next.js Route Handler に内蔵されているため、localhost:3001 のみでフロントエンドと API の両方が動作する。
 自然言語の指示・PR URL・明示的テストケースのいずれからでも実行可能。
 
 ## このスキルの構造
@@ -142,4 +143,4 @@ YYYY-MM-DD | テスト対象 | 戦略 | 結果(PASS/FAIL/BLOCKED数) | 発見事
 - **"Element with uid X no longer exists"**: 再度 `take_snapshot` で最新uid取得
 - **`navigate_page` タイムアウト**: `take_snapshot` で確認（読み込み済みの場合あり）
 - **セッション切れ**: Phase 2 の認証を再実行
-- **localhost 未起動**: `pnpm --filter @oryzae/server dev` と `pnpm --filter @oryzae/client dev` を起動
+- **localhost 未起動**: `pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/client dev` で起動

--- a/.claude/skills/auto-qa/references/strategy-snapshot-comparison.md
+++ b/.claude/skills/auto-qa/references/strategy-snapshot-comparison.md
@@ -18,11 +18,10 @@
 ```
 git stash
 git checkout main
-pnpm --filter @oryzae/server dev
-pnpm --filter @oryzae/client dev
+pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/client dev
 ```
 
-localhost が起動したら:
+localhost:3001 が起動したら:
 1. ログインして対象ページへ遷移
 2. take_snapshot filePath=/tmp/baseline-{testname}.txt
 3. take_screenshot filePath=/tmp/baseline-{testname}.png
@@ -32,8 +31,7 @@ localhost が起動したら:
 ```
 git checkout <pr-branch>
 git stash pop
-pnpm --filter @oryzae/server dev
-pnpm --filter @oryzae/client dev
+pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/client dev
 ```
 
 同一ページで:

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "設計ドキュメントを作成してから実装に進む。新機能、API、Bounded Context の追加時に使う。"
+description: "設計ドキュメントを作成してから実装に進む。新機能、API、UI、Bounded Context の追加時に使う。"
 argument-hint: "[機能の説明]"
 disable-model-invocation: true
 allowed-tools: "Bash(date) Read Write Glob Grep Agent WebFetch WebSearch"
@@ -12,11 +12,22 @@ allowed-tools: "Bash(date) Read Write Glob Grep Agent WebFetch WebSearch"
 
 1. ユーザーの要望から「なぜ（Why）」を明確にする。不明なら質問する
 2. 以下のガイドラインを読んでアーキテクチャを確認する:
-   - **`docs/backend-architecture-guide.md`** — 横断的ルール
+
+   **サーバー関連:**
+   - **`docs/backend-architecture-guide.md`** — DDD レイヤー依存、ドメインモデル
    - 関連するコンテキストのガイド（`docs/entry-backend-guide.md` 等）
+
+   **クライアント関連:**
+   - **`docs/client-architecture-guide.md`** — Feature-Sliced 構造、データフェッチング
+   - **`docs/client-testing-guide.md`** — フロントエンドテスト戦略
+
+   **共有・インフラ:**
+   - **`docs/shared-package-guide.md`** — `@oryzae/shared` の使用ルール
+   - **`docs/infra-guide.md`** — Vercel デプロイ（Hono 内蔵 + 単一デプロイ）
+
 3. 必要に応じて `docs/archive/` 配下の過去の設計指示書も参照する
 4. 設計ドキュメントを `docs/tasks/` に作成する
    - ファイル名: `YYYYMMDD_HHMM_{description}.md`（日付は `date` コマンドで取得）
-   - 内容: 目的、影響範囲、ディレクトリ構成、ドメインモデル、API、DB 変更、実装手順
-5. `docs/backend-architecture-guide.md` との整合性を確認する
+   - 内容: 目的、影響範囲、ディレクトリ構成、ドメインモデル/コンポーネント設計、API、DB 変更、実装手順
+5. ガイドラインとの整合性を確認する
 6. **ユーザーの承認を得るまで実装に着手しない**

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: "Bash(git,gh,pnpm) Read Glob Grep"
    pnpm lint               # Biome lint
    pnpm test               # テスト
    pnpm knip               # デッドコード検出
-   pnpm dep-cruise         # DDD レイヤー依存チェック
+   pnpm dep-cruise         # アーキテクチャ依存チェック（server DDD + client feature隔離）
    ```
 
 3. **変更内容を確認**

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: "現在の変更に対して設計レビューを行う。PR 作成前やコード変更後に使う。アーキテクチャ違反、レイヤー依存、ドメインモデルパターン、エラーハンドリング、命名規則、テスト有無を検査する。コードレビュー、設計レビュー、品質チェックを求められた時にも使う。"
+description: "現在の変更に対して設計レビューを行う。PR 作成前やコード変更後に使う。アーキテクチャ違反、レイヤー依存、型安全性、テスト有無を検査する。コードレビュー、設計レビュー、品質チェックを求められた時にも使う。"
 disable-model-invocation: true
 allowed-tools: "Bash(git,pnpm) Read Glob Grep Agent"
 ---
@@ -22,41 +22,56 @@ allowed-tools: "Bash(git,pnpm) Read Glob Grep Agent"
 
 変更対象に応じて以下のガイドラインを読み込む:
 
-- `apps/server/` 配下の変更 → **`docs/backend-architecture-guide.md`** を読む
-- `apps/server/src/contexts/entry/` 配下 → 追加で **`docs/entry-backend-guide.md`** を読む
-- `apps/server/src/contexts/question/` 配下 → 追加で **`docs/question-backend-guide.md`** を読む
-- テスト・ガードレール関連 → **`docs/backend-testing-guide.md`** を読む
-- デプロイ・インフラ関連 → **`docs/infra-guide.md`** を読む
+**サーバー（`apps/server/`）:**
+- **`docs/backend-architecture-guide.md`** — レイヤー依存、ドメインモデル、エラーハンドリング
+- **`docs/entry-backend-guide.md`** — Entry コンテキスト
+- **`docs/question-backend-guide.md`** — Question コンテキスト
+- **`docs/backend-testing-guide.md`** — テスト戦略
+
+**クライアント（`apps/client/`）:**
+- **`docs/client-architecture-guide.md`** — Feature-Sliced 構造、データフェッチング、型安全性
+- **`docs/client-testing-guide.md`** — フロントエンドテスト戦略
+
+**共有・インフラ:**
+- **`docs/shared-package-guide.md`** — `@oryzae/shared` の使用ルール
+- **`docs/infra-guide.md`** — Vercel デプロイ
 
 ### 3. レビュー実施
 
-ガイドラインに照らして以下の観点でレビューする:
+#### サーバー（`apps/server/` 配下の変更）
 
 - **A. レイヤー依存**: domain → 他層の依存がないか、application → infrastructure がないか
 - **B. ドメインモデル**: リッチクラスパターン（create/fromProps/withXxx/toProps）に従っているか
 - **C. エラーハンドリング**: domain は Result、application は throw、presentation は errorHandler
 - **D. ゲートウェイ**: IF が class インスタンスを受け渡し、infrastructure が toProps/fromProps で変換
-- **E. ユースケース**: 1 ファイル = 1 ユースケース、コンストラクタ DI、toProps でレスポンス
+- **E. ユースケース**: 1 ファイル = 1 ユースケース、コンストラクタ DI
 - **F. プレゼンテーション**: Zod バリデーション、DI がルートファイル内で完結
-- **G. 命名規則**: ファイル命名規則に従っているか
-- **H. テスト（必須）**: 以下を全て満たしているか確認する
-  - domain/models/ の各ファイルに対応する `.test.ts` が存在するか（**必須**）
-  - domain/services/ の各ファイルに対応する `.test.ts` が存在するか（**必須**）
-  - create() のバリデーション境界値（成功・各エラーパターン）をテストしているか
-  - Result<T,E> の success / error 両方のケースをカバーしているか
-  - withXxx() のイミュータブル性（元インスタンスが変更されないこと）をテストしているか
-  - fromProps → toProps のラウンドトリップをテストしているか
-  - テストファイルがない domain model/service がある場合は **❌ 要修正** として報告する
-- **I. コード品質**: 未使用 export、any 型、console.log
+- **G. テスト（必須）**: domain/models, domain/services の全ファイルにテストが存在するか
+- **H. `@oryzae/shared`**: domain 層から import していないか
+
+#### クライアント（`apps/client/` 配下の変更）
+
+- **I. Feature 隔離**: features/X → features/Y の依存がないか
+- **J. データフェッチング**: API 呼び出しが hooks に集約されているか（コンポーネントから直接呼んでいないか）
+- **K. 型安全性**: `as` キャストがないか（あれば `// @type-assertion-allowed` コメント付きか）、`any` がないか
+- **L. hooks テスト（必須）**: `features/*/hooks/` の新規・変更ファイルに対応テストがあるか
+- **M. インポート**: `lib/` が `features/` や `app/` に依存していないか
+- **N. app/ の責務**: page.tsx や layout.tsx が直接 API を呼んでいないか
+
+#### 共通
+
+- **O. 命名規則**: ファイル命名規則に従っているか
+- **P. コード品質**: 未使用 export、`any` 型、`console.log`
+- **Q. `--no-verify`**: 使用されていないか
 
 ### 4. ツールによる自動検証
 
 ```bash
-pnpm dep-cruise   # レイヤー依存違反
-pnpm knip         # 未使用コード
-pnpm lint         # Biome lint
 pnpm typecheck    # 型チェック
-pnpm test         # テスト
+pnpm lint         # Biome lint
+pnpm test         # テスト（server 85 + client 19）
+pnpm dep-cruise   # レイヤー依存違反 + feature 隔離
+pnpm knip         # 未使用コード
 ```
 
 ### 5. 結果報告
@@ -69,5 +84,5 @@ pnpm test         # テスト
 ### ❌ 要修正 — [ファイル名:行番号] 問題 + 理由 + 修正案
 
 ### 🔧 自動検証結果
-- dep-cruise / knip / lint / typecheck / test: ✅ or ❌
+- typecheck / lint / test / dep-cruise / knip: ✅ or ❌
 ```


### PR DESCRIPTION
## 概要

全スキルがサーバーのみを前提にしていたのを、フロントエンド（Feature-Sliced Architecture）にも対応するよう更新。また、`git push` 前に自動コードレビューが走るフックを追加。

## 変更内容

### スキル更新

| スキル | 修正内容 |
|---|---|
| `review/SKILL.md` | クライアントのレビュー観点を追加（feature 隔離、as 禁止、hooks テスト、app 責務分離） |
| `plan/SKILL.md` | クライアント・共有・インフラのガイドライン参照を追加 |
| `pr/SKILL.md` | dep-cruise コメントを修正（server + client 両方） |
| `auto-qa/SKILL.md` | ローカル開発説明を単一デプロイ構成に修正 |
| `auto-qa/strategy-snapshot-comparison.md` | 起動コマンドを修正 |

### 新規: pre-push レビューフック

`.claude/settings.json` に `PreToolUse` agent hook を追加。`git push` 実行時に自動でコードレビューが走り、ルール違反・バグ・不要ファイルを検出する。

## Test plan
- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — エラーなし
- [ ] `git push` 時にレビューフックが発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)