### PR TITLE
feat: Playwright E2E テスト + 週次 GitHub Actions

### DIFF
--- a/.claude/rules/client-architecture.md
+++ b/.claude/rules/client-architecture.md
@@ -33,7 +33,15 @@ paths:
 
 ## テスト（絶対ルール）
 
+### hooks テスト（vitest）
 - `src/features/*/hooks/` にファイルを作成・変更したら、対応するテストを `test/features/*/hooks/` に**同時に**作成すること
 - テストファイルの命名: `use-auth.ts` → `test/features/auth/hooks/use-auth.test.ts`
 - モックは `vi.fn()` の手動スタブ（モックライブラリ不使用）
+
+### E2E テスト（Playwright）
+- 新しいページや主要な機能を追加したら、対応する E2E テストを `e2e/` に追加すること
+- テストは features と1:1対応: `e2e/auth.spec.ts`, `e2e/entries.spec.ts`, `e2e/questions.spec.ts`
+- ログイン済み状態が必要なテストは `e2e/fixtures/auth.ts` のフィクスチャを使う
+
+### 共通
 - **テストなしで作業を完了してはならない**

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # 毎週月曜 UTC 0:00 (JST 9:00)
+  workflow_dispatch:        # 手動実行も可能
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @oryzae/client exec playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: pnpm --filter @oryzae/client exec playwright test
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/client/test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 .mcp.json
 .next/
 .playwright-mcp/
+test-results/
+playwright-report/
 *.png
 .DS_Store
 docs/reference-ui/

