### PR TITLE
feat: sidebar border-click toggle

### DIFF
--- a/apps/client/src/app/(protected)/layout.tsx
+++ b/apps/client/src/app/(protected)/layout.tsx
@@ -11,47 +11,16 @@ import {
   useSidebar,
 } from '@/lib/sidebar-context';
 
-function SidebarTrigger() {
-  const { toggle } = useSidebar();
-  return (
-    <button
-      type="button"
-      onClick={toggle}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-      title="サイドバーを切替 (⌘B)"
-    >
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="h-4 w-4"
-      >
-        <rect x="3" y="3" width="18" height="18" rx="2" />
-        <path d="M9 3v18" />
-      </svg>
-    </button>
-  );
-}
-
 function ProtectedContent({ children }: { children: React.ReactNode }) {
   const { expanded } = useSidebar();
   const sidebarWidth = expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH;
 
   return (
     <main
-      className="flex flex-1 flex-col overflow-auto transition-[margin-left] duration-200 ease-linear"
-      // @type-assertion-allowed: CSS custom properties require CSSProperties cast
+      className="flex-1 overflow-auto transition-[margin-left] duration-200 ease-linear"
       style={{ '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
     >
-      {/* Top bar with sidebar trigger */}
-      <div className="flex items-center px-4 py-2">
-        <SidebarTrigger />
-      </div>
-      <div className="mx-auto w-full max-w-4xl flex-1 px-4 pb-6">{children}</div>
+      <div className="mx-auto w-full max-w-4xl px-4 py-6">{children}</div>
     </main>
   );
 }

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -39,7 +39,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const { logout } = useAuth();
-  const { expanded } = useSidebar();
+  const { expanded, toggle } = useSidebar();
 
   function handleLogout() {
     logout();
@@ -49,106 +49,133 @@ export function Sidebar() {
   const width = expanded ? EXPANDED_WIDTH : COLLAPSED_WIDTH;
 
   return (
-    <nav
-      data-state={expanded ? 'expanded' : 'collapsed'}
-      className="group flex h-full shrink-0 flex-col border-r border-[var(--border-subtle)] bg-[var(--bg)] py-4 transition-[width] duration-200 ease-linear"
-      style={{ width }}
-    >
-      {/* Logo */}
-      <div className="mb-4 flex items-center justify-center">
-        {expanded ? (
-          <span
-            className="text-xs font-semibold tracking-[0.2em] text-[var(--accent)]"
-            style={{ fontFamily: 'Inter, sans-serif' }}
-          >
-            ORYZAE
-          </span>
-        ) : (
-          <span
-            className="text-[9px] font-semibold tracking-[0.15em] text-[var(--accent)]"
-            style={{
-              writingMode: 'vertical-rl',
-              textOrientation: 'mixed',
-              fontFamily: 'Inter, sans-serif',
-            }}
-          >
-            ORYZAE
-          </span>
-        )}
-      </div>
-
-      {/* Nav items */}
-      <div className="flex flex-col gap-1 px-2">
-        {NAV_ITEMS.map((item) => {
-          const isActive =
-            item.match === '/entries' ? pathname === '/entries' : pathname.startsWith(item.match);
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              title={item.label}
-              className={`flex items-center gap-3 rounded-lg px-2.5 py-2 transition-all ${
-                isActive
-                  ? 'bg-[var(--accent-light)] text-[var(--accent)]'
-                  : 'text-[var(--date-color)] hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]'
-              }`}
+    <div className="relative flex h-full shrink-0" style={{ width }}>
+      <nav
+        data-state={expanded ? 'expanded' : 'collapsed'}
+        className="flex h-full w-full flex-col bg-[var(--bg)] py-4 transition-[width] duration-200 ease-linear"
+      >
+        {/* Logo */}
+        <div className="mb-4 flex items-center justify-center">
+          {expanded ? (
+            <span
+              className="text-xs font-semibold tracking-[0.2em] text-[var(--accent)]"
+              style={{ fontFamily: 'Inter, sans-serif' }}
             >
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-[18px] w-[18px] shrink-0"
+              ORYZAE
+            </span>
+          ) : (
+            <span
+              className="text-[9px] font-semibold tracking-[0.15em] text-[var(--accent)]"
+              style={{
+                writingMode: 'vertical-rl',
+                textOrientation: 'mixed',
+                fontFamily: 'Inter, sans-serif',
+              }}
+            >
+              ORYZAE
+            </span>
+          )}
+        </div>
+
+        {/* Nav items */}
+        <div className="flex flex-col gap-1 px-2">
+          {NAV_ITEMS.map((item) => {
+            const isActive =
+              item.match === '/entries' ? pathname === '/entries' : pathname.startsWith(item.match);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                title={item.label}
+                className={`flex items-center gap-3 rounded-lg px-2.5 py-2 transition-all ${
+                  isActive
+                    ? 'bg-[var(--accent-light)] text-[var(--accent)]'
+                    : 'text-[var(--date-color)] hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]'
+                }`}
               >
-                <path d={item.iconPath} />
-              </svg>
-              {expanded && (
-                <span
-                  className="truncate text-[11px] font-medium uppercase tracking-[0.08em]"
-                  style={{ fontFamily: 'Inter, sans-serif' }}
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-[18px] w-[18px] shrink-0"
                 >
-                  {item.label}
-                </span>
-              )}
-            </Link>
-          );
-        })}
-      </div>
+                  <path d={item.iconPath} />
+                </svg>
+                {expanded && (
+                  <span
+                    className="truncate text-[11px] font-medium uppercase tracking-[0.08em]"
+                    style={{ fontFamily: 'Inter, sans-serif' }}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
 
-      {/* Spacer */}
-      <div className="flex-1" />
+        {/* Spacer */}
+        <div className="flex-1" />
 
-      {/* Logout */}
+        {/* Logout */}
+        <button
+          type="button"
+          onClick={handleLogout}
+          title="ログアウト"
+          className={`flex items-center gap-3 self-center rounded-full px-2.5 py-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--accent)] ${expanded ? 'mx-2 self-stretch rounded-lg' : ''}`}
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-[18px] w-[18px] shrink-0"
+          >
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
+          </svg>
+          {expanded && (
+            <span
+              className="text-[11px] font-medium uppercase tracking-[0.08em]"
+              style={{ fontFamily: 'Inter, sans-serif' }}
+            >
+              ログアウト
+            </span>
+          )}
+        </button>
+      </nav>
+
+      {/* Border handle — click to toggle, hover shows chevron cursor */}
       <button
         type="button"
-        onClick={handleLogout}
-        title="ログアウト"
-        className={`flex items-center gap-3 self-center rounded-full px-2.5 py-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--accent)] ${expanded ? 'mx-2 self-stretch rounded-lg' : ''}`}
+        onClick={toggle}
+        aria-label={expanded ? 'サイドバーを閉じる' : 'サイドバーを開く'}
+        className="group/handle absolute top-0 right-0 z-10 flex h-full w-2 translate-x-1/2 cursor-col-resize items-center justify-center"
       >
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-[18px] w-[18px] shrink-0"
-        >
-          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
-        </svg>
-        {expanded && (
-          <span
-            className="text-[11px] font-medium uppercase tracking-[0.08em]"
-            style={{ fontFamily: 'Inter, sans-serif' }}
+        {/* Visible border line */}
+        <div className="h-full w-px bg-[var(--border-subtle)] transition-colors group-hover/handle:bg-[var(--accent)]" />
+        {/* Chevron indicator on hover */}
+        <div className="absolute flex h-6 w-4 items-center justify-center rounded-full bg-[var(--bg)] opacity-0 shadow-sm transition-opacity group-hover/handle:opacity-100">
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--accent)"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={`h-3 w-3 ${expanded ? 'rotate-180' : ''}`}
           >
-            ログアウト
-          </span>
-        )}
+            <path d="M9 18l6-6-6-6" />
+          </svg>
+        </div>
       </button>
-    </nav>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Click sidebar border to toggle open/close
- Hover: border turns accent color + chevron indicator appears
- Remove panel icon from content header
- Cleaner, more intuitive interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)