### PR TITLE
feat: CSS tooltips on editor toolbar icons

### DIFF
--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -32,3 +32,43 @@ body {
   background: rgba(74, 158, 142, 0.2);
   color: inherit;
 }
+
+/* Tooltip for buttons with data-tooltip attribute */
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--fg);
+  color: var(--bg);
+  font-family: "Inter", "Noto Sans JP", sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 100;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+}
+
+/* Bottom toolbar tooltips should appear above */
+[data-tooltip-pos="top"]::after {
+  bottom: calc(100% + 6px);
+  top: auto;
+}
+
+[data-tooltip-pos="bottom"]::after {
+  top: calc(100% + 6px);
+  bottom: auto;
+}

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -174,7 +174,7 @@ export function EntryEditor({
             type="button"
             onClick={() => setSettingsOpen(!settingsOpen)}
             className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-            title="設定"
+            data-tooltip="設定"
           >
             <svg
               aria-hidden="true"
@@ -200,7 +200,7 @@ export function EntryEditor({
             type="button"
             onClick={toggleFullscreen}
             className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-            title="フルスクリーン"
+            data-tooltip="フルスクリーン"
           >
             <svg
               aria-hidden="true"
@@ -225,7 +225,7 @@ export function EntryEditor({
           type="button"
           onClick={() => router.push('/entries')}
           className="rounded-md p-1.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-          title="一覧に戻る"
+          data-tooltip="一覧に戻る"
         >
           <svg
             aria-hidden="true"
@@ -298,7 +298,7 @@ export function EntryEditor({
             type="button"
             onClick={() => router.push('/entries/new')}
             className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-            title="新規エントリ"
+            data-tooltip="新規エントリ"
           >
             <svg
               aria-hidden="true"
@@ -320,7 +320,7 @@ export function EntryEditor({
             onClick={handleSave}
             disabled={saving || !content.trim()}
             className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)] disabled:opacity-30"
-            title="保存"
+            data-tooltip="保存"
           >
             <svg
               aria-hidden="true"
@@ -341,7 +341,7 @@ export function EntryEditor({
             type="button"
             onClick={() => router.push('/entries')}
             className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-            title="一覧"
+            data-tooltip="一覧"
           >
             <svg
               aria-hidden="true"
@@ -365,7 +365,7 @@ export function EntryEditor({
           type="button"
           disabled
           className="rounded-md p-1.5 text-[var(--date-color)] opacity-40"
-          title="音声入力"
+          data-tooltip="音声入力"
         >
           <svg
             aria-hidden="true"
@@ -383,7 +383,7 @@ export function EntryEditor({
         <button
           type="button"
           className="rounded-md p-1.5 text-[var(--date-color)] transition-all hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]"
-          title="執筆統計"
+          data-tooltip="執筆統計"
         >
           <svg
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- Instant hover tooltips on all editor toolbar buttons
- CSS-only implementation via data-tooltip attribute + ::after pseudo-element
- Dark fg on light bg tooltip with smooth 150ms fade
- Replaces native title attribute (slow browser tooltip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)