--- a/apps/client/e2e/auth.spec.ts
+++ b/apps/client/e2e/auth.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? 'yukiagatsuma@gmail.com';
+const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'Test123456';
+
+test.describe('認証フロー', () => {
+  test('ログインして /entries にリダイレクト', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.locator('h1')).toHaveText('Oryzae');
+    await expect(page.locator('text=ログインして続ける')).toBeVisible();
+
+    await page.fill('input[type="email"]', TEST_EMAIL);
+    await page.fill('input[type="password"]', TEST_PASSWORD);
+    await page.click('button:has-text("ログイン")');
+
+    await page.waitForURL('**/entries**');
+    await expect(page).toHaveURL(/\/entries/);
+  });
+
+  test('未認証で /entries にアクセスすると /login にリダイレクト', async ({ page }) => {
+    await page.goto('/entries');
+    await page.waitForURL('**/login**');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('サインアップページが表示される', async ({ page }) => {
+    await page.goto('/signup');
+    await expect(page.locator('h1')).toHaveText('Oryzae');
+    await expect(page.locator('text=アカウントを作成')).toBeVisible();
+    await expect(page.locator('text=ログイン')).toBeVisible();
+  });
+
+  test('ログインとサインアップ間のリンク遷移', async ({ page }) => {
+    await page.goto('/login');
+    await page.click('a:has-text("サインアップ")');
+    await expect(page).toHaveURL(/\/signup/);
+
+    await page.click('a:has-text("ログイン")');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/apps/client/e2e/entries.spec.ts
+++ b/apps/client/e2e/entries.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from './fixtures/auth';
+
+test.describe('エントリ管理', () => {
+  test.beforeEach(async ({ authenticated }) => {
+    // ログイン済み状態
+  });
+
+  test('エントリ一覧が表示される', async ({ page }) => {
+    await expect(page.locator('text=エントリ')).toBeVisible();
+  });
+
+  test('新規エントリを作成できる', async ({ page }) => {
+    await page.click('a:has-text("新規"), button:has-text("新規"), a[href="/entries/new"]');
+    await page.waitForURL('**/entries/new**');
+
+    const editor = page.locator('textarea, [contenteditable="true"]');
+    await expect(editor).toBeVisible();
+
+    await editor.fill('Playwright E2E テスト用エントリ');
+    await page.click('button:has-text("保存"), button:has-text("作成")');
+
+    await page.waitForURL(/\/entries/);
+  });
+
+  test('エントリ一覧から詳細に遷移できる', async ({ page }) => {
+    const firstEntry = page.locator('[href*="/entries/"]').first();
+    if (await firstEntry.isVisible()) {
+      await firstEntry.click();
+      await page.waitForURL(/\/entries\/.+/);
+      await expect(page.locator('textarea, [contenteditable="true"]')).toBeVisible();
+    }
+  });
+});

--- a/apps/client/e2e/fixtures/auth.ts
+++ b/apps/client/e2e/fixtures/auth.ts
@@ -1,0 +1,21 @@
+import { test as base, expect } from '@playwright/test';
+
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? 'yukiagatsuma@gmail.com';
+const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'Test123456';
+
+// biome-ignore lint/suspicious/noConfusingVoidType: Playwright fixture type requires void for auto fixtures
+export const test = base.extend<{ authenticated: void }>({
+  authenticated: [
+    async ({ page }, use) => {
+      await page.goto('/login');
+      await page.fill('input[type="email"]', TEST_EMAIL);
+      await page.fill('input[type="password"]', TEST_PASSWORD);
+      await page.click('button:has-text("ログイン")');
+      await page.waitForURL('**/entries**');
+      await use();
+    },
+    { auto: false },
+  ],
+});
+
+export { expect };

--- a/apps/client/e2e/navigation.spec.ts
+++ b/apps/client/e2e/navigation.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from './fixtures/auth';
+
+test.describe('ナビゲーション', () => {
+  test.beforeEach(async ({ authenticated }) => {
+    // ログイン済み状態
+  });
+
+  test('サイドバーからエントリ一覧に遷移', async ({ page }) => {
+    await page.goto('/questions');
+    await page.click('a[href="/entries"]');
+    await expect(page).toHaveURL(/\/entries/);
+  });
+
+  test('サイドバーから質問ページに遷移', async ({ page }) => {
+    await page.click('a[href="/questions"]');
+    await expect(page).toHaveURL(/\/questions/);
+  });
+
+  test('サイドバーからエディタに遷移', async ({ page }) => {
+    await page.click('a[href="/entries/new"]');
+    await expect(page).toHaveURL(/\/entries\/new/);
+  });
+});

--- a/apps/client/e2e/questions.spec.ts
+++ b/apps/client/e2e/questions.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from './fixtures/auth';
+
+test.describe('質問管理', () => {
+  test.beforeEach(async ({ authenticated }) => {
+    // ログイン済み状態
+  });
+
+  test('質問ページに遷移できる', async ({ page }) => {
+    await page.goto('/questions');
+    await page.waitForURL('**/questions**');
+    await expect(page.locator('text=質問')).toBeVisible();
+  });
+
+  test('新しい質問を作成できる', async ({ page }) => {
+    await page.goto('/questions');
+
+    const input = page.locator('input[placeholder*="質問"]');
+    if (await input.isVisible()) {
+      const testQuestion = `E2E テスト質問 ${Date.now()}`;
+      await input.fill(testQuestion);
+      await page.click('button:has-text("追加")');
+
+      await expect(page.locator(`text=${testQuestion}`)).toBeVisible({ timeout: 5000 });
+    }
+  });
+});

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,7 +9,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run test/",
     "test:watch": "vitest",
-    "dep-cruise": "depcruise src --config .dependency-cruiser.cjs"
+    "dep-cruise": "depcruise src --config .dependency-cruiser.cjs",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@oryzae/server": "workspace:*",
@@ -18,6 +20,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/react": "^16.0.0",

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command:
+      'pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/client dev',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    cwd: '../..',
+    timeout: 120000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: link:../server
       next:
         specifier: 16.2.2
-        version: 16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.2(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -36,6 +36,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -834,6 +837,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -1370,6 +1378,11 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1688,6 +1701,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2561,6 +2584,10 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -3067,6 +3094,9 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3313,7 +3343,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.2(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.2
       '@swc/helpers': 0.5.15
@@ -3332,6 +3362,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.2
       '@next/swc-win32-arm64-msvc': 16.2.2
       '@next/swc-win32-x64-msvc': 16.2.2
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3414,6 +3445,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## 概要

Playwright による E2E テストを追加し、GitHub Actions で毎週月曜 JST 9:00 に自動実行する。

## テスト構造

```
e2e/
├── fixtures/auth.ts    — ログイン済みフィクスチャ（全テスト共有）
├── auth.spec.ts        — 認証フロー (4 tests)
├── entries.spec.ts     — エントリ CRUD (3 tests)
├── questions.spec.ts   — 質問管理 (2 tests)
└── navigation.spec.ts  — サイドバーナビ (3 tests)
```

### テスト自動増殖の仕組み

テストは features/ と1:1で対応。新機能を追加する際:
1. features/X/ にコンポーネント・hooks を実装
2. e2e/X.spec.ts にテストを追加
3. CI が自動的に新テストを検出・実行

`.claude/rules/client-architecture.md` に E2E テスト必須ルールを追記済み。

## GitHub Actions

- **スケジュール**: 毎週月曜 UTC 0:00 (JST 9:00)
- **手動実行**: workflow_dispatch で随時可能
- **失敗時**: スクリーンショットを artifacts に7日間保存

## セットアップ

GitHub Secrets に以下を設定:
- `SUPABASE_URL` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY`
- `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD`

## ローカル実行

```bash
pnpm --filter @oryzae/client test:e2e      # ヘッドレス実行
pnpm --filter @oryzae/client test:e2e:ui   # UI モードで実行
```

## /auto-qa との役割分担

| | Playwright (CI) | /auto-qa (手動) |
|---|---|---|
| 実行 | 毎週自動 | PR 時にオンデマンド |
| テストケース | 固定 (.spec.ts) | 動的導出（PR diff から） |
| 得意 | リグレッション検出 | 探索的テスト |

🤖 Generated with [Claude Code](https://claude.com/claude-code)