### PR TITLE
chore: docs/reference-ui/ を git 管理に追加

### DIFF
--- a/docs/reference-ui/index_board_jar.html
+++ b/docs/reference-ui/index_board_jar.html
@@ -1,0 +1,6107 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Oryzae</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&family=Noto+Sans+JP:wght@200..900&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="oryzae-data.js"></script>
+  <style>
+    /* ===== Theme Variables ===== */
+    :root {
+      --bg: #F9F8F4;
+      --text: #2D2D2D;
+      --ui-text: #2D2D2D;
+      --accent: #4a9e8e;
+      --accent-light: rgba(74,158,142,0.1);
+      --toolbar-hover-bg: rgba(0,0,0,0.05);
+      --toolbar-border: rgba(0,0,0,0.1);
+      --dialog-bg: #ffffff;
+      --dialog-shadow: rgba(0,0,0,0.12);
+      --drawer-bg: #F5F4F0;
+      --drawer-border: rgba(0,0,0,0.08);
+      --input-bg: #ffffff;
+      --input-border: rgba(0,0,0,0.12);
+      --item-hover: rgba(0,0,0,0.03);
+      --item-border: rgba(0,0,0,0.06);
+      --date-color: #999;
+      --placeholder-color: #ccc;
+      --trace-color: 130,130,130;
+      --mic-active: #e53935;
+      --ghost-color: rgba(0,0,0,0.22);
+      --border-subtle: rgba(0,0,0,0.05);
+      --card-snippet: #FFFBE0;
+      --card-snippet-alt: #FFFDF2;
+      --card-photo: #ffffff;
+      --card-entry: #ffffff;
+      --sidebar-bg: #F9F8F4;
+      --header-bg: rgba(249,248,244,0.9);
+      --footer-bg: #F9F8F4;
+    }
+    body.dark {
+      --bg: #1a1a1a;
+      --text: #cccccc;
+      --ui-text: #cccccc;
+      --accent: #5ab8a6;
+      --accent-light: rgba(90,184,166,0.12);
+      --toolbar-hover-bg: #333;
+      --toolbar-border: #555;
+      --dialog-bg: #2a2a2a;
+      --dialog-shadow: rgba(0,0,0,0.4);
+      --drawer-bg: #222;
+      --drawer-border: #444;
+      --input-bg: #333;
+      --input-border: #555;
+      --item-hover: #333;
+      --item-border: #3a3a3a;
+      --date-color: #666;
+      --placeholder-color: #555;
+      --trace-color: 100,100,100;
+      --mic-active: #ef5350;
+      --ghost-color: rgba(255,255,255,0.18);
+      --border-subtle: rgba(255,255,255,0.06);
+      --card-snippet: #3a3520;
+      --card-snippet-alt: #3a3825;
+      --card-photo: #2a2a2a;
+      --card-entry: #2a2a2a;
+      --sidebar-bg: #1a1a1a;
+      --header-bg: rgba(26,26,26,0.9);
+      --footer-bg: #1a1a1a;
+    }
+
+    /* ===== Reset & Base ===== */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; overflow: hidden; background: var(--bg); color: var(--text); transition: background 0.3s, color 0.3s; }
+    body { font-family: 'Noto Serif JP', serif; display: flex; }
+    .font-ui { font-family: 'Inter', 'Noto Sans JP', sans-serif; letter-spacing: 0.15em; }
+    .no-scrollbar::-webkit-scrollbar { width: 0; background: transparent; }
+    ::selection { background: rgba(74,158,142,0.2); color: inherit; }
+
+    /* ===== Sidebar ===== */
+    #app-sidebar {
+      width: 56px; height: 100%; flex-shrink: 0;
+      border-right: 1px solid var(--border-subtle);
+      display: flex; flex-direction: column; align-items: center;
+      padding: 16px 0; gap: 6px; background: var(--sidebar-bg);
+      z-index: 20;
+    }
+    .sidebar-logo {
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 600;
+      color: var(--accent); letter-spacing: 0.15em; margin-bottom: 16px;
+      writing-mode: vertical-rl; text-orientation: mixed;
+    }
+    .sidebar-btn {
+      width: 36px; height: 36px; border-radius: 8px; border: none; background: none;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      color: var(--date-color); transition: all 0.15s; position: relative;
+    }
+    .sidebar-btn:hover { background: var(--toolbar-hover-bg); color: var(--text); }
+    .sidebar-btn.active { background: var(--accent-light); color: var(--accent); }
+    .sidebar-btn svg { width: 18px; height: 18px; }
+    .sidebar-btn .sidebar-label {
+      position: absolute; left: 48px; top: 50%; transform: translateY(-50%);
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 500;
+      color: var(--date-color); letter-spacing: 0.12em; text-transform: uppercase;
+      white-space: nowrap; opacity: 0; pointer-events: none;
+      transition: opacity 0.15s;
+    }
+    .sidebar-btn:hover .sidebar-label { opacity: 1; }
+    .sidebar-spacer { flex: 1; }
+
+    /* ===== Dark mode button (standalone) ===== */
+    #btn-darkmode {
+      width: 32px; height: 32px; border-radius: 50%; border: none; background: none;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      color: var(--date-color); transition: background 0.15s, color 0.15s;
+    }
+    #btn-darkmode:hover { background: var(--toolbar-hover-bg); color: var(--accent); }
+
+    /* ===== Footer ===== */
+    #app-footer {
+      height: 36px; flex-shrink: 0;
+      border-top: 1px solid var(--border-subtle);
+      background: var(--footer-bg);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 24px; z-index: 30;
+    }
+    .footer-left, .footer-right { display: flex; align-items: center; gap: 24px; }
+    .footer-item {
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 400;
+      color: var(--date-color); letter-spacing: 0.2em; text-transform: uppercase;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .footer-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--date-color); opacity: 0.3; }
+    .footer-dot.saved { background: var(--accent); opacity: 0.8; }
+    .footer-progress {
+      width: 64px; height: 2px; background: rgba(0,0,0,0.06); border-radius: 1px; overflow: hidden;
+    }
+    .footer-progress-bar { height: 100%; background: var(--accent); width: 0; transition: width 0.3s; }
+
+    /* ===== Content Area ===== */
+    #content-area { position: relative; flex: 1; overflow: hidden; }
+    .view-container { position: absolute; inset: 0; display: none; }
+    .view-container.active { display: flex; flex-direction: column; }
+
+    /* ===== Editor→Jar Transition Overlay ===== */
+    #save-transition-overlay {
+      position: fixed; inset: 0; z-index: 9999;
+      pointer-events: none; overflow: hidden;
+      display: none;
+    }
+    #save-transition-overlay.active { display: block; }
+
+    /* Character movers — each wraps one character */
+    .st-char {
+      position: fixed;
+      display: inline-block;
+      font-family: inherit;
+      will-change: transform, opacity;
+      transition: transform 1.5s cubic-bezier(0.4, 0, 0.2, 1), opacity 1s, color 1.5s;
+      pointer-events: none;
+      z-index: 10000;
+    }
+
+    /* Phase 1: Scatter outward from center */
+    #save-transition-overlay.phase-scatter .st-char {
+      transform: translate(var(--tx), var(--ty)) rotate(var(--r));
+      opacity: 0.4;
+      color: #b45309;
+    }
+
+    /* Phase 2: Condense into small circle inside jar */
+    #save-transition-overlay.phase-condense .st-char {
+      transform: translate(var(--cx), var(--cy)) scale(0.25) rotate(var(--cr));
+      opacity: 0.95;
+      color: #5d2e0f;
+      transition-duration: 1.5s;
+      transition-timing-function: cubic-bezier(0.6, 0, 0.4, 1);
+      filter: blur(0.3px);
+    }
+
+    /* Phase 3: Float gently from condensed positions */
+    #save-transition-overlay.phase-float .st-char {
+      transform: translate(var(--fx), var(--fy)) rotate(var(--fr)) scale(0.25);
+      opacity: 0.6;
+      transition-duration: 2s;
+      transition-timing-function: ease-out;
+    }
+
+    /* Chars that fade out (70%) */
+    .st-char.st-hidden {
+      opacity: 0 !important;
+      transform: scale(0) !important;
+      transition: opacity 0.8s ease, transform 0.8s ease !important;
+    }
+
+    /* Gentle float animation for remaining chars */
+    @keyframes st-gentle-float {
+      0%   { transform: translate(0, 0) rotate(0deg); }
+      33%  { transform: translate(8px, -12px) rotate(5deg); }
+      66%  { transform: translate(-5px, -18px) rotate(-3deg); }
+      100% { transform: translate(0, 0) rotate(0deg); }
+    }
+    .st-char-inner {
+      display: inline-block;
+      will-change: transform;
+    }
+    .st-float-anim .st-char-inner {
+      animation: st-gentle-float var(--fdur) infinite alternate ease-in-out;
+      animation-delay: var(--fdel);
+    }
+
+    /* ===== Board View ===== */
+    #view-board .grid-bg {
+      position: absolute; inset: 0;
+      background-size: 40px 40px;
+      background-image:
+        linear-gradient(to right, rgba(0,0,0,0.03) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(0,0,0,0.03) 1px, transparent 1px);
+      pointer-events: none; z-index: 0; opacity: 0.6;
+    }
+    #board-canvas { width: 100%; height: 100%; position: relative; overflow: hidden; cursor: default; z-index: 1; }
+    .board-controls {
+      position: absolute; top: 12px; right: 12px; z-index: 50;
+      display: flex; gap: 8px; align-items: center;
+    }
+    .board-ctrl-btn {
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 500;
+      letter-spacing: 0.15em; text-transform: uppercase;
+      padding: 6px 14px; border-radius: 20px;
+      border: 1px solid var(--border-subtle); background: var(--bg);
+      color: var(--date-color); cursor: pointer; transition: all 0.15s;
+    }
+    .board-ctrl-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .board-ctrl-btn.active { background: var(--accent); color: white; border-color: var(--accent); }
+    .board-ctrl-btn svg { width: 14px; height: 14px; vertical-align: -2px; margin-right: 4px; }
+    .board-date-display {
+      position: absolute; top: 12px; left: 12px; z-index: 50;
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500;
+      color: var(--date-color); letter-spacing: 0.15em; text-transform: uppercase;
+    }
+    .board-date-nav {
+      display: flex; align-items: center; gap: 8px;
+    }
+    .board-date-nav button {
+      background: none; border: none; cursor: pointer; color: var(--date-color);
+      font-size: 14px; padding: 4px; transition: color 0.15s;
+    }
+    .board-date-nav button:hover { color: var(--accent); }
+
+    /* ===== Board Items ===== */
+    .board-item {
+      position: absolute; cursor: grab;
+      transition: box-shadow 0.2s ease, transform 0.1s linear;
+      touch-action: none; user-select: none;
+    }
+    .board-item:active { cursor: grabbing; }
+    .board-item.is-dragging {
+      box-shadow: 0 20px 40px rgba(0,0,0,0.15) !important;
+      z-index: 1000 !important; cursor: grabbing;
+    }
+    .board-item.is-selected {
+      outline: 1.5px solid rgba(74,158,142,0.5);
+      outline-offset: 4px; z-index: 900;
+    }
+    .paper-shadow { box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -1px rgba(0,0,0,0.03); }
+    .polaroid-shadow { box-shadow: 0 10px 15px -3px rgba(0,0,0,0.08), 0 4px 6px -2px rgba(0,0,0,0.04); }
+
+    .rotate-handle {
+      position: absolute; bottom: -32px; left: 50%; transform: translateX(-50%);
+      width: 24px; height: 24px; background: white;
+      border: 1.5px solid rgba(74,158,142,0.6); border-radius: 50%;
+      cursor: crosshair; display: flex; align-items: center; justify-content: center;
+      opacity: 0; transition: opacity 0.15s; z-index: 10; color: #4a9e8e;
+    }
+    .board-item.is-selected .rotate-handle { opacity: 1; }
+    .resize-handle {
+      position: absolute; width: 10px; height: 10px;
+      background: white; border: 1.5px solid rgba(74,158,142,0.6);
+      border-radius: 2px; opacity: 0; transition: opacity 0.15s; z-index: 10;
+    }
+    .resize-handle.se { bottom: -6px; right: -6px; cursor: se-resize; }
+    .resize-handle.sw { bottom: -6px; left: -6px; cursor: sw-resize; }
+    .resize-handle.ne { top: -6px; right: -6px; cursor: ne-resize; }
+    .resize-handle.nw { top: -6px; left: -6px; cursor: nw-resize; }
+    .board-item.is-selected .resize-handle { opacity: 1; }
+    .delete-btn {
+      position: absolute; top: -12px; right: -12px;
+      width: 22px; height: 22px; background: white;
+      border: 1.5px solid rgba(200,80,80,0.5); border-radius: 50%;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      opacity: 0; transition: opacity 0.15s, background 0.15s, border-color 0.15s; z-index: 10;
+    }
+    .delete-btn:hover { background: #e05555; border-color: #e05555; }
+    .delete-btn:hover svg { stroke: white; }
+    .board-item.is-selected .delete-btn { opacity: 1; }
+
+    /* Card type styles */
+    .card-snippet { background: var(--card-snippet); padding: 24px; border-radius: 2px; }
+    .card-snippet .snippet-badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-family: 'Inter', sans-serif; font-size: 9px; color: var(--accent);
+      border: 1px solid rgba(74,158,142,0.3); padding: 2px 6px; border-radius: 4px;
+      letter-spacing: 0.15em; text-transform: uppercase; background: rgba(255,255,255,0.5);
+    }
+    .card-snippet .snippet-text { font-size: 14px; line-height: 1.8; color: var(--text); margin-top: 12px; }
+    .card-entry { background: var(--card-entry); padding: 24px; overflow: hidden; border-radius: 2px; position: relative; }
+    .card-entry .entry-header {
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid var(--item-border);
+    }
+    .card-entry .entry-header-date {
+      font-family: 'Inter', sans-serif; font-size: 9px; color: var(--date-color);
+      letter-spacing: 0.2em; text-transform: uppercase;
+    }
+    .card-entry .entry-header-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent); }
+    .card-entry .entry-title-text { font-size: 14px; font-weight: 500; margin-bottom: 8px; }
+    .card-entry .entry-body-text { font-size: 13px; line-height: 2; color: var(--text); opacity: 0.85; }
+    .card-entry .entry-fade { position: absolute; bottom: 0; left: 0; width: 100%; height: 48px; background: linear-gradient(to top, var(--card-entry), transparent); }
+    .card-photo { background: var(--card-photo); padding: 12px; padding-bottom: 32px; border-radius: 2px; }
+    .card-photo img { width: 100%; aspect-ratio: 1; object-fit: cover; background: var(--item-hover); display: block; }
+    .card-photo .photo-caption {
+      text-align: center; font-size: 12px; color: var(--date-color);
+      font-style: italic; margin-top: 8px;
+    }
+
+    @keyframes popIn {
+      0% { transform: scale(0.8) translateY(20px); opacity: 0; }
+      100% { transform: scale(1) translateY(0); opacity: 1; }
+    }
+    .new-item-anim { animation: popIn 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; }
+    @keyframes itemRemove {
+      0%   { opacity: 1; transform: scale(1) rotate(var(--r, 0deg)); }
+      40%  { opacity: 0.6; transform: scale(1.06) rotate(var(--r, 0deg)); }
+      100% { opacity: 0; transform: scale(0.7) rotate(var(--r, 0deg)); }
+    }
+    .is-removing { animation: itemRemove 0.28s ease forwards; pointer-events: none; }
+
+    /* ===== List View ===== */
+    #view-list { overflow-y: auto; }
+    .list-container { max-width: 680px; margin: 0 auto; padding: 40px 24px 80px; }
+    .list-header {
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: 32px;
+    }
+    .list-header h2 {
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500;
+      color: var(--date-color); letter-spacing: 0.2em; text-transform: uppercase;
+    }
+    .list-new-btn {
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500;
+      letter-spacing: 0.15em; text-transform: uppercase;
+      padding: 8px 20px; border-radius: 20px;
+      border: 1px solid var(--accent); background: none;
+      color: var(--accent); cursor: pointer; transition: all 0.15s;
+    }
+    .list-new-btn:hover { background: var(--accent); color: white; }
+    .list-month-group { margin-bottom: 40px; }
+    .list-month-label {
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500;
+      color: var(--date-color); letter-spacing: 0.2em; text-transform: uppercase;
+      padding-bottom: 12px; border-bottom: 1px solid var(--border-subtle); margin-bottom: 16px;
+    }
+    .list-week-label {
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 400;
+      color: var(--date-color); letter-spacing: 0.15em; text-transform: uppercase;
+      margin: 16px 0 8px; opacity: 0.6;
+    }
+    .list-entry-item {
+      padding: 16px 0; border-bottom: 1px solid var(--item-border);
+      cursor: pointer; transition: background 0.15s;
+    }
+    .list-entry-item:hover { background: var(--item-hover); margin: 0 -12px; padding: 16px 12px; border-radius: 4px; }
+    .list-entry-date {
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 400;
+      color: var(--date-color); letter-spacing: 0.1em; margin-bottom: 4px;
+    }
+    .list-entry-title { font-size: 15px; font-weight: 500; margin-bottom: 6px; }
+    .list-entry-preview {
+      font-size: 13px; color: var(--date-color); line-height: 1.7;
+      display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;
+      overflow: hidden; margin-bottom: 6px;
+    }
+    .list-entry-meta {
+      font-family: 'Inter', sans-serif; font-size: 9px; font-weight: 400;
+      color: var(--date-color); letter-spacing: 0.1em; opacity: 0.5;
+      display: flex; gap: 16px;
+    }
+
+    /* ===== Editor View ===== */
+    /* NOTE: position:absolute + inset:0 is inherited from .view-container; do NOT override with position:relative */
+    #view-editor { overflow: visible; }
+    #view-editor #editor-wrapper { position: absolute; contain: layout style; overflow: hidden; }
+    #view-editor #trace-canvas {
+      position: absolute; top: 0; left: 0;
+      width: 100%; height: 100%;
+      pointer-events: none; z-index: 1;
+    }
+    #view-editor #editor {
+      position: absolute; inset: 0; background: transparent; outline: none;
+      overflow: auto; white-space: pre-wrap; word-break: break-all;
+      writing-mode: vertical-rl; text-orientation: mixed;
+      font-family: inherit; color: var(--text); z-index: 2;
+      -webkit-overflow-scrolling: touch;
+    }
+    #view-editor #editor {
+      caret-color: var(--text);
+    }
+    #view-editor #editor.is-empty::before {
+      content: none;
+    }
+    /* Blinking caret element for empty editor */
+    .editor-fake-caret {
+      display: inline-block;
+      width: 1.2em; height: 2px;
+      background: var(--text);
+      opacity: 0.7;
+      pointer-events: none;
+      animation: editor-caret-blink 1s step-end infinite;
+    }
+    /* Horizontal writing mode: vertical caret bar */
+    .wm-horizontal .editor-fake-caret {
+      width: 2px; height: 1.2em;
+    }
+    @keyframes editor-caret-blink {
+      0%, 100% { opacity: 0.7; }
+      50% { opacity: 0; }
+    }
+    .eblock { display: inline; transition: font-size 0.15s ease-out; }
+    .v-block { display: inline; vertical-align: middle; transition: font-size 0.3s cubic-bezier(0.2,0.8,0.2,1); }
+    .v-interim { display: inline; vertical-align: middle; color: var(--date-color); opacity: 0.8; transition: font-size 0.05s linear; }
+    #ghost-layer { position: fixed; inset: 0; pointer-events: none; z-index: 1; overflow: hidden; }
+    .ghost-el { position: absolute; pointer-events: none; white-space: nowrap; font-family: inherit; opacity: 0; will-change: opacity, transform, filter; }
+    .ghost-block, .ghost-block-composing { font-weight: 300; }
+    .ghost-dust, .ghost-dust-composing { font-weight: 400; }
+    #date-display {
+      position: absolute; z-index: 50; top: 12px; left: 50%; transform: translateX(-50%);
+      color: var(--date-color); writing-mode: horizontal-tb; text-orientation: initial;
+      font-family: 'Inter', 'Noto Sans JP', sans-serif; font-size: 10px; font-weight: 400;
+      letter-spacing: 0.15em; text-transform: uppercase;
+      pointer-events: none; user-select: none; transition: opacity 0.3s;
+      white-space: nowrap; text-align: center;
+    }
+    #editor-title-display {
+      position: absolute; z-index: 50; right: 7.5%; top: 50%; transform: translate(50%, -50%);
+      writing-mode: vertical-rl; text-orientation: mixed;
+      font-family: 'Noto Serif JP', serif; font-weight: 300;
+      color: var(--date-color); opacity: 0.5;
+      letter-spacing: 0.5em; line-height: 1;
+      pointer-events: none; user-select: none;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      max-height: 70%;
+    }
+
+    /* Editor toolbars (positioned within view-editor) */
+    .editor-toolbar-btn {
+      position: absolute; z-index: 100;
+      background: none; border: 1px solid transparent;
+      cursor: pointer; color: var(--ui-text);
+      display: flex; align-items: center; justify-content: center;
+      width: 36px; height: 36px; border-radius: 6px;
+      transition: background 0.15s, border-color 0.15s, color 0.3s;
+      opacity: 0.45;
+    }
+    .editor-toolbar-btn:hover { opacity: 1; background: var(--toolbar-hover-bg); border-color: var(--toolbar-border); }
+    .editor-toolbar-btn.active { opacity: 0.85; }
+    .editor-toolbar-btn.mic-on { color: var(--mic-active); opacity: 1; }
+    .editor-toolbar-btn.mic-on svg { stroke: var(--mic-active); animation: pulse 1.5s infinite; }
+    .editor-toolbar-btn svg { width: 20px; height: 20px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .editor-btn-group { position: absolute; z-index: 100; display: flex; gap: 4px; }
+    .editor-btn-group .editor-toolbar-btn { position: static; }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+    /* Selection toolbar for snippets */
+    #selection-toolbar {
+      position: absolute; z-index: 2000;
+      transform: translate(-50%, -100%);
+      padding-bottom: 12px;
+      opacity: 0; pointer-events: none;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    #selection-toolbar.visible { opacity: 1; pointer-events: auto; }
+    #btn-snippet {
+      display: flex; align-items: center; gap: 8px;
+      background: white; border: 1px solid var(--accent); color: var(--accent);
+      padding: 6px 14px; border-radius: 20px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      cursor: pointer; transition: all 0.15s;
+      font-family: 'Inter', sans-serif; font-size: 10px; font-weight: 500;
+      letter-spacing: 0.15em; text-transform: uppercase;
+    }
+    #btn-snippet:hover { background: var(--accent); color: white; }
+    #snippet-warning {
+      display: none; background: #333; color: white;
+      font-family: 'Inter', sans-serif; font-size: 10px;
+      padding: 4px 8px; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      margin-left: 8px;
+    }
+    #snippet-warning.show { display: block; }
+
+    /* ===== Settings Drawer ===== */
+    #settings-overlay {
+      position: fixed; inset: 0; z-index: 200;
+      background: rgba(0,0,0,0.05); opacity: 0; pointer-events: none;
+      transition: opacity 0.25s;
+    }
+    #settings-overlay.open { opacity: 1; pointer-events: auto; }
+    #settings-drawer {
+      position: fixed; top: 0; left: -340px; z-index: 201;
+      width: 320px; height: 100%; padding: 28px 24px;
+      background: var(--drawer-bg); border-right: 1px solid var(--drawer-border);
+      overflow-y: auto; transition: left 0.25s ease;
+      font-family: 'Noto Sans JP', sans-serif;
+    }
+    #settings-drawer.open { left: 0; }
+    #settings-drawer h2 {
+      font-size: 14px; font-weight: 500; margin-bottom: 24px;
+      font-family: 'Inter', sans-serif; letter-spacing: 0.1em; text-transform: uppercase;
+    }
+    .settings-section { margin-bottom: 20px; }
+    .settings-label { font-size: 12px; color: var(--date-color); margin-bottom: 10px; font-weight: 500; }
+    .settings-toggle {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 0; border-bottom: 1px solid var(--item-border);
+    }
+    .settings-toggle label { font-size: 13px; cursor: pointer; }
+    .settings-toggle input[type="checkbox"] { width: 16px; height: 16px; cursor: pointer; accent-color: var(--accent); }
+    .sub-options {
+      max-height: 0; overflow: hidden; transition: max-height 0.25s ease;
+      padding-left: 12px;
+    }
+    .sub-options.open { max-height: 800px; }
+    .sub-options label { display: block; padding: 6px 0; font-size: 12px; cursor: pointer; color: var(--ui-text); }
+    .sub-options input[type="radio"] { margin-right: 6px; accent-color: var(--accent); }
+    .slider-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; }
+    .slider-row label { font-size: 11px; min-width: 80px; color: var(--date-color); }
+    .slider-row input[type="range"] { flex: 1; accent-color: var(--accent); }
+    .slider-row .slider-val { font-size: 11px; min-width: 48px; text-align: right; color: var(--date-color); font-family: 'Inter', sans-serif; }
+
+    /* ===== Dialogs ===== */
+    .dialog-overlay {
+      position: fixed; inset: 0; z-index: 300;
+      background: rgba(0,0,0,0.25);
+      display: none; align-items: center; justify-content: center;
+    }
+    .dialog-overlay.open { display: flex; }
+    .dialog-box {
+      background: var(--dialog-bg); border-radius: 12px; padding: 28px 32px;
+      box-shadow: 0 8px 32px var(--dialog-shadow);
+      font-family: 'Noto Sans JP', sans-serif; color: var(--ui-text); transition: background 0.3s;
+    }
+    .dialog-box p { font-size: 14px; margin-bottom: 20px; line-height: 1.6; }
+    .dialog-actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .dialog-box button {
+      padding: 8px 18px; border: 1px solid var(--input-border); border-radius: 6px;
+      background: var(--dialog-bg); font-size: 13px; cursor: pointer;
+      font-family: 'Noto Sans JP', sans-serif; color: var(--ui-text); transition: background 0.15s;
+    }
+    .dialog-box button:hover { background: var(--item-hover); }
+    .dialog-box button.primary { background: var(--accent); color: white; border-color: var(--accent); }
+    .dialog-box button.primary:hover { opacity: 0.85; }
+    .dialog-box input[type="text"] {
+      width: 100%; padding: 10px 12px; border: 1px solid var(--input-border);
+      border-radius: 6px; font-size: 14px; font-family: 'Noto Sans JP', sans-serif;
+      background: var(--input-bg); color: var(--ui-text); outline: none; margin-bottom: 16px;
+    }
+    .dialog-box input[type="text"]:focus { border-color: var(--accent); }
+    #open-dialog .dialog-box { max-width: 480px; width: 90%; max-height: 60vh; display: flex; flex-direction: column; }
+    #open-dialog h3 { font-size: 14px; color: var(--date-color); margin-bottom: 16px; font-weight: 400; }
+    #entry-list { overflow-y: auto; flex: 1; }
+    .entry-item { padding: 12px 8px; border-bottom: 1px solid var(--item-border); cursor: pointer; transition: background 0.15s; }
+    .entry-item:hover { background: var(--item-hover); }
+    .entry-item .entry-title { font-size: 14px; font-weight: 500; }
+    .entry-item .entry-preview { font-size: 12px; color: var(--date-color); margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .entry-item .entry-date { font-size: 11px; color: var(--date-color); margin-top: 4px; }
+    .entry-empty { font-size: 13px; color: var(--placeholder-color); padding: 20px 0; text-align: center; }
+    .dialog-close { margin-top: 16px; text-align: right; }
+
+    /* ===== Stats Dialog ===== */
+    #stats-overlay {
+      position: fixed; inset: 0; z-index: 300;
+      background: rgba(0,0,0,0.25);
+      display: none; align-items: center; justify-content: center;
+    }
+    #stats-overlay.open { display: flex; }
+    #stats-dialog {
+      position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);
+      z-index: 301; display: none;
+      background: var(--dialog-bg); border-radius: 12px; padding: 28px 32px;
+      box-shadow: 0 8px 32px var(--dialog-shadow);
+      font-family: 'Noto Sans JP', sans-serif; color: var(--ui-text);
+      max-width: 520px; width: 90%; max-height: 80vh; overflow-y: auto;
+    }
+    #stats-dialog.open { display: block; }
+    .stats-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .stats-card { background: var(--input-bg); border: 1px solid var(--input-border); border-radius: 8px; padding: 14px 16px; }
+    .stats-card-label { font-size: 12px; color: var(--date-color); margin-bottom: 6px; }
+    .stats-card-value { font-size: 22px; font-weight: 600; }
+    .stats-deleted-list { max-height: 200px; overflow-y: auto; }
+    .stats-deleted-item { padding: 8px 10px; border-bottom: 1px solid var(--item-border); font-size: 13px; display: flex; flex-direction: column; gap: 2px; }
+    .stats-deleted-text { font-family: 'Noto Serif JP', serif; word-break: break-all; }
+    .stats-deleted-time { font-size: 11px; color: var(--date-color); }
+    .stats-tabs { display: flex; gap: 0; margin-bottom: 16px; border-bottom: 1px solid var(--input-border); }
+    .stats-tab {
+      padding: 8px 20px; border: none; background: none; cursor: pointer;
+      font-size: 14px; font-family: 'Noto Sans JP', sans-serif; color: var(--date-color);
+      border-bottom: 2px solid transparent; transition: color 0.15s, border-color 0.15s;
+    }
+    .stats-tab:hover { color: var(--ui-text); }
+    .stats-tab.active { color: var(--ui-text); border-bottom-color: var(--accent); font-weight: 500; }
+
+    /* ===== Photo Upload Dialog ===== */
+    #photo-upload-dialog {
+      position: fixed; inset: 0; z-index: 300;
+      background: rgba(0,0,0,0.25);
+      display: none; align-items: center; justify-content: center;
+    }
+    #photo-upload-dialog.open { display: flex; }
+    .photo-upload-box {
+      background: var(--dialog-bg); border-radius: 12px; padding: 28px 32px;
+      box-shadow: 0 8px 32px var(--dialog-shadow);
+      font-family: 'Noto Sans JP', sans-serif; color: var(--ui-text);
+      max-width: 400px; width: 90%; text-align: center;
+    }
+    .photo-upload-box h3 { font-size: 14px; margin-bottom: 16px; font-weight: 500; }
+    .photo-preview-area {
+      width: 100%; aspect-ratio: 1; background: var(--item-hover);
+      border: 2px dashed var(--input-border); border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+      margin-bottom: 16px; overflow: hidden; cursor: pointer;
+    }
+    .photo-preview-area img { width: 100%; height: 100%; object-fit: cover; display: none; }
+    .photo-preview-area .placeholder-text { font-size: 13px; color: var(--date-color); }
+    .photo-caption-input {
+      width: 100%; padding: 10px 12px; border: 1px solid var(--input-border);
+      border-radius: 6px; font-size: 14px; font-family: 'Noto Sans JP', sans-serif;
+      background: var(--input-bg); color: var(--ui-text); outline: none; margin-bottom: 16px;
+      text-align: center;
+    }
+    .photo-caption-input:focus { border-color: var(--accent); }
+
+    /* ===== Snippet Create Dialog ===== */
+    #snippet-create-dialog {
+      position: fixed; inset: 0; z-index: 300;
+      background: rgba(0,0,0,0.25);
+      display: none; align-items: center; justify-content: center;
+    }
+    #snippet-create-dialog.open { display: flex; }
+    .snippet-create-box {
+      background: var(--dialog-bg); border-radius: 12px; padding: 28px 32px;
+      box-shadow: 0 8px 32px var(--dialog-shadow);
+      font-family: 'Noto Sans JP', sans-serif; color: var(--ui-text);
+      max-width: 400px; width: 90%;
+    }
+    .snippet-create-box h3 { font-size: 14px; margin-bottom: 16px; font-weight: 500; }
+    .snippet-textarea {
+      width: 100%; height: 80px; padding: 10px 12px;
+      border: 1px solid var(--input-border); border-radius: 6px;
+      font-size: 14px; font-family: 'Noto Serif JP', serif;
+      background: var(--input-bg); color: var(--ui-text);
+      outline: none; resize: none; margin-bottom: 8px;
+    }
+    .snippet-textarea:focus { border-color: var(--accent); }
+    .snippet-char-count { font-size: 11px; color: var(--date-color); text-align: right; margin-bottom: 16px; }
+
+    /* ===== Lightbox ===== */
+    #lightbox-overlay {
+      position: fixed; inset: 0; z-index: 400;
+      background: rgba(0,0,0,0.85);
+      display: none; align-items: center; justify-content: center;
+      cursor: pointer;
+    }
+    #lightbox-overlay.open { display: flex; }
+    #lightbox-overlay img {
+      max-width: 90vw; max-height: 90vh; object-fit: contain;
+      border-radius: 4px; cursor: default;
+    }
+    #lightbox-close {
+      position: absolute; top: 20px; right: 20px;
+      width: 36px; height: 36px; border-radius: 50%;
+      background: rgba(255,255,255,0.15); border: none;
+      color: white; font-size: 18px; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+    }
+    #lightbox-caption {
+      position: absolute; bottom: 40px; left: 50%; transform: translateX(-50%);
+      color: white; font-size: 14px; font-style: italic; opacity: 0.8;
+    }
+
+    /* ===== Audio/Voice Debuggers (editor only) ===== */
+    #audio-debugger {
+      position: absolute; bottom: 20px; right: 20px; z-index: 9999;
+      display: none; background: rgba(0,0,0,0.85); border-radius: 8px; padding: 12px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3); font-family: monospace;
+    }
+    #audio-debugger-title { color: #0f0; font-size: 11px; margin-bottom: 6px; text-align: center; letter-spacing: 0.05em; }
+    #visualizer-amp { display: block; background: #000; border: 1px solid #333; border-radius: 4px; }
+    #debug-hud {
+      position: absolute; top: 50px; right: 12px; z-index: 200;
+      background: rgba(0,0,0,0.8); border-radius: 8px; padding: 10px 14px;
+      font-family: 'Inter', monospace; font-size: 10px; color: #0f0;
+      display: none; line-height: 1.8; letter-spacing: 0.05em;
+    }
+    #debug-hud .hud-label { color: #888; }
+    #visualizer-voice { display: block; background: #111; border: 1px solid #333; border-radius: 4px; margin-top: 6px; }
+
+    /* ===== Toi (問い) Link Area ===== */
+    #toi-link-area {
+      position: absolute; z-index: 100; top: 36px; left: 50%; transform: translateX(-50%);
+      display: flex; flex-direction: row; align-items: center; gap: 8px;
+      writing-mode: horizontal-tb; text-orientation: initial;
+    }
+    #toi-linked-questions {
+      display: flex; flex-wrap: wrap; gap: 6px; justify-content: center;
+    }
+    .toi-linked-tag {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 3px 10px; border-radius: 12px;
+      background: var(--accent-light); color: var(--accent);
+      font-family: 'Noto Serif JP', serif; font-size: 11px;
+      letter-spacing: 0.08em; white-space: nowrap;
+    }
+    .toi-linked-tag .toi-unlink {
+      cursor: pointer; opacity: 0.6; font-size: 13px; line-height: 1;
+      transition: opacity 0.15s;
+    }
+    .toi-linked-tag .toi-unlink:hover { opacity: 1; }
+    #toi-link-controls {
+      display: flex; align-items: center; gap: 4px;
+      order: -1;
+    }
+    #toi-question-select {
+      padding: 3px 8px; border: 1px solid var(--border-subtle); border-radius: 6px;
+      background: var(--input-bg); color: var(--text);
+      font-family: 'Noto Serif JP', serif; font-size: 11px;
+      outline: none; cursor: pointer; max-width: 260px;
+    }
+    #toi-link-btn {
+      width: 24px; height: 24px; border: 1px solid var(--accent); border-radius: 50%;
+      background: transparent; color: var(--accent); font-size: 14px; line-height: 1;
+      cursor: pointer; transition: all 0.15s;
+      display: flex; align-items: center; justify-content: center;
+    }
+    #toi-link-btn:hover { background: var(--accent); color: white; }
+
+    /* Tsukekomi button removed */
+
+    /* ===== Jar View ===== */
+    #view-jar {
+      position: absolute; inset: 0;
+      background-color: var(--bg);
+      background-image:
+        linear-gradient(to right, rgba(0,0,0,0.03) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(0,0,0,0.03) 1px, transparent 1px);
+      background-size: 40px 40px;
+      overflow: hidden;
+    }
+    body.dark #view-jar {
+      background-image:
+        linear-gradient(to right, rgba(255,255,255,0.03) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255,255,255,0.03) 1px, transparent 1px);
+    }
+
+    /* Jar bottle */
+    #jar-bottle-container {
+      position: absolute; top: 50%; left: 50%; transform: translate(-50%, -55%);
+      width: 570px; height: 720px; z-index: 2;
+    }
+    #jar-bottle-container canvas { width: 100% !important; height: 100% !important; }
+
+    /* Connection lines SVG */
+    .jar-connection-svg {
+      position: absolute; inset: 0; width: 100%; height: 100%; z-index: 1; pointer-events: none;
+    }
+    .jar-connection-svg line {
+      stroke: var(--accent); stroke-width: 1; opacity: 0.2;
+      stroke-dasharray: 4 4;
+    }
+
+    /* Circles container */
+    #jar-circles-container {
+      position: absolute; inset: 0; z-index: 3; pointer-events: none;
+    }
+
+    /* Individual circle graphic */
+    .jar-circle {
+      position: absolute; pointer-events: auto; cursor: pointer;
+      transition: transform 0.4s cubic-bezier(0.4,0,0.2,1), opacity 0.3s;
+    }
+    .jar-circle:hover { transform: scale(1.03); }
+    .jar-circle-svg { width: 100%; height: 100%; }
+
+    /* Circle inner elements */
+    .jar-circle-inner {
+      position: absolute; inset: 0; overflow: hidden; border-radius: 50%;
+    }
+    .jar-circle-element {
+      position: absolute; pointer-events: none;
+      --el-scale: 0.65;
+      transition: opacity 0.4s ease, transform 0.6s cubic-bezier(0.19,1,0.22,1);
+    }
+    /* === Zoom behavior (circle-zoom.html approach) === */
+    .jar-circle {
+      transition: left 1.2s cubic-bezier(0.19,1,0.22,1),
+                  top 1.2s cubic-bezier(0.19,1,0.22,1),
+                  transform 1.2s cubic-bezier(0.19,1,0.22,1),
+                  width 1.2s cubic-bezier(0.19,1,0.22,1),
+                  height 1.2s cubic-bezier(0.19,1,0.22,1),
+                  opacity 0.4s ease;
+    }
+    .jar-circle.zoomed {
+      z-index: 55 !important;
+      cursor: default;
+    }
+    .jar-circle.zoomed:hover { transform: translate(-50%, -50%); }
+    .jar-circle.zoomed .jar-circle-inner {
+      overflow: visible;
+    }
+    .jar-circle.zoomed .jar-circle-element {
+      --el-scale: 2;
+      pointer-events: auto;
+      cursor: pointer;
+      transition: transform 0.3s cubic-bezier(0.19,1,0.22,1), box-shadow 0.3s ease, outline 0.2s ease;
+    }
+    .jar-circle.zoomed .jar-circle-element:hover {
+      --el-scale: 2.16;
+      z-index: 10;
+    }
+    .jar-circle.zoomed .jar-circle-keyword:hover {
+      box-shadow: 0 4px 18px rgba(212,165,116,0.5);
+      outline: 2px solid #c4945a;
+      outline-offset: 2px;
+    }
+    .jar-circle.zoomed .jar-circle-snippet:hover {
+      box-shadow: 0 4px 18px rgba(139,115,85,0.25);
+      outline: 2px solid #b8a080;
+      outline-offset: 2px;
+    }
+    .jar-circle.zoomed .jar-circle-letter:hover {
+      filter: drop-shadow(0 4px 12px rgba(200,85,160,0.3));
+    }
+    /* Hide other circles and question list when any circle is zoomed */
+    #jar-circles-container.has-zoomed { z-index: 50; }
+    #jar-circles-container.has-zoomed .jar-circle:not(.zoomed) { opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+    #jar-circles-container.has-zoomed ~ #jar-question-list { opacity: 0; pointer-events: none; transition: opacity 0.4s; }
+    #jar-circles-container.has-zoomed ~ svg#jar-connection-lines { opacity: 0; transition: opacity 0.4s; }
+    /* Zoom backdrop */
+    .jar-zoom-backdrop {
+      position: absolute; inset: 0; z-index: 45;
+      background: rgba(250,248,244,0.75);
+      opacity: 0; pointer-events: none;
+      transition: opacity 0.6s ease;
+    }
+    body.dark .jar-zoom-backdrop { background: rgba(26,26,26,0.7); }
+    .jar-zoom-backdrop.active { opacity: 1; pointer-events: auto; }
+    .jar-circle-snippet {
+      display: inline-block;
+      background: rgba(255,255,255,0.90); backdrop-filter: blur(4px);
+      border: 1px solid rgba(139,115,85,0.2);
+      border-radius: 4px; padding: 3px 6px; font-size: 7px; color: var(--text);
+      font-family: 'Noto Serif JP', serif; max-width: 90px;
+      white-space: normal; line-height: 1.3;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    }
+    .jar-circle-keyword {
+      display: inline-block;
+      background: #d4a574; border: none;
+      border-radius: 6px; padding: 4px 10px; font-size: 9px; color: #fff;
+      font-family: 'Noto Serif JP', serif; white-space: nowrap;
+      font-weight: 500; letter-spacing: 0.05em;
+      box-shadow: 0 4px 15px rgba(212,165,116,0.3);
+    }
+    .jar-circle-keyword .kw-text {
+      display: inline-block;
+    }
+    body.dark .jar-circle-keyword { background: #b8894a; }
+    .jar-circle-letter {
+      display: inline-block;
+      width: 48px; height: 40px; cursor: pointer;
+    }
+    .letter-envelope-mini {
+      width: 100%; height: 100%;
+    }
+    .letter-envelope-mini svg { width: 100%; height: 100%; filter: drop-shadow(0 2px 6px rgba(0,0,0,0.1)); }
+    .microbe-attach { pointer-events: none; z-index: 3; }
+    .microbe-icon-svg { width: 100%; height: 100%; filter: drop-shadow(0 1px 3px rgba(0,0,0,0.15)); }
+
+    /* Question list below jar */
+    #jar-question-list {
+      position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
+      z-index: 10; display: flex; flex-direction: column; align-items: center; gap: 8px;
+    }
+    .jar-question-list-label {
+      font-family: 'Noto Sans JP', sans-serif; font-size: 10px; font-weight: 500;
+      color: var(--date-color); letter-spacing: 0.2em;
+    }
+    #jar-question-items {
+      display: flex; flex-direction: column; align-items: center; gap: 4px;
+    }
+    .jar-question-tag {
+      padding: 6px 18px; border-radius: 20px; border: 1.5px solid #8b2020;
+      background: #8b2020; color: #fff;
+      font-family: 'Noto Serif JP', serif; font-size: 12px; font-weight: 400;
+      letter-spacing: 0.08em; white-space: nowrap;
+    }
+    .jar-add-question {
+      padding: 6px 18px; border-radius: 20px; border: 1.5px solid var(--accent);
+      background: transparent; color: var(--accent);
+      font-family: 'Noto Sans JP', sans-serif; font-size: 11px; font-weight: 500;
+      letter-spacing: 0.15em; cursor: pointer; transition: all 0.2s;
+    }
+    .jar-add-question:hover { background: var(--accent); color: white; }
+
+    /* Zoom overlay */
+    .jar-zoom-overlay {
+      position: absolute; inset: 0; z-index: 50;
+      display: none; opacity: 0;
+      background: rgba(250,248,244,0.75);
+      transition: opacity 0.6s ease;
+      flex-direction: column; align-items: center;
+      justify-content: center;
+    }
+    body.dark .jar-zoom-overlay { background: rgba(26,26,26,0.7); }
+    .jar-zoom-overlay.active { display: flex; opacity: 1; }
+    .jar-zoom-title {
+      margin-top: 20px;
+      font-family: 'Noto Serif JP', serif; font-size: 22px; font-weight: 400;
+      color: var(--text); letter-spacing: 0.15em;
+      writing-mode: horizontal-tb;
+    }
+    .jar-zoom-content {
+      position: relative; margin-top: 0;
+      width: min(520px, 58vh); height: min(520px, 58vh);
+      border-radius: 50%;
+      overflow: visible;
+      flex-shrink: 0;
+      transform: scale(0.3);
+      opacity: 0;
+      transition: transform 1.2s cubic-bezier(0.19,1,0.22,1), opacity 0.4s ease;
+    }
+    .jar-zoom-overlay.active .jar-zoom-content {
+      transform: scale(1);
+      opacity: 1;
+    }
+    /* Zoom snippet/keyword styles */
+    .jar-zoom-snippet .zoom-snippet-text {
+      font-size: 10px; color: #4a3f35; line-height: 1.4; margin-bottom: 2px;
+    }
+    .jar-zoom-snippet .zoom-snippet-date {
+      font-size: 8px; color: #8b7355;
+    }
+
+    /* Float drift animations for scattered elements */
+    @keyframes floatDrift0 {
+      0%, 100% { transform: translate(-50%, -50%) translateY(0px) translateX(0px); }
+      33% { transform: translate(-50%, -50%) translateY(-6px) translateX(3px); }
+      66% { transform: translate(-50%, -50%) translateY(4px) translateX(-4px); }
+    }
+    @keyframes floatDrift1 {
+      0%, 100% { transform: translate(-50%, -50%) translateY(0px) translateX(0px); }
+      33% { transform: translate(-50%, -50%) translateY(5px) translateX(-5px); }
+      66% { transform: translate(-50%, -50%) translateY(-3px) translateX(4px); }
+    }
+    @keyframes floatDrift2 {
+      0%, 100% { transform: translate(-50%, -50%) translateY(0px) translateX(0px); }
+      33% { transform: translate(-50%, -50%) translateY(-4px) translateX(-3px); }
+      66% { transform: translate(-50%, -50%) translateY(6px) translateX(5px); }
+    }
+    @keyframes floatDrift3 {
+      0%, 100% { transform: translate(-50%, -50%) translateY(0px) translateX(0px); }
+      33% { transform: translate(-50%, -50%) translateY(3px) translateX(6px); }
+      66% { transform: translate(-50%, -50%) translateY(-5px) translateX(-3px); }
+    }
+    @keyframes floatDrift4 {
+      0%, 100% { transform: translate(-50%, -50%) translateY(0px) translateX(0px); }
+      33% { transform: translate(-50%, -50%) translateY(-5px) translateX(-4px); }
+      66% { transform: translate(-50%, -50%) translateY(3px) translateX(6px); }
+    }
+    .jar-zoom-empty {
+      font-family: 'Noto Serif JP', serif; font-size: 12px; color: var(--date-color);
+      letter-spacing: 0.1em; margin-top: 12px;
+    }
+
+    /* Right detail pane - cream/amber theme matching circle-zoom.html */
+    .jar-detail-pane {
+      position: absolute; top: 0; right: -400px; width: 400px; height: 100%;
+      z-index: 60; background: #faf8f5; backdrop-filter: blur(12px);
+      border-left: 1px solid rgba(139,115,85,0.2);
+      display: flex; flex-direction: column;
+      transition: right 0.7s cubic-bezier(0.19,1,0.22,1);
+      box-shadow: -10px 0 30px rgba(0,0,0,0.05);
+    }
+    body.dark .jar-detail-pane { background: rgba(42,36,30,0.95); }
+    .jar-detail-pane.active { right: 0; }
+    .jar-detail-close {
+      position: absolute; top: 16px; right: 16px; z-index: 2;
+      width: 32px; height: 32px; border: none; border-radius: 50%;
+      background: transparent; color: #8b7355; font-size: 18px; line-height: 1;
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      transition: all 0.2s;
+    }
+    .jar-detail-close:hover { background: rgba(139,115,85,0.1); color: #4a3f35; }
+    .jar-detail-question {
+      padding: 32px 32px 12px; font-family: 'Noto Serif JP', serif;
+      font-size: 14px; color: #4a3f35; letter-spacing: 0.1em;
+      font-weight: 500;
+    }
+    body.dark .jar-detail-question { color: #e8d5b5; }
+    .jar-detail-header {
+      padding: 0 32px 20px; font-family: 'Noto Serif JP', serif;
+      font-size: 22px; font-weight: 500; color: #4a3f35;
+      letter-spacing: 0.08em;
+      border-bottom: 1px solid rgba(139,115,85,0.1);
+    }
+    body.dark .jar-detail-header { color: #e8d5b5; }
+    .jar-detail-body {
+      flex: 1; overflow-y: auto; padding: 24px 32px;
+      font-family: 'Noto Serif JP', serif; font-size: 14px; line-height: 2.0;
+      color: #4a3f35;
+    }
+    body.dark .jar-detail-body { color: #d4c4a8; }
+    .jar-detail-body .snippet-item {
+      margin-bottom: 24px; padding-bottom: 20px; border-bottom: 1px solid rgba(139,115,85,0.1);
+    }
+    .jar-detail-body .snippet-item:last-child { border-bottom: none; }
+    .jar-detail-body .snippet-type {
+      font-family: 'Noto Sans JP', sans-serif; font-size: 10px; font-weight: 600;
+      color: #d97706; letter-spacing: 0.15em; margin-bottom: 6px;
+    }
+    .jar-detail-body .snippet-text {
+      font-size: 14px; font-weight: 400; margin-bottom: 8px; color: #4a3f35;
+    }
+    body.dark .jar-detail-body .snippet-text { color: #d4c4a8; }
+    .jar-detail-body .snippet-source {
+      font-size: 11px; color: #8b7355; margin-bottom: 6px;
+    }
+    .jar-detail-body .snippet-reason {
+      font-size: 13px; color: #8b7355; line-height: 1.8;
+    }
+    .jar-detail-body .keyword-item {
+      margin-bottom: 20px;
+    }
+    .jar-detail-body .keyword-name {
+      font-size: 15px; font-weight: 500; color: #d4a574; margin-bottom: 4px;
+    }
+    body.dark .jar-detail-body .keyword-name { color: #e8a020; }
+    .jar-detail-body .keyword-desc {
+      font-size: 13px; color: #4a3f35; line-height: 1.8;
+    }
+    body.dark .jar-detail-body .keyword-desc { color: #d4c4a8; }
+    .jar-detail-body .letter-text {
+      font-size: 14px; line-height: 2.0; color: #4a3f35;
+    }
+    body.dark .jar-detail-body .letter-text { color: #d4c4a8; }
+    .jar-detail-footer {
+      padding: 24px 32px; border-top: 1px solid rgba(139,115,85,0.1);
+      background: rgba(240,236,225,0.5);
+    }
+    body.dark .jar-detail-footer { background: rgba(42,36,30,0.5); }
+    .jar-detail-write-btn {
+      width: 100%; padding: 12px 20px;
+      border: 1px solid #d97706; background: transparent; color: #d97706;
+      font-family: 'Noto Sans JP', sans-serif; font-size: 13px; font-weight: 400;
+      letter-spacing: 0.15em; cursor: pointer; transition: all 0.3s;
+    }
+    .jar-detail-write-btn:hover { background: #d97706; color: white; }
+
+    /* Empty circle zoomed state */
+    .jar-empty-state {
+      position: absolute;
+      bottom: 12%;
+      left: 50%;
+      transform: translateX(-50%) translateY(8px);
+      text-align: center;
+      z-index: 10;
+      pointer-events: auto;
+      max-width: 70%;
+      opacity: 0;
+      transition: opacity 0.8s ease, transform 0.8s ease;
+    }
+    .jar-empty-state.visible {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+    .jar-empty-state-message {
+      font-family: 'Noto Serif JP', serif;
+      font-size: 12px;
+      line-height: 1.9;
+      color: #8b7355;
+      letter-spacing: 0.05em;
+      margin-bottom: 16px;
+      opacity: 0.85;
+    }
+    body.dark .jar-empty-state-message { color: #d4c4a8; }
+    .jar-empty-state-btn {
+      padding: 10px 24px;
+      border: 1px solid #d97706;
+      background: transparent;
+      color: #d97706;
+      font-family: 'Noto Sans JP', sans-serif;
+      font-size: 12px;
+      font-weight: 400;
+      letter-spacing: 0.12em;
+      cursor: pointer;
+      transition: all 0.3s;
+      border-radius: 2px;
+    }
+    .jar-empty-state-btn:hover {
+      background: #d97706;
+      color: white;
+    }
+
+    /* Modal */
+    .jar-modal-overlay {
+      position: absolute; inset: 0; z-index: 100;
+      background: rgba(0,0,0,0.3); display: flex;
+      align-items: center; justify-content: center;
+    }
+    .jar-modal {
+      background: var(--dialog-bg); border-radius: 12px;
+      padding: 28px 32px; width: 400px; max-width: 90vw;
+      box-shadow: 0 8px 40px var(--dialog-shadow);
+    }
+    .jar-modal-title {
+      font-family: 'Noto Serif JP', serif; font-size: 16px; font-weight: 400;
+      color: var(--text); margin-bottom: 16px; letter-spacing: 0.1em;
+    }
+    .jar-modal-input {
+      width: 100%; padding: 10px 14px; border: 1px solid var(--input-border);
+      border-radius: 8px; background: var(--input-bg); color: var(--text);
+      font-family: 'Noto Serif JP', serif; font-size: 14px; line-height: 1.6;
+      resize: none; outline: none;
+    }
+    .jar-modal-input:focus { border-color: var(--accent); }
+    .jar-modal-actions {
+      display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px;
+    }
+    .jar-modal-btn {
+      padding: 8px 20px; border-radius: 20px;
+      font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: 500;
+      letter-spacing: 0.1em; cursor: pointer; transition: all 0.2s;
+    }
+    .jar-modal-cancel {
+      border: 1px solid var(--border-subtle); background: transparent;
+      color: var(--date-color);
+    }
+    .jar-modal-cancel:hover { border-color: var(--text); color: var(--text); }
+    .jar-modal-save {
+      border: 1.5px solid var(--accent); background: var(--accent); color: white;
+    }
+    .jar-modal-save:hover { background: transparent; color: var(--accent); }
+    .jar-modal-archive {
+      border: 1px solid #8b2020; background: transparent;
+      color: #8b2020;
+    }
+    .jar-modal-archive:hover { background: #8b2020; color: white; }
+
+    /* Tsukekomi overlay removed */
+
+    /* ===== Questions Timeline ===== */
+    .timeline-page {
+      width: 100%; height: 100%;
+      overflow-y: auto; overflow-x: hidden;
+      background: var(--bg);
+      padding: 48px 60px;
+    }
+    .timeline-header {
+      text-align: center; margin-bottom: 48px;
+    }
+    .timeline-title {
+      font-family: 'Noto Serif JP', serif; font-size: 22px; font-weight: 500;
+      color: var(--text); letter-spacing: 0.12em; margin: 0 0 8px;
+    }
+    .timeline-subtitle {
+      font-family: 'Noto Serif JP', serif; font-size: 13px;
+      color: var(--date-color); letter-spacing: 0.08em; margin: 0;
+    }
+    .timeline-content {
+      max-width: 800px; margin: 0 auto;
+      position: relative;
+      padding-left: 32px;
+    }
+    /* Vertical line */
+    .timeline-content::before {
+      content: ''; position: absolute;
+      left: 7px; top: 0; bottom: 0;
+      width: 2px; background: rgba(139,115,85,0.15);
+    }
+    body.dark .timeline-content::before { background: rgba(200,180,140,0.15); }
+
+    .timeline-date-group {
+      margin-bottom: 36px; position: relative;
+    }
+    .timeline-date-label {
+      font-family: 'Noto Sans JP', sans-serif; font-size: 11px; font-weight: 600;
+      color: var(--date-color); letter-spacing: 0.15em;
+      margin-bottom: 12px;
+      position: relative;
+    }
+    .timeline-date-label::before {
+      content: ''; position: absolute;
+      left: -29px; top: 50%; transform: translateY(-50%);
+      width: 10px; height: 10px; border-radius: 50%;
+      background: var(--date-color); border: 2px solid var(--bg);
+    }
+
+    .timeline-event {
+      margin-bottom: 10px; margin-left: 4px;
+      padding: 14px 20px; border-radius: 10px;
+      border-left: 3px solid transparent;
+      background: rgba(139,115,85,0.04);
+      transition: all 0.2s;
+    }
+    body.dark .timeline-event { background: rgba(200,180,140,0.06); }
+
+    .timeline-event.event-created { border-left-color: #d97706; }
+    .timeline-event.event-updated { border-left-color: #2563eb; }
+    .timeline-event.event-archived { border-left-color: #8b2020; }
+    .timeline-event.event-proposed { border-left-color: #059669; }
+    .timeline-event.event-unarchived { border-left-color: #7c3aed; }
+
+    .timeline-event-type {
+      font-family: 'Noto Sans JP', sans-serif; font-size: 10px; font-weight: 600;
+      letter-spacing: 0.12em; margin-bottom: 4px;
+    }
+    .event-created .timeline-event-type { color: #d97706; }
+    .event-updated .timeline-event-type { color: #2563eb; }
+    .event-archived .timeline-event-type { color: #8b2020; }
+    .event-proposed .timeline-event-type { color: #059669; }
+    .event-unarchived .timeline-event-type { color: #7c3aed; }
+
+    .timeline-event-question {
+      font-family: 'Noto Serif JP', serif; font-size: 14px;
+      color: var(--text); line-height: 1.7; letter-spacing: 0.05em;
+    }
+    .timeline-event-detail {
+      font-family: 'Noto Serif JP', serif; font-size: 11px;
+      color: var(--date-color); margin-top: 4px; line-height: 1.6;
+    }
+    .timeline-event-arrow {
+      display: flex; align-items: center; gap: 8px; margin: 6px 0;
+    }
+    .timeline-event-arrow .arrow-icon {
+      color: var(--date-color); font-size: 12px;
+    }
+    .timeline-event-prev {
+      font-family: 'Noto Serif JP', serif; font-size: 12px;
+      color: var(--date-color); text-decoration: line-through; opacity: 0.6;
+    }
+    .timeline-event-new {
+      font-family: 'Noto Serif JP', serif; font-size: 14px;
+      color: var(--text); font-weight: 500;
+    }
+    .timeline-unarchive-btn {
+      margin-top: 8px; padding: 4px 14px; border-radius: 14px;
+      border: 1px solid #7c3aed; background: transparent; color: #7c3aed;
+      font-family: 'Noto Sans JP', sans-serif; font-size: 10px; font-weight: 500;
+      letter-spacing: 0.1em; cursor: pointer; transition: all 0.2s;
+    }
+    .timeline-unarchive-btn:hover { background: #7c3aed; color: white; }
+
+    .timeline-question-color {
+      display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+      margin-right: 6px; vertical-align: middle;
+    }
+
+    /* ===== Jar V2 View ===== */
+    #view-jar2 {
+      position: relative; width: 100%; height: 100%; overflow: hidden;
+      background: var(--bg);
+    }
+    .j2-bg-grid {
+      position: absolute; inset: 0; pointer-events: none; z-index: 0;
+      background-image:
+        linear-gradient(rgba(140,133,126,0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(140,133,126,0.04) 1px, transparent 1px);
+      background-size: 40px 40px; background-position: center center;
+    }
+    body.dark .j2-bg-grid {
+      background-image:
+        linear-gradient(rgba(60,80,90,0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(60,80,90,0.03) 1px, transparent 1px);
+    }
+    .j2-bg-radial {
+      position: absolute; inset: 0; pointer-events: none; z-index: 0;
+      background: radial-gradient(circle at 50% 40%, rgba(255,255,255,0.7) 0%, transparent 70%);
+    }
+    body.dark .j2-bg-radial {
+      background: radial-gradient(circle at 50% 40%, rgba(20,20,30,0.3) 0%, transparent 70%);
+    }
+    .j2-connection-svg {
+      position: absolute; inset: 0; width: 100%; height: 100%;
+      pointer-events: none; z-index: 1;
+      transition: opacity 0.5s ease;
+    }
+    #j2-bottle-container {
+      position: absolute; left: 50%; top: 45%;
+      transform: translate(-50%, -55%);
+      width: 420px; height: 520px; z-index: 2;
+      pointer-events: none;
+    }
+    .j2-zoom-backdrop {
+      position: fixed; inset: 0; z-index: 4;
+      background: rgba(0,0,0,0); pointer-events: none;
+      transition: background 0.5s ease;
+    }
+    .j2-zoom-backdrop.active {
+      background: rgba(0,0,0,0.3); pointer-events: auto; cursor: pointer;
+    }
+    #j2-circles-container {
+      position: absolute; inset: 0; z-index: 3;
+      pointer-events: none;
+    }
+    #j2-circles-container.has-zoomed {
+      z-index: 50;
+    }
+
+    /* Question list (bottom) */
+    .j2-question-list {
+      position: absolute; bottom: 40px; left: 50%; transform: translateX(-50%);
+      display: flex; flex-direction: column; align-items: center; gap: 10px;
+      z-index: 30; width: 100%; max-width: 700px; padding: 0 32px;
+      transition: opacity 0.5s ease;
+    }
+    .j2-question-list-divider {
+      width: 1px; height: 24px;
+      background: linear-gradient(to top, rgba(140,133,126,0.3), transparent);
+    }
+    .j2-question-list-label {
+      font-size: 10px; color: var(--date-color);
+      letter-spacing: 0.3em; font-family: 'Noto Sans JP', sans-serif;
+    }
+    .j2-question-items {
+      display: flex; justify-content: center; gap: 10px; flex-wrap: wrap;
+    }
+    .j2-question-tag {
+      background: linear-gradient(135deg, var(--text), rgba(140,133,126,0.9));
+      color: var(--bg); padding: 6px 16px; border-radius: 999px;
+      font-family: 'Noto Serif JP', serif; font-size: 11px;
+      letter-spacing: 0.08em; font-weight: 500;
+      border: 1px solid rgba(255,255,255,0.15);
+      backdrop-filter: blur(8px); cursor: pointer;
+      transition: all 0.5s; box-shadow: 0 2px 8px rgba(74,69,65,0.15);
+    }
+    .j2-question-tag:hover { transform: translateY(-2px); }
+    .j2-add-question {
+      font-size: 10px; color: var(--date-color);
+      background: none; border: 1px dashed var(--date-color);
+      padding: 4px 12px; border-radius: 999px; cursor: pointer;
+      font-family: 'Noto Sans JP', sans-serif; letter-spacing: 0.1em;
+      transition: all 0.2s;
+    }
+    .j2-add-question:hover { background: rgba(140,133,126,0.1); }
+
+    /* Detail pane (reuse styling from jar view) */
+    .j2-detail-pane {
+      position: absolute; right: -400px; top: 0; bottom: 0; width: 400px;
+      background: var(--bg); border-left: 1px solid var(--grid-line);
+      z-index: 60; padding: 40px 30px; overflow-y: auto;
+      transition: right 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: -4px 0 30px rgba(0,0,0,0.05);
+    }
+    .j2-detail-pane.open { right: 0; }
+    .j2-detail-close {
+      position: absolute; top: 16px; right: 16px;
+      background: none; border: none; font-size: 24px;
+      color: var(--date-color); cursor: pointer;
+    }
+    .j2-detail-question {
+      font-family: 'Noto Serif JP', serif; font-size: 13px;
+      color: var(--date-color); margin-bottom: 16px;
+      letter-spacing: 0.1em; line-height: 1.8;
+    }
+    .j2-detail-header {
+      font-family: 'Noto Sans JP', sans-serif; font-size: 11px;
+      color: var(--date-color); letter-spacing: 0.15em;
+      margin-bottom: 20px; padding-bottom: 10px;
+      border-bottom: 1px solid var(--grid-line);
+    }
+    .j2-detail-body {
+      font-family: 'Noto Serif JP', serif; font-size: 14px;
+      color: var(--text); line-height: 2;
+    }
+    .j2-detail-footer { margin-top: 30px; }
+    .j2-detail-write-btn {
+      width: 100%; padding: 12px; border-radius: 20px;
+      background: var(--text); color: var(--bg); border: none;
+      font-family: 'Noto Sans JP', sans-serif; font-size: 12px;
+      letter-spacing: 0.1em; cursor: pointer; transition: opacity 0.2s;
+    }
+    .j2-detail-write-btn:hover { opacity: 0.85; }
+
+    /* Modals */
+    .j2-modal-overlay {
+      position: absolute; inset: 0; z-index: 100;
+      background: rgba(0,0,0,0.4); display: flex;
+      align-items: center; justify-content: center;
+      animation: fadeIn 0.3s;
+    }
+    .j2-modal {
+      background: var(--bg); border-radius: 16px; padding: 28px;
+      width: 380px; max-width: 90%;
+      box-shadow: 0 20px 50px rgba(0,0,0,0.15);
+    }
+    .j2-modal-title {
+      font-family: 'Noto Serif JP', serif; font-size: 14px;
+      color: var(--text); margin-bottom: 16px;
+    }
+    .j2-modal-input {
+      width: 100%; padding: 12px; border-radius: 8px;
+      border: 1px solid var(--grid-line); background: transparent;
+      color: var(--text); font-family: 'Noto Serif JP', serif;
+      font-size: 13px; resize: none; outline: none;
+    }
+    .j2-modal-actions {
+      display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px;
+    }
+    .j2-modal-btn {
+      padding: 8px 20px; border-radius: 20px;
+      font-family: 'Noto Sans JP', sans-serif; font-size: 11px;
+      cursor: pointer; transition: all 0.2s; border: none;
+    }
+    .j2-modal-cancel { background: transparent; color: var(--date-color); border: 1px solid var(--grid-line); }
+    .j2-modal-save { background: var(--text); color: var(--bg); }
+    .j2-modal-archive { background: transparent; color: #dc2626; border: 1px solid #dc2626; }
+
+    /* Jar V2: Bottle */
+    .j2-jar-glow {
+      position: absolute; inset: 0;
+      background: rgba(226,194,142,0.1); border-radius: 200px;
+      filter: blur(80px);
+      animation: j2-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;
+    }
+    .j2-jar-svg { width: 100%; height: 100%; filter: drop-shadow(0 20px 40px rgba(140,133,126,0.15)); }
+    .j2-jar-glass { transition: fill 0.6s, stroke 0.6s; }
+    body.dark .j2-jar-glass { fill: rgba(20,20,30,0.3); stroke: rgba(100,110,120,0.4); }
+    body.dark .j2-jar-glow { background: rgba(142,168,156,0.05); }
+
+    .j2-jar-content {
+      position: absolute; inset: 0; overflow: hidden; pointer-events: auto;
+      clip-path: path('M190,100 C190,60 290,60 290,100 C290,130 270,140 270,170 C270,270 410,330 410,480 C410,580 70,580 70,480 C70,330 210,270 210,170 C210,140 190,130 190,100 Z');
+    }
+    .j2-jar-text {
+      font-family: 'Noto Serif JP', serif; color: var(--date-color);
+      pointer-events: none; user-select: none;
+      transition: color 0.6s;
+    }
+    body.dark .j2-jar-text { color: rgba(200,200,210,0.5); }
+
+    /* Jar V2: Float animations */
+    @keyframes j2-float-1 {
+      0%, 100% { transform: translateY(0) translateX(0); }
+      33% { transform: translateY(-10px) translateX(5px); }
+      66% { transform: translateY(5px) translateX(-5px); }
+    }
+    @keyframes j2-float-2 {
+      0%, 100% { transform: translateY(0) translateX(0); }
+      33% { transform: translateY(5px) translateX(-8px); }
+      66% { transform: translateY(-8px) translateX(3px); }
+    }
+    @keyframes j2-float-3 {
+      0%, 100% { transform: translateY(0) translateX(0); }
+      33% { transform: translateY(-6px) translateX(-4px); }
+      66% { transform: translateY(8px) translateX(6px); }
+    }
+    .j2-float-1 { animation: j2-float-1 8s ease-in-out infinite; }
+    .j2-float-2 { animation: j2-float-2 12s ease-in-out infinite; }
+    .j2-float-3 { animation: j2-float-3 10s ease-in-out infinite 2s; }
+
+    @keyframes j2-pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.6; }
+    }
+
+    /* Jar V2: Connection lines */
+    @keyframes j2-flow {
+      0% { stroke-dashoffset: 1000; }
+      100% { stroke-dashoffset: 0; }
+    }
+    .j2-flow-line { animation: j2-flow 60s linear infinite; }
+
+    /* Jar V2: Circle elements */
+    .j2-circle {
+      position: absolute; cursor: pointer; pointer-events: auto;
+      transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+      --el-scale: 0.65;
+    }
+    .j2-circle:hover { transform: translate(-50%, -50%) scale(1.03); }
+    .j2-circle.zoomed:hover { transform: translate(-50%, -50%); }
+    .j2-circle-glow {
+      position: absolute; inset: -10%; border-radius: 50%;
+      background: rgba(217,180,143,0.05); filter: blur(30px);
+      animation: j2-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite;
+    }
+
+    /* Rotating question text ring */
+    .j2-circle-text-ring {
+      position: absolute; left: 50%; top: 50%;
+      transform: translate(-50%, -50%);
+      animation: spin 120s linear infinite;
+      pointer-events: none;
+    }
+    @keyframes spin { from { transform: translate(-50%, -50%) rotate(0deg); } to { transform: translate(-50%, -50%) rotate(360deg); } }
+    .j2-circle-text-svg { width: 100%; height: 100%; }
+    .j2-ring-text {
+      font-family: 'Noto Serif JP', serif; font-size: 9px;
+      letter-spacing: 0.2em; fill: #7A3B3F; opacity: 0.6;
+    }
+    body.dark .j2-ring-text { fill: #c87070; opacity: 0.5; }
+
+    /* Mycelium lines inside circles */
+    .j2-mycelium-svg {
+      position: absolute; left: 50%; top: 50%;
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+      animation: spin 120s linear infinite reverse;
+    }
+
+    /* Circle inner content — NO overflow clip, elements float above circle */
+    .j2-circle-inner {
+      position: absolute; left: 50%; top: 50%;
+      transform: translate(-50%, -50%);
+      border-radius: 50%; overflow: visible;
+      pointer-events: none;
+    }
+    .j2-circle.zoomed .j2-circle-inner { pointer-events: auto; }
+    .j2-circle-element-wrapper {
+      transform: scale(var(--el-scale));
+      transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .j2-circle-microbe {
+      transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .j2-circle.zoomed { --el-scale: 1.1; }
+
+    /* Microbe attached to elements */
+    .j2-element-microbe {
+      position: absolute; top: -10px; right: -12px;
+      width: 18px; height: 18px; display: block;
+      pointer-events: none; opacity: 0.6;
+    }
+    .j2-element-microbe svg { width: 100%; height: 100%; }
+    .j2-microbe-bottom {
+      top: auto; bottom: -10px; right: auto; left: -8px;
+    }
+
+    /* Keywords in circles */
+    .j2-circle-keyword {
+      position: relative; z-index: 10;
+      background: linear-gradient(135deg, #E8D1B5, #D9B48F);
+      color: var(--text); font-family: 'Noto Serif JP', serif;
+      font-size: 11px; letter-spacing: 0.15em;
+      padding: 6px 16px; border-radius: 999px;
+      box-shadow: 0 4px 12px rgba(217,180,143,0.3);
+      border: 1px solid rgba(255,255,255,0.5);
+      cursor: pointer; transition: transform 0.5s;
+      white-space: nowrap;
+    }
+    .j2-circle-keyword:hover { transform: scale(1.05); z-index: 30; }
+    .j2-circle.zoomed .j2-circle-keyword { font-size: 13px; padding: 8px 20px; }
+    body.dark .j2-circle-keyword {
+      background: linear-gradient(135deg, #8a6e50, #6e5438);
+      color: #F8F5EF; border-color: rgba(255,255,255,0.15);
+    }
+
+    /* Snippets in circles */
+    .j2-circle-snippet {
+      position: relative; z-index: 20;
+      background: rgba(253,251,247,0.4);
+      backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+      border: 1px solid rgba(255,255,255,0.6);
+      padding: 10px 12px; border-radius: 12px; max-width: 140px;
+      box-shadow: 0 4px 16px rgba(140,133,126,0.08);
+      cursor: pointer; transition: all 0.3s;
+    }
+    .j2-circle-snippet:hover { transform: translateY(-4px); z-index: 40; }
+    .j2-circle.zoomed .j2-circle-snippet { max-width: 200px; }
+    .j2-snippet-text {
+      font-size: 9px; color: var(--text); line-height: 1.6;
+      font-family: 'Noto Sans JP', sans-serif; font-weight: 500;
+      opacity: 0.95;
+    }
+    .j2-circle.zoomed .j2-snippet-text { font-size: 11px; }
+    .j2-snippet-dot {
+      position: absolute; top: -6px; left: 24px;
+      width: 6px; height: 6px; border-radius: 50%;
+      background: #E2C28E; border: 1px solid white;
+      box-shadow: 0 0 4px rgba(226,194,142,0.4);
+    }
+    body.dark .j2-circle-snippet {
+      background: rgba(12,12,18,0.6);
+      border-color: rgba(80,90,100,0.15);
+    }
+
+    /* Letter in circles */
+    .j2-circle-letter {
+      position: relative; z-index: 20;
+      width: 32px; height: 32px; border-radius: 50%;
+      background: linear-gradient(135deg, white, #FDFBF7);
+      box-shadow: 0 4px 12px rgba(140,133,126,0.15);
+      border: 1px solid rgba(140,133,126,0.2);
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer; transition: all 0.3s;
+    }
+    .j2-circle-letter:hover { transform: scale(1.1); z-index: 40; }
+    .j2-letter-icon { width: 16px; height: 16px; color: #7A3B3F; }
+    .j2-letter-dot {
+      position: absolute; top: -6px; left: 50%;
+      transform: translateX(-50%);
+      width: 6px; height: 6px; border-radius: 50%;
+      background: #E2C28E; border: 1px solid white;
+    }
+    body.dark .j2-circle-letter {
+      background: linear-gradient(135deg, #1a1a24, #0f0f18);
+      border-color: rgba(80,90,100,0.2);
+    }
+    body.dark .j2-letter-icon { color: #c87070; }
+
+  </style>
+</head>
+<body>
+  <!-- Sidebar -->
+  <nav id="app-sidebar">
+    <div class="sidebar-logo">ORYZAE</div>
+    <button class="sidebar-btn active" data-screen="jar" title="Jar">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 2h8v4H8z" opacity="0.5"/><path d="M6 6h12v2c0 5.5-2.5 8-6 12-3.5-4-6-6.5-6-12V6z"/></svg>
+      <span class="sidebar-label">Jar</span>
+    </button>
+    <button class="sidebar-btn" data-screen="jar2" title="Jar v2">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 2h8v4H8z" opacity="0.5"/><path d="M6 6h12v2c0 5.5-2.5 8-6 12-3.5-4-6-6.5-6-12V6z"/><circle cx="18" cy="18" r="4" fill="currentColor" opacity="0.4"/></svg>
+      <span class="sidebar-label">Jar v2</span>
+    </button>
+    <button class="sidebar-btn" data-screen="board" title="Board">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+      <span class="sidebar-label">Board</span>
+    </button>
+    <button class="sidebar-btn" data-screen="list" title="List">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+      <span class="sidebar-label">List</span>
+    </button>
+    <button class="sidebar-btn" data-screen="editor" title="Editor">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+      <span class="sidebar-label">Editor</span>
+    </button>
+    <button class="sidebar-btn" data-screen="timeline" title="問い一覧">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="5" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="12" cy="19" r="1.5"/><line x1="12" y1="6.5" x2="12" y2="10.5"/><line x1="12" y1="13.5" x2="12" y2="17.5"/></svg>
+      <span class="sidebar-label">問い一覧</span>
+    </button>
+    <div class="sidebar-spacer"></div>
+    <button class="sidebar-btn" id="btn-darkmode" title="ダークモード">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+    </button>
+  </nav>
+  <main style="flex:1;display:flex;flex-direction:column;height:100%;position:relative;">
+    <!-- Header removed - navigation is in sidebar -->
+    <!-- Content Area -->
+    <div id="content-area">
+
+      <!-- ===== BOARD VIEW ===== -->
+      <div id="view-board" class="view-container">
+        <div class="grid-bg"></div>
+        <div class="board-date-display">
+          <div class="board-date-nav">
+            <button id="board-prev-day" title="前日">‹</button>
+            <span id="board-date-label">2026.02.25 — 水曜日</span>
+            <button id="board-next-day" title="翌日">›</button>
+          </div>
+        </div>
+        <div class="board-controls">
+          <button class="board-ctrl-btn active" id="board-view-daily">Daily</button>
+          <button class="board-ctrl-btn" id="board-view-weekly">Weekly</button>
+          <button class="board-ctrl-btn" id="board-add-snippet">✦ Snippet</button>
+          <button class="board-ctrl-btn" id="board-add-photo">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+            Photo
+          </button>
+        </div>
+        <div id="board-canvas"></div>
+      </div>
+
+      <!-- ===== LIST VIEW ===== -->
+      <div id="view-list" class="view-container">
+        <div class="list-container no-scrollbar" id="list-scroll-container">
+          <div class="list-header">
+            <h2>All Entries</h2>
+            <button class="list-new-btn" id="list-new-entry">+ New Entry</button>
+          </div>
+          <div id="entry-list-container"></div>
+        </div>
+      </div>
+
+      <!-- ===== EDITOR VIEW ===== -->
+      <div id="view-editor" class="view-container">
+        <div id="ghost-layer"></div>
+        <div id="editor-wrapper">
+          <canvas id="trace-canvas"></canvas>
+          <div contenteditable="true" id="editor" data-placeholder="ここに書き始める…" spellcheck="false"></div>
+        </div>
+        <div id="date-display"></div>
+        <div id="editor-title-display"></div>
+
+        <!-- 問い (Question) Link Area -->
+        <div id="toi-link-area">
+          <div id="toi-linked-questions"></div>
+          <div id="toi-link-controls">
+            <select id="toi-question-select">
+              <option value="">問いを紐づける…</option>
+            </select>
+            <button id="toi-link-btn" title="紐づける">+</button>
+          </div>
+        </div>
+
+        <!-- Selection toolbar for snippet creation -->
+        <div id="selection-toolbar" class="flex items-center gap-2">
+          <button id="btn-snippet"><span>✦</span> スニペット化</button>
+          <div id="snippet-warning">50文字以内</div>
+        </div>
+
+        <!-- Audio debugger -->
+        <div id="audio-debugger">
+          <div id="audio-debugger-title">♫ ASMR AMP</div>
+          <canvas id="visualizer-amp" width="160" height="40"></canvas>
+        </div>
+        <!-- Voice HUD -->
+        <div id="debug-hud">
+          <div><span class="hud-label">STATUS</span> <span id="debug-status">OFF</span></div>
+          <div><span class="hud-label">RMS</span> <span id="debug-rms">0.0000</span></div>
+          <div><span class="hud-label">SIZE</span> <span id="debug-size">1.00em</span></div>
+          <canvas id="visualizer-voice" width="160" height="40"></canvas>
+        </div>
+
+        <!-- Editor toolbar buttons -->
+        <!-- Top center: date display (now repositioned from absolute to here) -->
+        <!-- Top right: writing direction (three-line icon) + font toggle (T icon) -->
+        <div class="editor-btn-group" style="top:12px;right:12px;">
+          <button class="editor-toolbar-btn" id="btn-direction" title="横書きに切替">
+            <svg viewBox="0 0 24 24"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>
+          </button>
+          <button class="editor-toolbar-btn" id="btn-font" title="ゴシックに切替">
+            <svg viewBox="0 0 24 24" style="fill:currentColor;stroke:none;"><text x="12" y="17" text-anchor="middle" font-size="16" font-weight="600" font-family="serif">T</text></svg>
+          </button>
+        </div>
+        <!-- Top left: settings + fullscreen -->
+        <div class="editor-btn-group" style="top:12px;left:12px;">
+          <button class="editor-toolbar-btn" id="btn-settings" title="設定">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          </button>
+          <button class="editor-toolbar-btn" id="btn-fullscreen" title="フルスクリーン">
+            <svg viewBox="0 0 24 24"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+          </button>
+        </div>
+        <!-- Bottom left: new + save + open + 漬け込む -->
+        <div class="editor-btn-group" style="bottom:12px;left:12px;">
+          <button class="editor-toolbar-btn" id="btn-new" title="新規ドキュメント">
+            <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+          </button>
+          <button class="editor-toolbar-btn" id="btn-save" title="保存">
+            <svg viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+          </button>
+          <button class="editor-toolbar-btn" id="btn-open" title="開く">
+            <svg viewBox="0 0 24 24"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+          </button>
+          <!-- 漬け込む button removed - text auto-fed on save -->
+        </div>
+        <!-- Bottom center: mic button -->
+        <div class="editor-btn-group" style="bottom:12px;left:50%;transform:translateX(-50%);">
+          <button class="editor-toolbar-btn" id="btn-mic" title="音声入力 (Voice Dynamics)">
+            <svg viewBox="0 0 24 24"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+          </button>
+        </div>
+        <!-- Bottom right: stats -->
+        <div class="editor-btn-group" style="bottom:12px;right:12px;">
+          <button class="editor-toolbar-btn" id="btn-stats" title="執筆統計">
+            <svg viewBox="0 0 24 24"><rect x="4" y="14" width="4" height="7" fill="currentColor" stroke="none"/><rect x="10" y="10" width="4" height="11" fill="currentColor" stroke="none"/><rect x="16" y="3" width="4" height="18" fill="currentColor" stroke="none"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- ===== JAR VIEW ===== -->
+      <div id="view-jar" class="view-container active">
+        <!-- SVG layer for connection lines -->
+        <svg id="jar-connection-lines" class="jar-connection-svg"></svg>
+        <!-- Jar (Three.js canvas injected here) -->
+        <div id="jar-bottle-container"></div>
+        <!-- Zoom backdrop (click to unzoom) -->
+        <div id="jar-zoom-backdrop" class="jar-zoom-backdrop"></div>
+        <!-- Circular graphics for questions -->
+        <div id="jar-circles-container"></div>
+        <!-- Question list below jar -->
+        <div id="jar-question-list">
+          <div class="jar-question-list-label">現在の問い</div>
+          <div id="jar-question-items"></div>
+          <button id="jar-add-question-btn" class="jar-add-question">＋ 問いを追加する</button>
+        </div>
+        <!-- Right detail pane -->
+        <div id="jar-detail-pane" class="jar-detail-pane">
+          <button id="jar-detail-close" class="jar-detail-close">&times;</button>
+          <div id="jar-detail-question" class="jar-detail-question"></div>
+          <div id="jar-detail-header" class="jar-detail-header"></div>
+          <div id="jar-detail-body" class="jar-detail-body"></div>
+          <div class="jar-detail-footer">
+            <button id="jar-detail-write-btn" class="jar-detail-write-btn">この問いのエントリを書く</button>
+          </div>
+        </div>
+        <!-- Question add modal -->
+        <div id="jar-modal-overlay" class="jar-modal-overlay" style="display:none;">
+          <div class="jar-modal">
+            <div class="jar-modal-title">新しい問いを追加する</div>
+            <textarea id="jar-modal-input" class="jar-modal-input" placeholder="ここに問いを入力してください…" maxlength="80" rows="3"></textarea>
+            <div class="jar-modal-actions">
+              <button id="jar-modal-cancel" class="jar-modal-btn jar-modal-cancel">キャンセル</button>
+              <button id="jar-modal-save" class="jar-modal-btn jar-modal-save">保存</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Edit/Archive Question Modal -->
+        <div id="jar-edit-modal-overlay" class="jar-modal-overlay" style="display:none;">
+          <div class="jar-modal">
+            <div class="jar-modal-title">問いを編集する</div>
+            <textarea id="jar-edit-modal-input" class="jar-modal-input" placeholder="問いの文言を編集…" maxlength="64" rows="3"></textarea>
+            <div id="jar-edit-char-count" style="text-align:right;font-size:10px;color:var(--date-color);margin-top:4px;">0/64</div>
+            <div class="jar-modal-actions" style="justify-content:space-between;">
+              <button id="jar-edit-modal-archive" class="jar-modal-btn jar-modal-archive">アーカイブ</button>
+              <div style="display:flex;gap:10px;">
+                <button id="jar-edit-modal-cancel" class="jar-modal-btn jar-modal-cancel">キャンセル</button>
+                <button id="jar-edit-modal-save" class="jar-modal-btn jar-modal-save">保存</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===== JAR V2 VIEW (new design) ===== -->
+      <div id="view-jar2" class="view-container">
+        <!-- Background layers -->
+        <div class="j2-bg-grid"></div>
+        <div class="j2-bg-radial"></div>
+        <!-- SVG layer for connection lines (jar → circle centers) -->
+        <svg id="j2-connection-lines" class="j2-connection-svg"></svg>
+        <!-- Central jar (SVG) -->
+        <div id="j2-bottle-container"></div>
+        <!-- Zoom backdrop -->
+        <div id="j2-zoom-backdrop" class="j2-zoom-backdrop"></div>
+        <!-- Circular graphics for questions -->
+        <div id="j2-circles-container"></div>
+        <!-- Question list below jar -->
+        <div id="j2-question-list" class="j2-question-list">
+          <div class="j2-question-list-divider"></div>
+          <div class="j2-question-list-label">現在の問い</div>
+          <div id="j2-question-items" class="j2-question-items"></div>
+          <button id="j2-add-question-btn" class="j2-add-question">＋ 問いを追加する</button>
+        </div>
+        <!-- Right detail pane -->
+        <div id="j2-detail-pane" class="j2-detail-pane">
+          <button id="j2-detail-close" class="j2-detail-close">&times;</button>
+          <div id="j2-detail-question" class="j2-detail-question"></div>
+          <div id="j2-detail-header" class="j2-detail-header"></div>
+          <div id="j2-detail-body" class="j2-detail-body"></div>
+          <div class="j2-detail-footer">
+            <button id="j2-detail-write-btn" class="j2-detail-write-btn">この問いのエントリを書く</button>
+          </div>
+        </div>
+        <!-- Question add modal -->
+        <div id="j2-modal-overlay" class="j2-modal-overlay" style="display:none;">
+          <div class="j2-modal">
+            <div class="j2-modal-title">新しい問いを追加する</div>
+            <textarea id="j2-modal-input" class="j2-modal-input" placeholder="ここに問いを入力してください…" maxlength="80" rows="3"></textarea>
+            <div class="j2-modal-actions">
+              <button id="j2-modal-cancel" class="j2-modal-btn j2-modal-cancel">キャンセル</button>
+              <button id="j2-modal-save" class="j2-modal-btn j2-modal-save">保存</button>
+            </div>
+          </div>
+        </div>
+        <!-- Edit/Archive Question Modal -->
+        <div id="j2-edit-modal-overlay" class="j2-modal-overlay" style="display:none;">
+          <div class="j2-modal">
+            <div class="j2-modal-title">問いを編集する</div>
+            <textarea id="j2-edit-modal-input" class="j2-modal-input" placeholder="問いの文言を編集…" maxlength="64" rows="3"></textarea>
+            <div id="j2-edit-char-count" style="text-align:right;font-size:10px;color:var(--date-color);margin-top:4px;">0/64</div>
+            <div class="j2-modal-actions" style="justify-content:space-between;">
+              <button id="j2-edit-modal-archive" class="j2-modal-btn j2-modal-archive">アーカイブ</button>
+              <div style="display:flex;gap:10px;">
+                <button id="j2-edit-modal-cancel" class="j2-modal-btn j2-modal-cancel">キャンセル</button>
+                <button id="j2-edit-modal-save" class="j2-modal-btn j2-modal-save">保存</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===== QUESTIONS TIMELINE VIEW ===== -->
+      <div id="view-timeline" class="view-container">
+        <div class="timeline-page">
+          <div class="timeline-header">
+            <h2 class="timeline-title">問いの変遷</h2>
+            <p class="timeline-subtitle">あなたの問いが生まれ、育ち、変化してきた記録</p>
+          </div>
+          <div id="timeline-content" class="timeline-content">
+            <!-- Timeline rendered by JS -->
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- (Tsukekomi overlay removed) -->
+
+    <!-- Footer -->
+    <footer id="app-footer">
+      <div class="footer-left">
+        <div class="footer-item" id="footer-save-indicator">
+          <div class="footer-dot" id="footer-save-dot"></div>
+          <span id="footer-mode">Board</span>
+        </div>
+      </div>
+      <div style="flex:1;display:flex;justify-content:center;">
+        <div class="footer-progress"><div class="footer-progress-bar" id="footer-progress-bar"></div></div>
+      </div>
+      <div class="footer-right">
+        <span class="footer-item" id="footer-stats"></span>
+      </div>
+    </footer>
+  </main>
+
+  <!-- ===== Settings Drawer ===== -->
+  <div id="settings-overlay"></div>
+  <div id="settings-drawer">
+    <h2>Settings</h2>
+    <div class="settings-section">
+      <div class="settings-label">基本設定</div>
+      <div style="padding:4px 0;">
+        <div class="slider-row">
+          <label>文字サイズ</label>
+          <input type="range" id="font-size-slider" min="14" max="48" value="32" />
+          <span class="slider-val" id="font-size-value">32px</span>
+        </div>
+      </div>
+    </div>
+    <div class="settings-section">
+      <div class="settings-label">エフェクト</div>
+      <div class="settings-toggle">
+        <label for="toggle-time-inscription">時間内包</label>
+        <input type="checkbox" id="toggle-time-inscription" checked />
+      </div>
+      <div class="sub-options open" id="ti-sub-options">
+        <label><input type="radio" name="ti-mode" value="fontSize" checked /> 文字サイズ</label>
+        <label><input type="radio" name="ti-mode" value="fontWeight" /> 文字太さ</label>
+        <label><input type="radio" name="ti-mode" value="pressureBleed" /> 圧力にじみ</label>
+      </div>
+      <div class="settings-toggle">
+        <label for="toggle-eraser-trace">消し跡</label>
+        <input type="checkbox" id="toggle-eraser-trace" />
+      </div>
+      <div class="settings-toggle">
+        <label for="toggle-amp">打鍵音増幅（ASMR）</label>
+        <input type="checkbox" id="toggle-amp" />
+      </div>
+      <div class="settings-toggle">
+        <label for="toggle-voice">音量内包</label>
+        <input type="checkbox" id="toggle-voice" />
+      </div>
+      <div class="settings-toggle">
+        <label for="toggle-ghost">ゴースト</label>
+        <input type="checkbox" id="toggle-ghost" />
+      </div>
+      <div class="sub-options" id="ghost-sub-options">
+        <label><input type="radio" name="ghost-mode" value="block" checked /> 塊（コミット時）</label>
+        <label><input type="radio" name="ghost-mode" value="dust" /> 塵（キー毎）</label>
+        <div class="slider-row"><label>サイズ</label><input type="range" id="ghost-size-slider" min="20" max="200" value="100" /><span class="slider-val" id="ghost-size-value">100%</span></div>
+        <div class="slider-row"><label>散乱</label><input type="range" id="ghost-scatter-slider" min="0" max="100" value="30" /><span class="slider-val" id="ghost-scatter-value">30%</span></div>
+        <div class="slider-row"><label>初期ブラー</label><input type="range" id="ghost-blur-start-slider" min="0" max="20" step="0.5" value="4" /><span class="slider-val" id="ghost-blur-start-value">4.0px</span></div>
+        <div class="slider-row"><label>最終ブラー</label><input type="range" id="ghost-blur-end-slider" min="2" max="40" step="0.5" value="14" /><span class="slider-val" id="ghost-blur-end-value">14px</span></div>
+        <div class="slider-row"><label>持続時間</label><input type="range" id="ghost-duration-slider" min="30" max="250" value="100" /><span class="slider-val" id="ghost-duration-value">100%</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== Dialogs ===== -->
+  <div class="dialog-overlay" id="save-title-dialog">
+    <div class="dialog-box" style="min-width:320px;">
+      <p>タイトルを入力してください</p>
+      <input type="text" id="save-title-input" placeholder="無題" />
+      <div class="dialog-actions">
+        <button id="save-title-cancel">キャンセル</button>
+        <button id="save-title-ok" class="primary">保存</button>
+      </div>
+    </div>
+  </div>
+  <div class="dialog-overlay" id="unsaved-dialog">
+    <div class="dialog-box" style="min-width:320px;">
+      <p>変更が保存されていません。</p>
+      <div class="dialog-actions">
+        <button id="unsaved-cancel">キャンセル</button>
+        <button id="unsaved-discard">破棄</button>
+        <button id="unsaved-save" class="primary">保存</button>
+      </div>
+    </div>
+  </div>
+  <div class="dialog-overlay" id="open-dialog">
+    <div class="dialog-box">
+      <h3>保存済みエントリー</h3>
+      <div id="entry-list"></div>
+      <div class="dialog-close"><button id="open-dialog-close">閉じる</button></div>
+    </div>
+  </div>
+  <div id="stats-overlay"></div>
+  <div id="stats-dialog"></div>
+  <div id="photo-upload-dialog">
+    <div class="photo-upload-box">
+      <h3>写真を追加</h3>
+      <div class="photo-preview-area" id="photo-preview-area">
+        <img id="photo-preview-img" />
+        <span class="placeholder-text">クリックして写真を選択</span>
+      </div>
+      <input type="file" id="photo-file-input" accept="image/*" style="display:none;" />
+      <input type="text" class="photo-caption-input" id="photo-caption-input" placeholder="キャプション（20文字以内）" maxlength="20" />
+      <div class="dialog-actions" style="justify-content:center;">
+        <button id="photo-upload-cancel">キャンセル</button>
+        <button id="photo-upload-ok" class="primary">追加</button>
+      </div>
+    </div>
+  </div>
+  <div id="snippet-create-dialog">
+    <div class="snippet-create-box">
+      <h3>スニペットを作成</h3>
+      <textarea class="snippet-textarea" id="snippet-textarea" maxlength="50" placeholder="テキストを入力…"></textarea>
+      <div class="snippet-char-count"><span id="snippet-char-count">0</span>/50</div>
+      <div class="dialog-actions" style="justify-content:center;">
+        <button id="snippet-create-cancel">キャンセル</button>
+        <button id="snippet-create-ok" class="primary">作成</button>
+      </div>
+    </div>
+  </div>
+  <div id="lightbox-overlay">
+    <button id="lightbox-close">✕</button>
+    <img id="lightbox-img" />
+    <div id="lightbox-caption"></div>
+  </div>
+<script>
+// =============================================================================
+// Oryzae — Board + List + Editor (β)
+// =============================================================================
+
+// ─── core/state ─────────────────────────────────────────────────────────────
+const State = (() => {
+  // Keys that should be persisted to localStorage
+  const PERSIST_KEYS = new Set([
+    'writingMode', 'font', 'darkMode', 'userFontSize',
+    'timeInscriptionEnabled', 'timeInscriptionMode',
+    'eraserTraceEnabled', 'ghostEnabled', 'ghostMode',
+    'ghostSize', 'ghostScatter', 'ghostBlurStart', 'ghostBlurEnd', 'ghostDuration',
+  ]);
+  const LS_PREFIX = 'oryzae_pref_';
+
+  // Load persisted values
+  function loadPersisted(defaults) {
+    for (const k of PERSIST_KEYS) {
+      try {
+        const raw = localStorage.getItem(LS_PREFIX + k);
+        if (raw !== null) {
+          const v = JSON.parse(raw);
+          if (v !== undefined && v !== null) defaults[k] = v;
+        }
+      } catch (e) { /* ignore parse errors */ }
+    }
+  }
+
+  const s = {
+    currentEntryId: null,
+    currentTitle: '',
+    writingMode: 'vertical',
+    font: 'serif',
+    darkMode: false,
+    isDirty: false,
+    isComposing: false,
+    userFontSize: 32,
+    timeInscriptionEnabled: false,
+    timeInscriptionMode: 'fontSize',
+    eraserTraceEnabled: false,
+    ampEnabled: false,
+    voiceEnabled: false,
+    ghostEnabled: false,
+    ghostMode: 'block',
+    ghostSize: 100,
+    ghostScatter: 30,
+    ghostBlurStart: 4,
+    ghostBlurEnd: 14,
+    ghostDuration: 100,
+    openedAt: null,
+    // Metadata tracking
+    totalOpenTime: 0,
+    activeTypingTime: 0,
+    lastHeartbeatSecond: -1,
+    peakWPM: 0,
+    slowestWPM: Infinity,
+    averageWPMSum: 0,
+    averageWPMCount: 0,
+    recentCharTimestamps: [],
+    deletedBlocks: [],
+    totalDeletedCharCount: 0,
+    pendingDeleteBuffer: '',
+    // Navigation
+    currentScreen: 'board',
+    boardDateKey: '',
+    boardViewType: 'daily',
+  };
+  loadPersisted(s);
+
+  const L = new Map();
+  return {
+    get(k) { return s[k]; },
+    set(k, v) {
+      if (s[k] === v) return;
+      s[k] = v;
+      // Auto-persist editor preferences
+      if (PERSIST_KEYS.has(k)) {
+        try { localStorage.setItem(LS_PREFIX + k, JSON.stringify(v)); } catch (e) {}
+      }
+      const fs = L.get(k);
+      if (fs) fs.forEach(f => f(v));
+    },
+    on(k, f) { if (!L.has(k)) L.set(k, new Set()); L.get(k).add(f); },
+    snapshot() { return { ...s }; },
+  };
+})();
+
+// ─── date/utils ─────────────────────────────────────────────────────────────
+const DateUtils = (() => {
+  const DAYS_JP = ['日','月','火','水','木','金','土'];
+  function getTodayKey() {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+  }
+  function getWeekKey(dateStr) {
+    const d = new Date(dateStr + 'T00:00:00');
+    const jan1 = new Date(d.getFullYear(), 0, 1);
+    const days = Math.floor((d - jan1) / 86400000);
+    const week = Math.ceil((days + jan1.getDay() + 1) / 7);
+    return `${d.getFullYear()}-W${String(week).padStart(2,'0')}`;
+  }
+  function formatDisplayDate(dateKey) {
+    if (dateKey.includes('W')) {
+      const [y, w] = dateKey.split('-W');
+      return `${y}年 第${parseInt(w)}週`;
+    }
+    const d = new Date(dateKey + 'T00:00:00');
+    const dayName = DAYS_JP[d.getDay()];
+    return `${d.getFullYear()}.${String(d.getMonth()+1).padStart(2,'0')}.${String(d.getDate()).padStart(2,'0')} — ${dayName}曜日`;
+  }
+  function shiftDate(dateKey, delta) {
+    const d = new Date(dateKey + 'T00:00:00');
+    d.setDate(d.getDate() + delta);
+    return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+  }
+  function getWeekDates(dateKey) {
+    const d = new Date(dateKey + 'T00:00:00');
+    const day = d.getDay();
+    const monday = new Date(d);
+    monday.setDate(d.getDate() - ((day + 6) % 7));
+    const dates = [];
+    for (let i = 0; i < 7; i++) {
+      const dd = new Date(monday);
+      dd.setDate(monday.getDate() + i);
+      dates.push(`${dd.getFullYear()}-${String(dd.getMonth()+1).padStart(2,'0')}-${String(dd.getDate()).padStart(2,'0')}`);
+    }
+    return dates;
+  }
+  function isSameDay(isoStr, dateKey) {
+    if (!isoStr) return false;
+    return isoStr.slice(0, 10) === dateKey;
+  }
+  function getMonthLabel(isoStr) {
+    const d = new Date(isoStr);
+    return `${d.getFullYear()}年${d.getMonth()+1}月`;
+  }
+  function getWeekLabel(isoStr) {
+    const wk = getWeekKey(isoStr.slice(0, 10));
+    const [, w] = wk.split('-W');
+    return `第${parseInt(w)}週`;
+  }
+  return { getTodayKey, getWeekKey, formatDisplayDate, shiftDate, getWeekDates, isSameDay, getMonthLabel, getWeekLabel };
+})();
+
+// ─── storage/indexeddb ──────────────────────────────────────────────────────
+const Storage = (() => {
+  const DB = 'oryzae_board', VER = 2;
+  const STORES = { entries: 'entries', snippets: 'snippets', photos: 'photos', boards: 'boards' };
+  let _db = null;
+  async function db() {
+    if (_db) return _db;
+    return new Promise((res, rej) => {
+      const r = indexedDB.open(DB, VER);
+      r.onupgradeneeded = e => {
+        const d = e.target.result;
+        if (!d.objectStoreNames.contains('entries')) {
+          const st = d.createObjectStore('entries', { keyPath: 'id' });
+          st.createIndex('updatedAt', 'updatedAt');
+        }
+        if (!d.objectStoreNames.contains('snippets')) {
+          const st = d.createObjectStore('snippets', { keyPath: 'id' });
+          st.createIndex('createdAt', 'createdAt');
+        }
+        if (!d.objectStoreNames.contains('photos')) {
+          const st = d.createObjectStore('photos', { keyPath: 'id' });
+          st.createIndex('createdAt', 'createdAt');
+        }
+        if (!d.objectStoreNames.contains('boards')) {
+          const st = d.createObjectStore('boards', { keyPath: 'id' });
+          st.createIndex('dateKey', 'dateKey');
+        }
+      };
+      r.onsuccess = () => { _db = r.result; res(_db); };
+      r.onerror = () => rej(r.error);
+    });
+  }
+  function crud(storeName) {
+    return {
+      async save(obj) {
+        const d = await db();
+        return new Promise((res, rej) => {
+          const tx = d.transaction(storeName, 'readwrite');
+          tx.objectStore(storeName).put(obj);
+          tx.oncomplete = () => res();
+          tx.onerror = () => rej(tx.error);
+        });
+      },
+      async load(id) {
+        const d = await db();
+        return new Promise((res, rej) => {
+          const tx = d.transaction(storeName, 'readonly');
+          const rq = tx.objectStore(storeName).get(id);
+          rq.onsuccess = () => res(rq.result);
+          rq.onerror = () => rej(rq.error);
+        });
+      },
+      async remove(id) {
+        const d = await db();
+        return new Promise((res, rej) => {
+          const tx = d.transaction(storeName, 'readwrite');
+          tx.objectStore(storeName).delete(id);
+          tx.oncomplete = () => res();
+          tx.onerror = () => rej(tx.error);
+        });
+      },
+      async listAll() {
+        const d = await db();
+        return new Promise((res, rej) => {
+          const tx = d.transaction(storeName, 'readonly');
+          const rq = tx.objectStore(storeName).getAll();
+          rq.onsuccess = () => res(rq.result || []);
+          rq.onerror = () => rej(rq.error);
+        });
+      },
+    };
+  }
+  const entryCrud = crud('entries');
+  const snippetCrud = crud('snippets');
+  const photoCrud = crud('photos');
+  const boardCrud = crud('boards');
+  return {
+    // Entries (sorted by updatedAt desc)
+    async save(entry) { return entryCrud.save(entry); },
+    async load(id) { return entryCrud.load(id); },
+    async listAll() {
+      const d = await db();
+      return new Promise((res, rej) => {
+        const tx = d.transaction('entries', 'readonly');
+        const rq = tx.objectStore('entries').index('updatedAt').openCursor(null, 'prev');
+        const out = [];
+        rq.onsuccess = e => { const c = e.target.result; if (c) { out.push(c.value); c.continue(); } else res(out); };
+        rq.onerror = () => rej(rq.error);
+      });
+    },
+    // Snippets
+    saveSnippet: snippetCrud.save,
+    loadSnippet: snippetCrud.load,
+    removeSnippet: snippetCrud.remove,
+    listSnippets: snippetCrud.listAll,
+    listAllSnippets: snippetCrud.listAll,
+    // Photos
+    savePhoto: photoCrud.save,
+    loadPhoto: photoCrud.load,
+    removePhoto: photoCrud.remove,
+    listPhotos: photoCrud.listAll,
+    listAllPhotos: photoCrud.listAll,
+    // Boards
+    saveBoard: boardCrud.save,
+    async loadBoard(dateKey, viewType) {
+      const all = await boardCrud.listAll();
+      return all.find(b => b.dateKey === dateKey && b.viewType === viewType) || null;
+    },
+    listBoards: boardCrud.listAll,
+  };
+})();
+// ─── editor/layout ──────────────────────────────────────────────────────────
+const Layout = (() => {
+  const wrapper = document.getElementById('editor-wrapper');
+  const editorEl = document.getElementById('editor');
+  const canvas = document.getElementById('trace-canvas');
+  const dateEl = document.getElementById('date-display');
+  let _fontSize = 40;
+
+  function calc() {
+    const viewEl = document.getElementById('view-editor');
+    const w = viewEl.clientWidth || window.innerWidth, h = viewEl.clientHeight || window.innerHeight;
+    _fontSize = State.get('userFontSize') || 32;
+    const lh = _fontSize * 1.85;
+    const mLR = w * 0.15, mT = h * 0.10, mB = h * 0.16;
+    const ew = w - mLR * 2, eh = h - mT - mB;
+
+    wrapper.style.cssText = `position:absolute;left:${mLR}px;top:${mT}px;width:${ew}px;height:${eh}px;`;
+    editorEl.style.fontSize = _fontSize + 'px';
+    editorEl.style.lineHeight = '1.85';
+
+    // Title display: 80% of body text size
+    const titleEl = document.getElementById('editor-title-display');
+    if (titleEl) titleEl.style.fontSize = (_fontSize * 0.8) + 'px';
+
+    // Canvas sizing (high-DPI)
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = ew * dpr;
+    canvas.height = eh * dpr;
+    canvas.style.width = ew + 'px';
+    canvas.style.height = eh + 'px';
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    // Date display is now always at top center via CSS (no dynamic repositioning needed)
+
+    EraserTrace.requestRedraw();
+  }
+
+  return { calc, get fontSize() { return _fontSize; } };
+})();
+
+// ─── effect/time-inscription ────────────────────────────────────────────────
+const TimeInscription = (() => {
+  let enabled = false;
+  let mode = 'fontSize';
+  let compStartTime = null;
+  let directBuffer = [];
+  let directTimer = null;
+  const editorEl = document.getElementById('editor');
+
+  function calcT(ms) {
+    const sec = ms / 1000;
+    return Math.max(0, Math.min(1, Math.log2(1 + sec) / Math.log2(16)));
+  }
+
+  const FS_MIN = 0.80, FS_MAX = 1.35;
+  function applyFontSize(span, t) {
+    const scale = FS_MIN + (FS_MAX - FS_MIN) * t;
+    span.style.fontSize = (Layout.fontSize * scale).toFixed(1) + 'px';
+    span.style.fontWeight = '400';
+  }
+
+  const FW_MIN = 300, FW_MAX = 700;
+  function applyFontWeight(span, t) {
+    const w = Math.round(FW_MIN + (FW_MAX - FW_MIN) * t);
+    span.style.fontWeight = w;
+    span.style.fontSize = Layout.fontSize + 'px';
+  }
+
+  function applyStyle(span, t) {
+    if (mode === 'fontWeight') applyFontWeight(span, t);
+    else applyFontSize(span, t);
+  }
+
+  function wrapText(text, t, durationMs) {
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    const node = range.startContainer;
+    const offset = range.startOffset;
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const full = node.textContent;
+      const end = offset;
+      const start = end - text.length;
+      if (start < 0 || full.substring(start, end) !== text) return;
+
+      const before = full.substring(0, start);
+      const after = full.substring(end);
+      const span = createEBlock(text, t, durationMs);
+
+      const parent = node.parentNode;
+      const frag = document.createDocumentFragment();
+      if (before) frag.appendChild(document.createTextNode(before));
+      frag.appendChild(span);
+      if (after) frag.appendChild(document.createTextNode(after));
+      parent.replaceChild(frag, node);
+
+      const newRange = document.createRange();
+      if (after) newRange.setStart(span.nextSibling, 0);
+      else newRange.setStartAfter(span);
+      newRange.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(newRange);
+      return;
+    }
+
+    if (node.nodeType === Node.ELEMENT_NODE && offset > 0) {
+      const prev = node.childNodes[offset - 1];
+      if (prev && prev.nodeType === Node.TEXT_NODE) {
+        const full = prev.textContent;
+        if (full.endsWith(text)) {
+          const before = full.substring(0, full.length - text.length);
+          const span = createEBlock(text, t, durationMs);
+          if (before) {
+            prev.textContent = before;
+            node.insertBefore(span, prev.nextSibling);
+          } else {
+            node.replaceChild(span, prev);
+          }
+          const newRange = document.createRange();
+          newRange.setStartAfter(span);
+          newRange.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(newRange);
+        }
+      }
+    }
+  }
+
+  function createEBlock(text, t, durationMs) {
+    const span = document.createElement('span');
+    span.className = 'eblock';
+    span.dataset.t = t.toFixed(4);
+    span.dataset.duration = durationMs;
+    span.dataset.mode = mode;
+    span.textContent = text;
+    applyStyle(span, t);
+    return span;
+  }
+
+  function refreshAllEBlocks() {
+    editorEl.querySelectorAll('.eblock').forEach(span => {
+      // Only refresh spans that belong to TimeInscription (fontSize/fontWeight)
+      if (span.dataset.mode === 'pressureBleed') return;
+      const t = parseFloat(span.dataset.t);
+      if (!isNaN(t)) applyStyle(span, t);
+    });
+  }
+
+  function flushDirect() {
+    if (directBuffer.length === 0) return;
+    const chars = directBuffer;
+    directBuffer = [];
+    clearTimeout(directTimer);
+    directTimer = null;
+
+    const text = chars.map(c => c.char).join('');
+    const duration = chars.length > 1
+      ? chars[chars.length - 1].time - chars[0].time
+      : 200;
+    const t = calcT(Math.max(duration, 150));
+    requestAnimationFrame(() => wrapText(text, t, duration));
+  }
+
+  function onCompositionStart() {
+    if (!enabled || mode === 'pressureBleed') return;
+    flushDirect();
+    compStartTime = Date.now();
+  }
+
+  function onCompositionEnd(e) {
+    if (!enabled || mode === 'pressureBleed' || compStartTime == null) { compStartTime = null; return; }
+    const duration = Date.now() - compStartTime;
+    const text = e.data;
+    compStartTime = null;
+    if (!text) return;
+    const t = calcT(duration);
+    requestAnimationFrame(() => wrapText(text, t, duration));
+  }
+
+  function onInput(e) {
+    if (!enabled || mode === 'pressureBleed') return;
+    if (State.get('isComposing')) return;
+    if (e.inputType === 'insertText' && e.data) {
+      directBuffer.push({ char: e.data, time: Date.now() });
+      clearTimeout(directTimer);
+      directTimer = setTimeout(flushDirect, 350);
+    }
+    if (e.inputType === 'insertParagraph' || e.inputType === 'insertLineBreak') {
+      flushDirect();
+    }
+  }
+
+  function onBeforeInput(e) {
+    if (!enabled || mode === 'pressureBleed') return;
+    if (e.inputType && e.inputType.startsWith('delete')) {
+      flushDirect();
+    }
+  }
+
+  function init() {
+    editorEl.addEventListener('compositionstart', onCompositionStart);
+    editorEl.addEventListener('compositionend', onCompositionEnd);
+    editorEl.addEventListener('input', onInput);
+    editorEl.addEventListener('beforeinput', onBeforeInput);
+  }
+
+  return {
+    init,
+    setEnabled(v) { enabled = v; },
+    setMode(m) { mode = m; },
+    flushDirect,
+    refreshAllEBlocks,
+    calcT,
+  };
+})();
+
+// ─── effect/pressure-bleed (faithfully from index_pressure_hybrid.html) ─────
+const PressureBleed = (() => {
+  let enabled = false;
+  const editorEl = document.getElementById('editor');
+
+  const HOLD_THRESHOLD_MS = 100;
+  const PAUSE_THRESHOLD_MS = 150;
+
+  function seededRng(seed) {
+    let s = seed | 0;
+    return () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
+  }
+
+  function calcIntensity(ms, threshold) {
+    const BASE_INTENSITY = 0.18;
+    const MAX_ADDED = 0.60;
+    if (ms <= threshold) return BASE_INTENSITY;
+    const effective = ms - threshold;
+    const added = Math.min(MAX_ADDED, effective / 800);
+    return BASE_INTENSITY + added;
+  }
+
+  // B: IMEタメ記録用
+  let imePauseLog = [];
+  let lastImeInteractionTime = 0;
+
+  // A: 物理キーの長押し＆トラップ用
+  let activePhysicalKeys = new Map();
+  let activeHoldCode = null;
+  let activeHoldStart = 0;
+  let activePBlock = null;
+  let trapEl = null;
+  let savedRange = null;
+  let editorRangeBeforeTrap = null;
+
+  // A: 直接入力の遅延処理用
+  let directKeyDown = null;
+  let directLastChar = null;
+
+  // ── フォーカストラップ（IME強制確定ハック） ──
+  function activateTrap() {
+    if (trapEl) return;
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount > 0) {
+      editorRangeBeforeTrap = sel.getRangeAt(0).cloneRange();
+    }
+    trapEl = document.createElement('textarea');
+    trapEl.style.cssText = 'position:fixed; top:-9999px; left:-9999px; width:1px; height:1px; opacity:0; pointer-events:none;';
+    trapEl.tabIndex = -1;
+    document.body.appendChild(trapEl);
+    trapEl.focus();
+  }
+
+  function releaseTrap() {
+    if (!trapEl) return;
+    trapEl.remove();
+    trapEl = null;
+    editorRangeBeforeTrap = null;
+    editorEl.focus();
+    if (savedRange) {
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(savedRange);
+      savedRange = null;
+    }
+  }
+
+  // ── リアルタイム滲みループ ──
+  function updateLiveBleed() {
+    if (!activePBlock || !activeHoldCode) return;
+    const holdMs = Date.now() - activeHoldStart;
+    const intensity = calcIntensity(holdMs, HOLD_THRESHOLD_MS);
+    activePBlock.dataset.intensity = intensity.toFixed(4);
+    applyBleedStyle(activePBlock);
+    if (activeHoldCode) requestAnimationFrame(updateLiveBleed);
+  }
+
+  // ── シャドウ生成 ──
+  function generateBleedShadow(intensity, seed) {
+    if (intensity < 0.01) return 'none';
+    const rng = seededRng(seed);
+    const dark = State.get('darkMode');
+    const biasAngle = rng() * Math.PI * 2;
+    const biasDx = Math.cos(biasAngle);
+    const biasDy = Math.sin(biasAngle);
+    const numLayers = Math.floor(4 + intensity * 10);
+    const shadows = [];
+
+    for (let i = 0; i < numLayers; i++) {
+      const angle = rng() * Math.PI * 2;
+      const dist  = rng() * intensity * 1.0;
+      const ox = dist * Math.cos(angle) + biasDx * intensity * 0.3 * rng();
+      const oy = dist * Math.sin(angle) + biasDy * intensity * 0.3 * rng();
+      const blur = 0.2 + rng() * rng() * intensity * 2.5;
+      let r, g, b;
+      if (dark) { const v = 180 + Math.floor(rng() * 40); r = g = b = v; }
+      else { r = 40 + Math.floor(rng() * 30); g = 30 + Math.floor(rng() * 25); b = 20 + Math.floor(rng() * 20); }
+      const alpha = (0.02 + rng() * intensity * 0.15).toFixed(3);
+      shadows.push(`${ox.toFixed(2)}px ${oy.toFixed(2)}px ${blur.toFixed(1)}px rgba(${r},${g},${b},${alpha})`);
+    }
+    if (intensity > 0.4) {
+      const poolBlur = (2 + intensity * 4).toFixed(1);
+      const poolAlpha = ((intensity - 0.4) * 0.15).toFixed(3);
+      const poolOx = (biasDx * intensity * 0.2).toFixed(2);
+      const poolOy = (biasDy * intensity * 0.2).toFixed(2);
+      const pc = dark ? '180,180,180' : '50,40,30';
+      shadows.push(`${poolOx}px ${poolOy}px ${poolBlur}px rgba(${pc},${poolAlpha})`);
+    }
+    if (intensity > 0.5) {
+      const splats = Math.floor((intensity - 0.5) * 6);
+      for (let i = 0; i < splats; i++) {
+        const a = rng() * Math.PI * 2;
+        const d = 0.4 + rng() * intensity * 1.5;
+        const sx = (d * Math.cos(a)).toFixed(2);
+        const sy = (d * Math.sin(a)).toFixed(2);
+        const sc = dark ? '200,200,200' : '30,25,15';
+        const sa = (0.05 + rng() * 0.1).toFixed(3);
+        shadows.push(`${sx}px ${sy}px 0.5px rgba(${sc},${sa})`);
+      }
+    }
+    return shadows.join(', ');
+  }
+
+  function applyBleedStyle(span) {
+    const intensity = parseFloat(span.dataset.intensity) || 0;
+    const seed = parseInt(span.dataset.seed) || 0;
+    if (intensity < 0.01) {
+      span.style.textShadow = 'none';
+      span.style.filter = 'none';
+      span.style.letterSpacing = 'normal';
+      return;
+    }
+    span.style.textShadow = generateBleedShadow(intensity, seed);
+    const rng = seededRng(seed + 7777);
+    const filterBlur = intensity * (0.10 + rng() * 0.15);
+    span.style.filter = filterBlur > 0.05 ? `blur(${filterBlur.toFixed(2)}px)` : 'none';
+    const ls = intensity * 0.020;
+    span.style.letterSpacing = ls > 0.005 ? `${ls.toFixed(3)}em` : 'normal';
+  }
+
+  function refreshAllPBlocks() {
+    editorEl.querySelectorAll('.eblock').forEach(span => {
+      if (span.dataset.intensity) applyBleedStyle(span);
+    });
+  }
+
+  // ── B: 思考のタメ時間を確定文字にマッピング ──
+  function mapPausesToCharPressures(pauseLog, charCount) {
+    if (pauseLog.length === 0 || charCount === 0) return new Array(charCount).fill(0);
+    const maxHolds = new Array(charCount).fill(0);
+    for (let i = 0; i < pauseLog.length; i++) {
+      const ratio = i / Math.max(1, pauseLog.length - 1);
+      const idx = Math.min(Math.floor(ratio * charCount), charCount - 1);
+      maxHolds[idx] = Math.max(maxHolds[idx], pauseLog[i].pauseMs);
+    }
+    return maxHolds;
+  }
+
+  // ── DOMに滲みスパンを適用 ──
+  function wrapCommittedText(text, charMsArray, isLiveDirect, threshold) {
+    let range;
+    if (trapEl && editorRangeBeforeTrap) {
+      range = editorRangeBeforeTrap;
+    } else {
+      const sel = window.getSelection();
+      if (!sel || !sel.rangeCount) return;
+      range = sel.getRangeAt(0);
+    }
+
+    let node = range.startContainer;
+    let offset = range.startOffset;
+    let targetNode = null, targetEnd = -1;
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const full = node.textContent;
+      const end = offset;
+      const start = end - text.length;
+      if (start >= 0 && full.substring(start, end) === text) {
+        targetNode = node;
+        targetEnd = end;
+      }
+    } else if (node.nodeType === Node.ELEMENT_NODE && offset > 0) {
+      const prev = node.childNodes[offset - 1];
+      if (prev && prev.nodeType === Node.TEXT_NODE && prev.textContent.endsWith(text)) {
+        targetNode = prev;
+        targetEnd = prev.textContent.length;
+      }
+    }
+
+    if (!targetNode) return;
+
+    const full = targetNode.textContent;
+    const textStart = targetEnd - text.length;
+    const before = full.substring(0, textStart);
+    const after = full.substring(targetEnd);
+    const frag = document.createDocumentFragment();
+    if (before) frag.appendChild(document.createTextNode(before));
+
+    let plainBuf = '';
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i];
+      const ms = charMsArray[i] || 0;
+      const intensity = calcIntensity(ms, threshold);
+      const isLastChar = (i === text.length - 1);
+
+      if (intensity > 0.01 || (isLastChar && activeHoldCode) || isLiveDirect) {
+        if (plainBuf) { frag.appendChild(document.createTextNode(plainBuf)); plainBuf = ''; }
+        const span = document.createElement('span');
+        span.className = 'eblock';
+        span.dataset.intensity = intensity.toFixed(4);
+        span.dataset.seed = Math.floor(Math.random() * 99999);
+        span.dataset.mode = 'pressureBleed';
+        span.textContent = ch;
+        applyBleedStyle(span);
+        frag.appendChild(span);
+
+        if (isLastChar && activeHoldCode) {
+          activePBlock = span;
+          requestAnimationFrame(updateLiveBleed);
+        }
+      } else {
+        plainBuf += ch;
+      }
+    }
+    if (plainBuf) frag.appendChild(document.createTextNode(plainBuf));
+
+    const cursorAnchor = document.createTextNode('\u200B');
+    frag.appendChild(cursorAnchor);
+    if (after) frag.appendChild(document.createTextNode(after));
+
+    targetNode.parentNode.replaceChild(frag, targetNode);
+
+    const newRange = document.createRange();
+    newRange.setStart(cursorAnchor, 1);
+    newRange.collapse(true);
+
+    if (trapEl) {
+      savedRange = newRange.cloneRange();
+    } else {
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(newRange);
+    }
+  }
+
+  function isModifier(e) {
+    return e.ctrlKey || e.metaKey || e.altKey ||
+      ['Shift', 'Control', 'Alt', 'Meta', 'CapsLock', 'Tab', 'Escape',
+       'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+       'Home', 'End', 'PageUp', 'PageDown', 'F1', 'F2', 'F3', 'F4',
+       'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12'].includes(e.key);
+  }
+
+  // ── イベント制御 ──
+  function onKeyDown(e) {
+    if (!enabled) return;
+    if (document.activeElement !== editorEl && document.activeElement !== trapEl) return;
+
+    const code = e.code || e.key;
+    const isMod = isModifier(e);
+    const isControlKey = (e.key === 'Backspace' || e.key === 'Delete' || e.key === 'Enter');
+
+    if (!isMod && !isControlKey && code) {
+      if (!activePhysicalKeys.has(code)) {
+        activePhysicalKeys.set(code, Date.now());
+      }
+    }
+
+    // 長押し（リピート）の検知
+    if (e.repeat) {
+      if (!isMod && !isControlKey) {
+        e.preventDefault();
+        activeHoldCode = code;
+        activeHoldStart = activePhysicalKeys.get(code) || Date.now();
+
+        if (State.get('isComposing')) {
+          activateTrap();
+        } else {
+          if (directLastChar && !activePBlock) {
+            const ch = directLastChar;
+            directLastChar = null;
+            directKeyDown = null;
+            requestAnimationFrame(() => wrapCommittedText(ch, [0], true, HOLD_THRESHOLD_MS));
+          }
+        }
+      }
+      return;
+    }
+
+    // 初回のキーダウン（タメの計測）
+    if (State.get('isComposing')) {
+      if (!isMod) {
+        const now = Date.now();
+        const pauseMs = now - lastImeInteractionTime;
+        imePauseLog.push({ key: e.key, pauseMs });
+        lastImeInteractionTime = now;
+      }
+    } else {
+      if (!isMod && !isControlKey) {
+        directKeyDown = { key: e.key, downAt: Date.now() };
+      }
+    }
+  }
+
+  function onKeyUp(e) {
+    if (!enabled) return;
+    const code = e.code || e.key;
+
+    if (code) {
+      activePhysicalKeys.delete(code);
+      if (code === activeHoldCode) {
+        activeHoldCode = null;
+        activePBlock = null;
+        releaseTrap();
+      }
+    }
+
+    if (directKeyDown && directKeyDown.key === e.key && directLastChar) {
+      const holdMs = Date.now() - directKeyDown.downAt;
+      const ch = directLastChar;
+      directKeyDown = null;
+      directLastChar = null;
+      requestAnimationFrame(() => wrapCommittedText(ch, [holdMs], false, HOLD_THRESHOLD_MS));
+    } else if (directKeyDown && directKeyDown.key === e.key) {
+      directKeyDown = null;
+    }
+  }
+
+  function onInput(e) {
+    if (!enabled || State.get('isComposing')) return;
+    if (e.inputType === 'insertText' && e.data && directKeyDown) {
+      directLastChar = e.data;
+    }
+  }
+
+  function onCompositionStart() {
+    if (!enabled) return;
+    imePauseLog = [];
+    lastImeInteractionTime = Date.now();
+    breakOutOfPBlock();
+  }
+
+  function onCompositionEnd(e) {
+    if (!enabled) { imePauseLog = []; return; }
+    const text = e.data;
+    if (!text) { imePauseLog = []; return; }
+
+    const now = Date.now();
+    const finalPause = now - lastImeInteractionTime;
+    imePauseLog.push({ key: 'Enter', pauseMs: finalPause });
+
+    const charMsArray = mapPausesToCharPressures(imePauseLog, text.length);
+    imePauseLog = [];
+
+    const hasBleed = charMsArray.some(ms => calcIntensity(ms, PAUSE_THRESHOLD_MS) > 0.01) || !!activeHoldCode;
+    if (hasBleed) {
+      requestAnimationFrame(() => wrapCommittedText(text, charMsArray, false, PAUSE_THRESHOLD_MS));
+    }
+  }
+
+  function breakOutOfPBlock() {
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
+    const node = sel.getRangeAt(0).startContainer;
+    const pblock = (node.nodeType === Node.TEXT_NODE ? node.parentNode : node);
+    if (pblock && pblock.classList && pblock.classList.contains('eblock') && pblock.dataset.mode === 'pressureBleed') {
+      const zws = document.createTextNode('\u200B');
+      pblock.parentNode.insertBefore(zws, pblock.nextSibling);
+      const range = document.createRange();
+      range.setStart(zws, 1);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }
+
+  function init() {
+    editorEl.addEventListener('compositionstart', onCompositionStart);
+    editorEl.addEventListener('compositionend', onCompositionEnd);
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keyup', onKeyUp, true);
+    editorEl.addEventListener('input', onInput);
+
+    window.addEventListener('blur', () => {
+      activePhysicalKeys.clear();
+      activeHoldCode = null;
+      activePBlock = null;
+      releaseTrap();
+    });
+  }
+
+  return {
+    init,
+    setEnabled(v) {
+      enabled = v;
+      if (!v) {
+        activePhysicalKeys.clear();
+        activeHoldCode = null;
+        activePBlock = null;
+        releaseTrap();
+        directKeyDown = null;
+        directLastChar = null;
+      }
+    },
+    refreshAllPBlocks,
+  };
+})();
+
+// ─── effect/eraser-trace ────────────────────────────────────────────────────
+const EraserTrace = (() => {
+  let traces = [];
+  let enabled = false;
+  let redrawQueued = false;
+  const canvas = document.getElementById('trace-canvas');
+  const editorEl = document.getElementById('editor');
+  const wrapperEl = document.getElementById('editor-wrapper');
+  const BASE = 0.07, INC = 0.04, MAX = 0.22;
+  const OVERLAP_PX = 8;
+  let pendingDel = null;
+  const smudgeCache = new Map();
+  let sentinel = null;
+
+  function ensureSentinel() {
+    if (sentinel && editorEl.contains(sentinel)) {
+      if (editorEl.firstChild !== sentinel) editorEl.insertBefore(sentinel, editorEl.firstChild);
+      return sentinel;
+    }
+    sentinel = document.createElement('span');
+    sentinel.id = '_trace_sentinel';
+    sentinel.setAttribute('contenteditable', 'false');
+    sentinel.setAttribute('data-sentinel', 'true');
+    sentinel.style.cssText = 'display:inline;font-size:0;line-height:0;width:0;height:0;overflow:hidden;padding:0;margin:0;border:0;user-select:none;pointer-events:none;';
+    sentinel.textContent = '\u200B';
+    editorEl.insertBefore(sentinel, editorEl.firstChild);
+    return sentinel;
+  }
+
+  function getSentinelRect() {
+    return ensureSentinel().getBoundingClientRect();
+  }
+
+  function charRangeBefore(sel) {
+    const r = sel.getRangeAt(0);
+    if (!r.collapsed) return r.cloneRange();
+    const node = r.startContainer, off = r.startOffset;
+    const cr = document.createRange();
+    if (node.nodeType === Node.TEXT_NODE && off > 0) {
+      cr.setStart(node, off - 1); cr.setEnd(node, off); return cr;
+    }
+    if (node.nodeType === Node.ELEMENT_NODE && off > 0) {
+      const prev = node.childNodes[off - 1];
+      if (prev && prev.nodeType === Node.TEXT_NODE && prev.textContent.length > 0) {
+        cr.setStart(prev, prev.textContent.length - 1); cr.setEnd(prev, prev.textContent.length); return cr;
+      }
+      const last = lastTextNode(prev);
+      if (last && last.textContent.length > 0) {
+        cr.setStart(last, last.textContent.length - 1); cr.setEnd(last, last.textContent.length); return cr;
+      }
+    }
+    return null;
+  }
+
+  function charRangeAfter(sel) {
+    const r = sel.getRangeAt(0);
+    if (!r.collapsed) return r.cloneRange();
+    const node = r.startContainer, off = r.startOffset;
+    const cr = document.createRange();
+    if (node.nodeType === Node.TEXT_NODE && off < node.textContent.length) {
+      cr.setStart(node, off); cr.setEnd(node, off + 1); return cr;
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const next = node.childNodes[off];
+      if (next && next.nodeType === Node.TEXT_NODE && next.textContent.length > 0) {
+        cr.setStart(next, 0); cr.setEnd(next, 1); return cr;
+      }
+      const first = firstTextNode(next);
+      if (first && first.textContent.length > 0) {
+        cr.setStart(first, 0); cr.setEnd(first, 1); return cr;
+      }
+    }
+    return null;
+  }
+
+  function lastTextNode(el) {
+    if (!el) return null;
+    if (el.nodeType === Node.TEXT_NODE) return el;
+    for (let i = el.childNodes.length - 1; i >= 0; i--) {
+      const r = lastTextNode(el.childNodes[i]); if (r) return r;
+    }
+    return null;
+  }
+  function firstTextNode(el) {
+    if (!el) return null;
+    if (el.nodeType === Node.TEXT_NODE) return el;
+    for (const ch of el.childNodes) {
+      const r = firstTextNode(ch); if (r) return r;
+    }
+    return null;
+  }
+
+  function capturePos(charRange) {
+    const rect = charRange.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return null;
+    const sr = getSentinelRect();
+    return { rx: rect.left - sr.left, ry: rect.top - sr.top, w: rect.width, h: rect.height };
+  }
+
+  function seededRng(seed) {
+    let s = seed | 0;
+    return () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
+  }
+
+  function generateSmudge(char, seed) {
+    const key = char + '_' + seed + '_' + (document.body.classList.contains('dark') ? 'd' : 'l');
+    if (smudgeCache.has(key)) return smudgeCache.get(key);
+    const fs = Layout.fontSize;
+    const pad = 6, sz = Math.ceil(fs * 1.4) + pad * 2;
+    const c = document.createElement('canvas');
+    c.width = sz; c.height = sz;
+    const cx = c.getContext('2d');
+    const ff = State.get('font') === 'serif' ? "'Noto Serif JP',serif" : "'Noto Sans JP',sans-serif";
+    const dark = document.body.classList.contains('dark');
+    cx.filter = 'blur(3px)';
+    cx.font = `${fs}px ${ff}`;
+    cx.fillStyle = dark ? 'rgba(100,100,100,1)' : 'rgba(140,140,140,1)';
+    cx.textBaseline = 'middle';
+    cx.textAlign = 'center';
+    cx.fillText(char, sz / 2, sz / 2);
+    cx.filter = 'blur(1px)';
+    const rng = seededRng(seed);
+    const n = 3 + Math.floor(rng() * 4);
+    cx.strokeStyle = dark ? 'rgba(80,80,80,0.6)' : 'rgba(160,160,160,0.6)';
+    for (let i = 0; i < n; i++) {
+      cx.lineWidth = 0.5 + rng() * 1.5;
+      cx.beginPath();
+      const sx = sz * 0.2 + rng() * sz * 0.6, sy = sz * 0.2 + rng() * sz * 0.6;
+      cx.moveTo(sx, sy);
+      cx.quadraticCurveTo(sx + (rng() - 0.5) * sz * 0.5, sy + (rng() - 0.5) * sz * 0.3,
+                           sx + (rng() - 0.5) * sz * 0.6, sy + (rng() - 0.5) * sz * 0.4);
+      cx.stroke();
+    }
+    smudgeCache.set(key, c);
+    return c;
+  }
+
+  function onBeforeInput(e) {
+    if (!enabled || State.get('isComposing')) return;
+    const tp = e.inputType;
+    if (tp !== 'deleteContentBackward' && tp !== 'deleteContentForward' && tp !== 'deleteByCut') return;
+    const sel = window.getSelection();
+    if (!sel.rangeCount) return;
+    const charRange = (tp === 'deleteContentBackward') ? charRangeBefore(sel) : charRangeAfter(sel);
+    if (!charRange) return;
+    const text = charRange.toString();
+    if (!text || text === '\n' || text === '\r\n') return;
+    const pos = capturePos(charRange);
+    if (!pos) return;
+    pendingDel = { rx: pos.rx, ry: pos.ry, w: pos.w, h: pos.h, char: text.charAt(0) };
+  }
+
+  function onInput(e) {
+    if (!enabled || State.get('isComposing')) { pendingDel = null; return; }
+    if (!pendingDel) return;
+    const del = pendingDel;
+    pendingDel = null;
+    const nearby = traces.find(t =>
+      Math.abs(t.rx - del.rx) < OVERLAP_PX && Math.abs(t.ry - del.ry) < OVERLAP_PX
+    );
+    if (nearby) {
+      nearby.chars.push(del.char);
+      nearby.intensity = Math.min(nearby.intensity + INC, MAX);
+    } else {
+      traces.push({
+        rx: del.rx, ry: del.ry, w: del.w, h: del.h,
+        chars: [del.char], intensity: BASE,
+        seed: Math.floor(Math.random() * 99999),
+      });
+    }
+    requestRedraw();
+  }
+
+  function requestRedraw() {
+    if (redrawQueued) return;
+    redrawQueued = true;
+    requestAnimationFrame(draw);
+  }
+
+  function draw() {
+    redrawQueued = false;
+    const ctx = canvas.getContext('2d');
+    const dpr = window.devicePixelRatio || 1;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const cw = canvas.width / dpr, ch = canvas.height / dpr;
+    ctx.clearRect(0, 0, cw, ch);
+    if (!enabled || traces.length === 0) return;
+
+    const fs = Layout.fontSize;
+    const sz = Math.ceil(fs * 1.4) + 12;
+    const sr = getSentinelRect();
+    const wr = wrapperEl.getBoundingClientRect();
+    const baseX = sr.left - wr.left;
+    const baseY = sr.top - wr.top;
+
+    for (const t of traces) {
+      const dx = baseX + t.rx;
+      const dy = baseY + t.ry;
+      if (dx < -sz || dy < -sz || dx > cw + sz || dy > ch + sz) continue;
+      for (const c of t.chars) {
+        const smudge = generateSmudge(c, t.seed);
+        ctx.globalAlpha = t.intensity;
+        ctx.drawImage(smudge, dx + t.w / 2 - sz / 2, dy + t.h / 2 - sz / 2, sz, sz);
+      }
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  function init() {
+    editorEl.addEventListener('beforeinput', onBeforeInput);
+    editorEl.addEventListener('input', onInput);
+    editorEl.addEventListener('scroll', requestRedraw);
+    ensureSentinel();
+  }
+
+  return {
+    init, requestRedraw, ensureSentinel,
+    setEnabled(v) {
+      enabled = v;
+      smudgeCache.clear();
+      if (v) ensureSentinel();
+      requestRedraw();
+    },
+    getTraces() { return JSON.parse(JSON.stringify(traces)); },
+    setTraces(t) { traces = t || []; smudgeCache.clear(); requestRedraw(); },
+    clear() { traces = []; smudgeCache.clear(); requestRedraw(); },
+  };
+})();
+
+// ─── effect/typing-amplifier ────────────────────────────────────────────────
+const TypingAmplifier = (() => {
+  let audioCtx = null;
+  let mediaStream = null;
+  let sourceNode = null;
+  let gainNode = null;
+  let lowCutFilter = null;
+  let highBoostFilter = null;
+  let compressor = null;
+  let analyser = null;
+  let drawVisualId = null;
+  let envelopeTimeout = null;
+
+  const debugUI = document.getElementById('audio-debugger');
+  const ampCanvas = document.getElementById('visualizer-amp');
+  const canvasCtx = ampCanvas.getContext('2d');
+
+  function drawWaveform() {
+    if (!analyser) return;
+    drawVisualId = requestAnimationFrame(drawWaveform);
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    analyser.getByteTimeDomainData(dataArray);
+    canvasCtx.fillStyle = 'rgb(0, 0, 0)';
+    canvasCtx.fillRect(0, 0, ampCanvas.width, ampCanvas.height);
+    canvasCtx.lineWidth = 2;
+    canvasCtx.strokeStyle = 'rgb(0, 255, 0)';
+    canvasCtx.beginPath();
+    const sliceWidth = ampCanvas.width / bufferLength;
+    let x = 0;
+    for (let i = 0; i < bufferLength; i++) {
+      const v = dataArray[i] / 128.0;
+      const y = v * ampCanvas.height / 2;
+      if (i === 0) canvasCtx.moveTo(x, y);
+      else canvasCtx.lineTo(x, y);
+      x += sliceWidth;
+    }
+    canvasCtx.lineTo(ampCanvas.width, ampCanvas.height / 2);
+    canvasCtx.stroke();
+  }
+
+  function triggerHit() {
+    if (!audioCtx || !gainNode) return;
+    const now = audioCtx.currentTime;
+    gainNode.gain.cancelScheduledValues(now);
+    gainNode.gain.setValueAtTime(Math.max(gainNode.gain.value, 0.001), now);
+    gainNode.gain.exponentialRampToValueAtTime(4.0, now + 0.01);
+    clearTimeout(envelopeTimeout);
+    envelopeTimeout = setTimeout(() => {
+      if (!audioCtx || !gainNode) return;
+      const releaseTime = audioCtx.currentTime;
+      gainNode.gain.cancelScheduledValues(releaseTime);
+      gainNode.gain.setValueAtTime(Math.max(gainNode.gain.value, 0.001), releaseTime);
+      gainNode.gain.exponentialRampToValueAtTime(0.001, releaseTime + 0.12);
+    }, 60);
+  }
+
+  function handleKey(e) {
+    if (e.repeat) return;
+    triggerHit();
+  }
+
+  async function start() {
+    if (audioCtx && audioCtx.state === 'suspended') await audioCtx.resume();
+    if (mediaStream) return;
+    try {
+      mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false }
+      });
+      const AC = window.AudioContext || window.webkitAudioContext;
+      audioCtx = new AC();
+      // Safari requires explicit resume after user gesture
+      if (audioCtx.state === 'suspended') await audioCtx.resume();
+      sourceNode = audioCtx.createMediaStreamSource(mediaStream);
+      lowCutFilter = audioCtx.createBiquadFilter();
+      lowCutFilter.type = 'highpass'; lowCutFilter.frequency.value = 350;
+      highBoostFilter = audioCtx.createBiquadFilter();
+      highBoostFilter.type = 'highshelf'; highBoostFilter.frequency.value = 3500; highBoostFilter.gain.value = 8;
+      gainNode = audioCtx.createGain();
+      gainNode.gain.value = 0.001;
+      compressor = audioCtx.createDynamicsCompressor();
+      compressor.threshold.value = -20; compressor.knee.value = 5;
+      compressor.ratio.value = 8; compressor.attack.value = 0.002; compressor.release.value = 0.1;
+      analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 2048;
+      sourceNode.connect(lowCutFilter);
+      lowCutFilter.connect(highBoostFilter);
+      highBoostFilter.connect(gainNode);
+      gainNode.connect(compressor);
+      compressor.connect(analyser);
+      analyser.connect(audioCtx.destination);
+      // Safari: play a silent buffer to unlock audio output
+      try {
+        const silentBuf = audioCtx.createBuffer(1, 1, audioCtx.sampleRate);
+        const silentSrc = audioCtx.createBufferSource();
+        silentSrc.buffer = silentBuf;
+        silentSrc.connect(audioCtx.destination);
+        silentSrc.start(0);
+      } catch(e) { /* ignore */ }
+      debugUI.style.display = 'block';
+      drawWaveform();
+      window.addEventListener('keydown', handleKey);
+      window.addEventListener('keyup', handleKey);
+    } catch (err) {
+      console.error("マイクへのアクセスに失敗しました:", err);
+      alert("マイクへのアクセスが許可されませんでした。");
+      State.set('ampEnabled', false);
+    }
+  }
+
+  function stop() {
+    window.removeEventListener('keydown', handleKey);
+    window.removeEventListener('keyup', handleKey);
+    if (drawVisualId) { cancelAnimationFrame(drawVisualId); drawVisualId = null; }
+    debugUI.style.display = 'none';
+    if (mediaStream) { mediaStream.getTracks().forEach(t => t.stop()); mediaStream = null; }
+    if (audioCtx) { audioCtx.close(); audioCtx = null; }
+    analyser = null;
+    clearTimeout(envelopeTimeout);
+  }
+
+  return { setEnabled(v) { if (v) start(); else stop(); } };
+})();
+
+// ─── effect/voice-dynamics ──────────────────────────────────────────────────
+const VoiceDynamics = (() => {
+  let isEnabled = false;
+  let recognition = null;
+  let audioCtx = null;
+  let analyser = null;
+  let dataArray = null;
+  let mediaStream = null;
+  let rafId = null;
+  let interimSpan = null;
+  let currentPeakRms = 0;
+  let audioCtxInitialized = false;
+
+  const debugHud = document.getElementById('debug-hud');
+  const dStatus = document.getElementById('debug-status');
+  const dRms = document.getElementById('debug-rms');
+  const dSize = document.getElementById('debug-size');
+  const voiceCanvas = document.getElementById('visualizer-voice');
+  const canvasCtx = voiceCanvas.getContext('2d');
+
+  function mapVolumeToSize(rms) {
+    let effectiveRms = Math.max(0, rms - 0.01);
+    let size = 1.0 + (effectiveRms * 2.0);
+    return Math.max(1.0, Math.min(size, 4.5));
+  }
+
+  function keepElementInView(el, smooth) {
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const editor = document.getElementById('editor');
+    const editorRect = editor.getBoundingClientRect();
+    const pad = 120;
+    let dx = 0, dy = 0;
+    if (rect.left < editorRect.left + pad) dx = rect.left - (editorRect.left + pad);
+    else if (rect.right > editorRect.right - pad) dx = rect.right - (editorRect.right - pad);
+    if (rect.bottom > editorRect.bottom - pad) dy = rect.bottom - (editorRect.bottom - pad);
+    else if (rect.top < editorRect.top + pad) dy = rect.top - (editorRect.top + pad);
+    if (dx !== 0 || dy !== 0) editor.scrollBy({ left: dx, top: dy, behavior: smooth ? 'smooth' : 'auto' });
+  }
+
+  function audioLoop() {
+    if (!isEnabled || !analyser || !dataArray) return;
+    rafId = requestAnimationFrame(audioLoop);
+    analyser.getFloatTimeDomainData(dataArray);
+    let sum = 0;
+    for (let i = 0; i < dataArray.length; i++) sum += dataArray[i] * dataArray[i];
+    let rms = Math.sqrt(sum / dataArray.length);
+    currentPeakRms = Math.max(currentPeakRms, rms);
+    dRms.textContent = rms.toFixed(4);
+    const currentTargetSize = mapVolumeToSize(rms);
+    dSize.textContent = currentTargetSize.toFixed(2) + 'em';
+
+    if (interimSpan && interimSpan.textContent.length > 0) {
+      const currentSize = parseFloat(interimSpan.style.fontSize) || 1.0;
+      if (currentTargetSize > currentSize) {
+        interimSpan.style.fontSize = (currentSize * 0.2 + currentTargetSize * 0.8).toFixed(2) + 'em';
+      } else {
+        interimSpan.style.fontSize = (currentSize * 0.8 + currentTargetSize * 0.2).toFixed(2) + 'em';
+      }
+      keepElementInView(interimSpan, false);
+    }
+
+    canvasCtx.fillStyle = 'rgb(0, 0, 0)';
+    canvasCtx.fillRect(0, 0, 200, 60);
+    canvasCtx.lineWidth = 2;
+    canvasCtx.strokeStyle = 'rgb(0, 255, 0)';
+    canvasCtx.beginPath();
+    const sliceWidth = 200 / dataArray.length;
+    let x = 0;
+    for (let i = 0; i < dataArray.length; i++) {
+      const v = dataArray[i] * 50;
+      const y = 30 - v;
+      if (i === 0) canvasCtx.moveTo(x, y);
+      else canvasCtx.lineTo(x, y);
+      x += sliceWidth;
+    }
+    canvasCtx.stroke();
+  }
+
+  async function startAudioPhase() {
+    if (audioCtxInitialized) return;
+    try {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      audioCtx = new AC();
+      if (audioCtx.state === 'suspended') await audioCtx.resume();
+      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 512;
+      const source = audioCtx.createMediaStreamSource(mediaStream);
+      source.connect(analyser);
+      dataArray = new Float32Array(analyser.frequencyBinCount);
+      audioCtxInitialized = true;
+      audioLoop();
+    } catch (e) {
+      console.error("マイク（Audio）エラー:", e);
+      dStatus.textContent = "音量取得エラー";
+      dStatus.style.color = "#f00";
+    }
+  }
+
+  function initSpeech() {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) return;
+    recognition = new SR();
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.lang = 'ja-JP';
+
+    recognition.onstart = () => {
+      dStatus.textContent = "🎙️ 認識中 (Listening...)";
+      dStatus.style.color = "#0f0";
+      ensureInterimSpan();
+    };
+
+    recognition.onresult = (e) => {
+      let finalStr = "", interimStr = "";
+      for (let i = e.resultIndex; i < e.results.length; ++i) {
+        if (e.results[i].isFinal) finalStr += e.results[i][0].transcript;
+        else interimStr += e.results[i][0].transcript;
+      }
+      if (finalStr) {
+        const span = commitVoiceText(finalStr, currentPeakRms);
+        currentPeakRms = 0;
+        keepElementInView(span, true);
+      }
+      if (interimSpan) {
+        interimSpan.textContent = interimStr;
+        if (interimStr.length > 0) keepElementInView(interimSpan, false);
+      }
+    };
+
+    recognition.onerror = (e) => {
+      if (e.error === 'no-speech' || e.error === 'aborted') return;
+      console.error("音声認識エラー:", e.error);
+      dStatus.textContent = `待機中 (${e.error})`;
+      dStatus.style.color = "#ffaa00";
+    };
+
+    recognition.onend = () => {
+      if (isEnabled && recognition) {
+        setTimeout(() => {
+          if (isEnabled && recognition) {
+            try { recognition.start(); } catch(err){}
+          }
+        }, 50);
+      }
+    };
+  }
+
+  function ensureInterimSpan() {
+    if (!interimSpan || !interimSpan.parentNode) {
+      interimSpan = document.createElement('span');
+      interimSpan.className = 'v-interim';
+      insertNodeAtCursor(interimSpan);
+    }
+  }
+
+  function commitVoiceText(text, peakRms) {
+    const finalSize = mapVolumeToSize(peakRms);
+    const span = document.createElement('span');
+    span.className = 'v-block';
+    span.style.fontSize = finalSize.toFixed(2) + 'em';
+    span.textContent = text;
+    if (interimSpan && interimSpan.parentNode) {
+      interimSpan.parentNode.insertBefore(span, interimSpan);
+    } else {
+      insertNodeAtCursor(span);
+    }
+    const sel = window.getSelection();
+    if (sel) {
+      const range = document.createRange();
+      range.setStartAfter(span);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+    document.getElementById('editor').classList.remove('is-empty');
+    return span;
+  }
+
+  function insertNodeAtCursor(node) {
+    const editor = document.getElementById('editor');
+    const sel = window.getSelection();
+    editor.focus();
+    if (!sel.rangeCount) { editor.appendChild(node); return; }
+    const range = sel.getRangeAt(0);
+    if (!editor.contains(range.commonAncestorContainer)) {
+      editor.appendChild(node);
+      range.selectNodeContents(editor);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+
+  async function start() {
+    isEnabled = true;
+    document.getElementById('btn-mic').classList.add('mic-on');
+    debugHud.style.display = 'flex';
+    dStatus.textContent = "準備中...";
+    dStatus.style.color = "#fff";
+    audioCtxInitialized = false;
+    await startAudioPhase();
+    if (!recognition) initSpeech();
+    try { recognition.start(); } catch(e){}
+  }
+
+  function stop() {
+    isEnabled = false;
+    document.getElementById('btn-mic').classList.remove('mic-on');
+    debugHud.style.display = 'none';
+    if (recognition) { recognition.onend = null; recognition.stop(); recognition = null; }
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    if (audioCtx) { audioCtx.close(); audioCtx = null; }
+    if (mediaStream) { mediaStream.getTracks().forEach(t => t.stop()); mediaStream = null; }
+    analyser = null; dataArray = null; audioCtxInitialized = false;
+    if (interimSpan) { interimSpan.remove(); interimSpan = null; }
+  }
+
+  return { setEnabled(v) { if (v) start(); else stop(); } };
+})();
+
+// ─── effect/ghost ───────────────────────────────────────────────────────────
+const Ghost = (() => {
+  let enabled = false;
+  let mode = 'block';
+  const editorEl = document.getElementById('editor');
+  const ghostLayer = document.getElementById('ghost-layer');
+
+  // ── Dynamic keyframes (driven by blur/duration sliders) ──
+  const styleEl = document.createElement('style');
+  document.head.appendChild(styleEl);
+
+  function updateKeyframes() {
+    const bs = Number(State.get('ghostBlurStart')) || 4;
+    const be = Number(State.get('ghostBlurEnd')) || 14;
+    const dp = (Number(State.get('ghostDuration')) || 100) / 100;
+    const lerp = (a, b, t) => (Number(a) + (Number(b) - Number(a)) * t).toFixed(1);
+
+    const blkDur = (3.2 * dp).toFixed(2);
+    const blkCDur = (1.0 * dp).toFixed(2);
+    const dustBs = bs * 0.075;
+    const dustBe = be * 0.107;
+    const dustDur = (0.85 * dp).toFixed(2);
+    const dustCDur = (0.6 * dp).toFixed(2);
+
+    styleEl.textContent = `
+      .ghost-block { animation: ghostBlockFade ${blkDur}s ease-out forwards; }
+      @keyframes ghostBlockFade {
+        0%   { opacity: 0.32; filter: blur(${bs}px); transform: scale(1.0); }
+        8%   { opacity: 0.28; filter: blur(${lerp(bs, be, 0.1)}px); }
+        30%  { opacity: 0.18; filter: blur(${lerp(bs, be, 0.35)}px); }
+        60%  { opacity: 0.08; filter: blur(${lerp(bs, be, 0.65)}px); transform: scale(1.01); }
+        100% { opacity: 0; filter: blur(${be}px); transform: scale(1.02); }
+      }
+      .ghost-block-composing { animation: ghostBlockComposingFade ${blkCDur}s ease-out forwards; }
+      @keyframes ghostBlockComposingFade {
+        0%   { opacity: 0.18; filter: blur(${lerp(bs, be, 0.2)}px); transform: scale(1.0); }
+        40%  { opacity: 0.10; filter: blur(${lerp(bs, be, 0.5)}px); }
+        100% { opacity: 0; filter: blur(${lerp(bs, be, 0.8)}px); transform: scale(1.01); }
+      }
+      .ghost-dust { animation: ghostDustFade ${dustDur}s ease-out forwards; }
+      @keyframes ghostDustFade {
+        0%   { opacity: 0.45; filter: blur(${dustBs.toFixed(2)}px); transform: scale(1); }
+        20%  { opacity: 0.35; filter: blur(${lerp(dustBs, dustBe, 0.3)}px); }
+        100% { opacity: 0; filter: blur(${dustBe.toFixed(2)}px); transform: scale(0.94); }
+      }
+      .ghost-dust-composing { animation: ghostDustComposingFade ${dustCDur}s ease-out forwards; }
+      @keyframes ghostDustComposingFade {
+        0%   { opacity: 0.30; filter: blur(${lerp(dustBs, dustBe, 0.4)}px); transform: scale(1); }
+        100% { opacity: 0; filter: blur(${lerp(dustBs, dustBe, 0.8)}px); transform: scale(0.96); }
+      }
+    `;
+  }
+
+  // Direct input buffer for block mode
+  let directBuffer = [];
+  let directTimer = null;
+  const DIRECT_FLUSH_MS = 400;
+
+  // Safe cursor position (no DOM mutation)
+  function getCursorPos() {
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return null;
+    const range = sel.getRangeAt(0);
+    const rects = range.getClientRects();
+    let rect;
+    if (rects.length > 0) {
+      rect = rects[rects.length - 1];
+    } else {
+      rect = range.getBoundingClientRect();
+    }
+    if (rect.width === 0 && rect.height === 0) {
+      const edRect = editorEl.getBoundingClientRect();
+      const isV = State.get('writingMode') === 'vertical';
+      if (isV) {
+        return { x: edRect.right - Layout.fontSize, y: edRect.top + Layout.fontSize, charW: Layout.fontSize, charH: Layout.fontSize };
+      } else {
+        return { x: edRect.left + Layout.fontSize, y: edRect.top + Layout.fontSize, charW: Layout.fontSize, charH: Layout.fontSize };
+      }
+    }
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2, charW: rect.width || Layout.fontSize, charH: rect.height || Layout.fontSize };
+  }
+
+  function spawnGhost(text, pos, type, composing) {
+    if (!pos) return;
+    const el = document.createElement('div');
+    let cssClass;
+    if (composing) {
+      cssClass = type === 'block' ? 'ghost-block-composing' : 'ghost-dust-composing';
+    } else {
+      cssClass = type === 'block' ? 'ghost-block' : 'ghost-dust';
+    }
+    el.className = 'ghost-el ' + cssClass;
+    el.textContent = text;
+
+    const isV = State.get('writingMode') === 'vertical';
+    const fontSize = Layout.fontSize;
+    const sizePct = (State.get('ghostSize') || 100) / 100;
+    const scatterPct = (State.get('ghostScatter') || 0) / 100;
+
+    if (type === 'block') {
+      const baseScale = Math.min(8, Math.max(5, 18 / Math.max(text.length, 1)));
+      const ghostFontSize = fontSize * baseScale * sizePct;
+      el.style.fontSize = ghostFontSize + 'px';
+      el.style.color = 'var(--ghost-color)';
+      const scatterRange = fontSize * 6 * scatterPct;
+      const randX = (Math.random() - 0.5) * scatterRange;
+      const randY = (Math.random() - 0.5) * scatterRange;
+
+      if (isV) {
+        el.style.writingMode = 'vertical-rl';
+        el.style.textOrientation = 'mixed';
+        const ghostTextH = text.length * ghostFontSize * 0.95;
+        let targetX = pos.x - ghostFontSize * 0.6 + randX;
+        let targetY = pos.y - ghostFontSize * 0.2 + randY;
+        const viewH = window.innerHeight;
+        const ghostBottom = targetY + ghostTextH;
+        const overflowThreshold = viewH * 0.75;
+        if (ghostBottom > overflowThreshold) {
+          const excess = ghostBottom - overflowThreshold;
+          const maxPull = ghostTextH * 0.55;
+          targetY -= Math.min(excess * 0.7, maxPull);
+        }
+        el.style.left = targetX + 'px';
+        el.style.top = targetY + 'px';
+      } else {
+        const textWidth = text.length * ghostFontSize * 0.55;
+        el.style.left = (pos.x - textWidth * 0.6 + randX) + 'px';
+        el.style.top = (pos.y - ghostFontSize * 0.65 + randY) + 'px';
+      }
+    } else {
+      const ghostFontSize = fontSize * 2.5 * sizePct;
+      el.style.fontSize = ghostFontSize + 'px';
+      el.style.color = 'var(--ghost-color)';
+      const scatterRange = fontSize * 3 * scatterPct;
+      const randX = (Math.random() - 0.5) * scatterRange;
+      const randY = (Math.random() - 0.5) * scatterRange;
+
+      if (isV) {
+        el.style.writingMode = 'vertical-rl';
+        el.style.textOrientation = 'mixed';
+        el.style.left = (pos.x - ghostFontSize * 0.45 + randX) + 'px';
+        el.style.top = (pos.y - ghostFontSize * 0.35 + randY) + 'px';
+      } else {
+        el.style.left = (pos.x - ghostFontSize * 0.35 + randX) + 'px';
+        el.style.top = (pos.y - ghostFontSize * 0.55 + randY) + 'px';
+      }
+    }
+
+    ghostLayer.appendChild(el);
+    const dp = (State.get('ghostDuration') || 100) / 100;
+    let duration;
+    if (composing) {
+      duration = (type === 'block' ? 1000 : 600) * dp;
+    } else {
+      duration = (type === 'block' ? 3200 : 850) * dp;
+    }
+    setTimeout(() => { if (el.parentNode) el.remove(); }, duration + 200);
+  }
+
+  function flushDirectBuffer() {
+    if (directBuffer.length === 0) return;
+    const text = directBuffer.join('');
+    directBuffer = [];
+    clearTimeout(directTimer);
+    directTimer = null;
+    const pos = getCursorPos();
+    if (pos) spawnGhost(text, pos, 'block', false);
+  }
+
+  function onCompositionEnd(e) {
+    if (!enabled || mode !== 'block') return;
+    const text = e.data;
+    if (!text) return;
+    if (directBuffer.length > 0) flushDirectBuffer();
+    requestAnimationFrame(() => {
+      const pos = getCursorPos();
+      if (pos) spawnGhost(text, pos, 'block', false);
+    });
+  }
+
+  function onInput(e) {
+    if (!enabled) return;
+    if (State.get('isComposing')) return;
+    if (mode === 'block') {
+      if (e.inputType === 'insertText' && e.data) {
+        directBuffer.push(e.data);
+        clearTimeout(directTimer);
+        directTimer = setTimeout(flushDirectBuffer, DIRECT_FLUSH_MS);
+      }
+      if (e.inputType === 'insertParagraph' || e.inputType === 'insertLineBreak') {
+        flushDirectBuffer();
+      }
+    }
+  }
+
+  function onBeforeInput(e) {
+    if (!enabled || mode !== 'block') return;
+    if (e.inputType && e.inputType.startsWith('delete')) {
+      flushDirectBuffer();
+    }
+  }
+
+  function onKeyDown(e) {
+    if (!enabled || mode !== 'dust') return;
+    if (e.repeat) return;
+    if (e.isComposing || State.get('isComposing')) return;
+    const key = e.key;
+    if (key.length > 1) return;
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const pos = getCursorPos();
+        if (pos) spawnGhost(key, pos, 'dust', false);
+      });
+    });
+  }
+
+  function onCompositionEndDust(e) {
+    if (!enabled || mode !== 'dust') return;
+    const text = e.data;
+    if (!text) return;
+    requestAnimationFrame(() => {
+      for (let i = 0; i < text.length; i++) {
+        setTimeout(() => {
+          const pos = getCursorPos();
+          if (pos) spawnGhost(text[i], pos, 'dust', false);
+        }, i * 60);
+      }
+    });
+  }
+
+  let lastComposingText = '';
+  function onCompositionUpdate(e) {
+    if (!enabled) return;
+    const text = e.data;
+    if (!text || text === lastComposingText) return;
+    lastComposingText = text;
+    requestAnimationFrame(() => {
+      const pos = getCursorPos();
+      if (!pos) return;
+      if (mode === 'block') {
+        spawnGhost(text, pos, 'block', true);
+      } else {
+        const lastChar = text[text.length - 1];
+        if (lastChar) spawnGhost(lastChar, pos, 'dust', true);
+      }
+    });
+  }
+
+  function onCompositionStartGhost() {
+    lastComposingText = '';
+  }
+
+  function init() {
+    updateKeyframes();
+    editorEl.addEventListener('compositionstart', onCompositionStartGhost);
+    editorEl.addEventListener('compositionupdate', onCompositionUpdate);
+    editorEl.addEventListener('compositionend', (e) => {
+      lastComposingText = '';
+      onCompositionEnd(e);
+      onCompositionEndDust(e);
+    });
+    editorEl.addEventListener('input', onInput);
+    editorEl.addEventListener('beforeinput', onBeforeInput);
+    window.addEventListener('keydown', onKeyDown);
+  }
+
+  return {
+    init,
+    updateKeyframes,
+    setEnabled(v) {
+      enabled = v;
+      if (!v) { directBuffer = []; clearTimeout(directTimer); directTimer = null; }
+    },
+    setMode(m) { mode = m; },
+  };
+})();
+
+// ─── metadata/tracker ───────────────────────────────────────────────────────
+const MetadataTracker = (() => {
+  let openTimeInterval = null;
+  let deleteDebounceTimer = null;
+  const DELETE_DEBOUNCE_MS = 500;
+  const WPM_WINDOW_MS = 60000; // 60-second rolling window
+  const CHARS_PER_WORD = 5;
+
+  function init() {
+    // Start tracking total open time — 1-second heartbeat
+    openTimeInterval = setInterval(() => {
+      State.set('totalOpenTime', State.get('totalOpenTime') + 1);
+    }, 1000);
+  }
+
+  function stop() {
+    if (openTimeInterval) { clearInterval(openTimeInterval); openTimeInterval = null; }
+    flushDeleteBuffer();
+  }
+
+  // Called on every input event — records "active typing" seconds via heartbeat
+  function recordCharacterTyped() {
+    const now = Math.floor(Date.now() / 1000);
+    if (now !== State.get('lastHeartbeatSecond')) {
+      State.set('lastHeartbeatSecond', now);
+      State.set('activeTypingTime', State.get('activeTypingTime') + 1);
+    }
+    // WPM tracking — push timestamp
+    const timestamps = State.get('recentCharTimestamps').slice();
+    const nowMs = Date.now();
+    timestamps.push(nowMs);
+    // Trim to rolling window
+    const cutoff = nowMs - WPM_WINDOW_MS;
+    const trimmed = timestamps.filter(t => t >= cutoff);
+    State.set('recentCharTimestamps', trimmed);
+  }
+
+  // Samples current WPM and updates peak/slowest/average
+  function sampleWPM() {
+    const timestamps = State.get('recentCharTimestamps');
+    if (!timestamps || timestamps.length < 2) return;
+    const nowMs = Date.now();
+    const cutoff = nowMs - WPM_WINDOW_MS;
+    const recent = timestamps.filter(t => t >= cutoff);
+    const charCount = recent.length;
+    const words = charCount / CHARS_PER_WORD;
+    // Calculate elapsed time in minutes within the window
+    const elapsed = recent.length > 1 ? (recent[recent.length - 1] - recent[0]) / 60000 : 1;
+    const wpm = elapsed > 0 ? parseFloat((words / elapsed).toFixed(2)) : 0;
+    if (wpm <= 0) return;
+
+    if (wpm > State.get('peakWPM')) State.set('peakWPM', wpm);
+    const slowest = State.get('slowestWPM');
+    if (slowest === Infinity || wpm < slowest) State.set('slowestWPM', wpm);
+    State.set('averageWPMSum', State.get('averageWPMSum') + wpm);
+    State.set('averageWPMCount', State.get('averageWPMCount') + 1);
+  }
+
+  // Single-char deletion (Backspace/Delete) — debounce into block
+  // direction: 'backward' prepends (so reversed chars become reading order),
+  //            'forward' appends normally
+  function recordDeletion(text, direction) {
+    if (!text) return;
+    const buf = State.get('pendingDeleteBuffer');
+    const newBuf = direction === 'forward' ? buf + text : text + buf;
+    State.set('pendingDeleteBuffer', newBuf);
+    clearTimeout(deleteDebounceTimer);
+    deleteDebounceTimer = setTimeout(flushDeleteBuffer, DELETE_DEBOUNCE_MS);
+  }
+
+  // Selection deletion — immediate block
+  function recordSelectionDeletion(text) {
+    if (!text) return;
+    flushDeleteBuffer(); // flush any pending single-char buffer first
+    commitDeleteBlock(text);
+  }
+
+  function flushDeleteBuffer() {
+    const buf = State.get('pendingDeleteBuffer');
+    if (buf) {
+      commitDeleteBlock(buf);
+      State.set('pendingDeleteBuffer', '');
+    }
+    clearTimeout(deleteDebounceTimer);
+    deleteDebounceTimer = null;
+  }
+
+  function commitDeleteBlock(text) {
+    const blocks = State.get('deletedBlocks').slice();
+    blocks.push({ text, time: new Date().toISOString() });
+    // Keep max 100 blocks per entry to avoid bloat
+    if (blocks.length > 100) blocks.splice(0, blocks.length - 100);
+    State.set('deletedBlocks', blocks);
+    State.set('totalDeletedCharCount', State.get('totalDeletedCharCount') + text.length);
+  }
+
+  // Returns metadata object for saving
+  function getMeta() {
+    sampleWPM(); // capture final WPM sample before save
+    const avgCount = State.get('averageWPMCount');
+    const avgWPM = avgCount > 0 ? parseFloat((State.get('averageWPMSum') / avgCount).toFixed(2)) : 0;
+    return {
+      totalOpenTime: State.get('totalOpenTime'),
+      activeTypingTime: State.get('activeTypingTime'),
+      peakWPM: State.get('peakWPM'),
+      slowestWPM: State.get('slowestWPM') === Infinity ? 0 : State.get('slowestWPM'),
+      averageWPM: avgWPM,
+      averageWPMSum: State.get('averageWPMSum'),
+      averageWPMCount: State.get('averageWPMCount'),
+      deletedBlocks: State.get('deletedBlocks'),
+      totalDeletedCharCount: State.get('totalDeletedCharCount'),
+    };
+  }
+
+  // Restores metadata from a loaded entry
+  function loadFromMeta(m) {
+    State.set('totalOpenTime', m.totalOpenTime || 0);
+    State.set('activeTypingTime', m.activeTypingTime || 0);
+    State.set('lastHeartbeatSecond', -1);
+    State.set('peakWPM', m.peakWPM || 0);
+    State.set('slowestWPM', m.slowestWPM || Infinity);
+    State.set('averageWPMSum', m.averageWPMSum || 0);
+    State.set('averageWPMCount', m.averageWPMCount || 0);
+    State.set('recentCharTimestamps', []);
+    State.set('deletedBlocks', m.deletedBlocks || []);
+    State.set('totalDeletedCharCount', m.totalDeletedCharCount || 0);
+    State.set('pendingDeleteBuffer', '');
+  }
+
+  function resetForNewEntry() {
+    State.set('totalOpenTime', 0);
+    State.set('activeTypingTime', 0);
+    State.set('lastHeartbeatSecond', -1);
+    State.set('peakWPM', 0);
+    State.set('slowestWPM', Infinity);
+    State.set('averageWPMSum', 0);
+    State.set('averageWPMCount', 0);
+    State.set('recentCharTimestamps', []);
+    State.set('deletedBlocks', []);
+    State.set('totalDeletedCharCount', 0);
+    State.set('pendingDeleteBuffer', '');
+  }
+
+  return { init, stop, recordCharacterTyped, recordDeletion, recordSelectionDeletion, flushDeleteBuffer, getMeta, loadFromMeta, resetForNewEntry, sampleWPM };
+})();
+
+// ─── stats/dialog ───────────────────────────────────────────────────────────
+const StatsDialog = (() => {
+  function formatTime(seconds) {
+    seconds = Math.floor(seconds);
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}時間${m}分${s}秒`;
+    if (m > 0) return `${m}分${s}秒`;
+    return `${s}秒`;
+  }
+
+  function fmtWPM(v) {
+    return (typeof v === 'number' && isFinite(v)) ? v.toFixed(2) : '0.00';
+  }
+
+  function buildDeletedListHTML(blocks) {
+    if (!blocks || blocks.length === 0) {
+      return '<p style="color:var(--date-color);font-size:13px;">削除テキストはまだありません</p>';
+    }
+    const sorted = blocks.slice().sort((a, b) => (b.time || '').localeCompare(a.time || ''));
+    return sorted.slice(0, 10).map(b => {
+      const preview = b.text.length > 60 ? b.text.slice(0, 60) + '…' : b.text;
+      const timeStr = b.time ? new Date(b.time).toLocaleString('ja-JP') : '';
+      return `<div class="stats-deleted-item"><span class="stats-deleted-text">${esc(preview)}</span><span class="stats-deleted-time">${esc(timeStr)}</span></div>`;
+    }).join('');
+  }
+
+  function buildPanel(data) {
+    return `
+      <div class="stats-grid">
+        <div class="stats-card">
+          <div class="stats-card-label">総エディタ開時間</div>
+          <div class="stats-card-value">${formatTime(data.totalOpen)}</div>
+        </div>
+        <div class="stats-card">
+          <div class="stats-card-label">アクティブ入力時間</div>
+          <div class="stats-card-value">${formatTime(data.activeTyping)}</div>
+        </div>
+        <div class="stats-card">
+          <div class="stats-card-label">ピーク WPM</div>
+          <div class="stats-card-value">${fmtWPM(data.peakWPM)}</div>
+        </div>
+        <div class="stats-card">
+          <div class="stats-card-label">平均 WPM</div>
+          <div class="stats-card-value">${fmtWPM(data.avgWPM)}</div>
+        </div>
+        <div class="stats-card">
+          <div class="stats-card-label">削除ブロック数</div>
+          <div class="stats-card-value">${data.deletedBlockCount}</div>
+        </div>
+        <div class="stats-card">
+          <div class="stats-card-label">削除文字数</div>
+          <div class="stats-card-value">${data.deletedChars.toLocaleString()}</div>
+        </div>
+      </div>
+      <h3 style="margin:20px 0 10px;font-size:15px;">直近の削除テキスト</h3>
+      <div class="stats-deleted-list">${buildDeletedListHTML(data.deletedBlocks)}</div>
+    `;
+  }
+
+  // Gather cumulative data from all saved entries + current session
+  async function gatherCumulativeData() {
+    const entries = await Storage.listAll();
+    let totalOpen = 0, activeTyping = 0;
+    let peakWPM = 0, wpmSum = 0, wpmCount = 0;
+    let deletedBlockCount = 0, deletedChars = 0;
+    const allDeleted = [];
+
+    for (const en of entries) {
+      const m = en.meta || {};
+      totalOpen += m.totalOpenTime || 0;
+      activeTyping += m.activeTypingTime || 0;
+      if ((m.peakWPM || 0) > peakWPM) peakWPM = m.peakWPM;
+      wpmSum += m.averageWPMSum || 0;
+      wpmCount += m.averageWPMCount || 0;
+      const blocks = m.deletedBlocks || [];
+      deletedBlockCount += blocks.length;
+      deletedChars += m.totalDeletedCharCount || 0;
+      for (const b of blocks) allDeleted.push(b);
+    }
+
+    // Add current (unsaved) session
+    totalOpen += State.get('totalOpenTime');
+    activeTyping += State.get('activeTypingTime');
+    const cp = State.get('peakWPM');
+    if (cp > peakWPM) peakWPM = cp;
+    wpmSum += State.get('averageWPMSum');
+    wpmCount += State.get('averageWPMCount');
+    const cb = State.get('deletedBlocks');
+    deletedBlockCount += cb.length;
+    deletedChars += State.get('totalDeletedCharCount');
+    for (const b of cb) allDeleted.push(b);
+
+    const avgWPM = wpmCount > 0 ? wpmSum / wpmCount : 0;
+    return { totalOpen, activeTyping, peakWPM, avgWPM, deletedBlockCount, deletedChars, deletedBlocks: allDeleted };
+  }
+
+  // Gather data for current entry only (live State values)
+  function gatherEntryData() {
+    MetadataTracker.sampleWPM();
+    const wpmCount = State.get('averageWPMCount');
+    const avgWPM = wpmCount > 0 ? State.get('averageWPMSum') / wpmCount : 0;
+    const slowest = State.get('slowestWPM');
+    return {
+      totalOpen: State.get('totalOpenTime'),
+      activeTyping: State.get('activeTypingTime'),
+      peakWPM: State.get('peakWPM'),
+      slowestWPM: (slowest === Infinity) ? 0 : slowest,
+      avgWPM,
+      deletedBlockCount: State.get('deletedBlocks').length,
+      deletedChars: State.get('totalDeletedCharCount'),
+      deletedBlocks: State.get('deletedBlocks'),
+    };
+  }
+
+  async function show() {
+    const overlay = document.getElementById('stats-overlay');
+    const dialog = document.getElementById('stats-dialog');
+
+    const cumData = await gatherCumulativeData();
+    const entryData = gatherEntryData();
+
+    // Build tabbed UI
+    dialog.innerHTML = `
+      <h2 style="margin-bottom:16px;">執筆統計</h2>
+      <div class="stats-tabs">
+        <button class="stats-tab active" data-tab="cumulative">累計</button>
+        <button class="stats-tab" data-tab="entry">このエントリ</button>
+      </div>
+      <div class="stats-tab-content" id="stats-tab-cumulative">${buildPanel(cumData)}</div>
+      <div class="stats-tab-content" id="stats-tab-entry" style="display:none;">
+        ${buildPanel(entryData)}
+        <div class="stats-grid" style="margin-top:12px;">
+          <div class="stats-card">
+            <div class="stats-card-label">最低 WPM</div>
+            <div class="stats-card-value">${fmtWPM(entryData.slowestWPM)}</div>
+          </div>
+        </div>
+      </div>
+      <div style="text-align:center;margin-top:20px;">
+        <button id="stats-close-btn" style="padding:8px 24px;border-radius:6px;border:1px solid var(--toolbar-border);background:var(--bg);color:var(--text);cursor:pointer;font-size:14px;">閉じる</button>
+      </div>
+    `;
+
+    // Tab switching
+    dialog.querySelectorAll('.stats-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        dialog.querySelectorAll('.stats-tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        const which = tab.dataset.tab;
+        document.getElementById('stats-tab-cumulative').style.display = which === 'cumulative' ? '' : 'none';
+        document.getElementById('stats-tab-entry').style.display = which === 'entry' ? '' : 'none';
+      });
+    });
+
+    overlay.classList.add('open');
+    dialog.classList.add('open');
+
+    const closeHandler = () => {
+      overlay.classList.remove('open');
+      dialog.classList.remove('open');
+    };
+    document.getElementById('stats-close-btn').addEventListener('click', closeHandler);
+    overlay.addEventListener('click', closeHandler, { once: true });
+  }
+
+  return { show };
+})();
+
+// ─── editor/controller ──────────────────────────────────────────────────────
+const Editor = (() => {
+  const el = document.getElementById('editor');
+  let _dirtyFlag = false;
+
+  // Keep caret in a comfortable position in vertical mode,
+  // so IME candidate box appears in a less obtrusive location.
+  function ensureCaretVisible() {
+    if (State.get('writingMode') !== 'vertical') return;
+    const sel = window.getSelection();
+    if (!sel || !sel.rangeCount) return;
+    const range = sel.getRangeAt(0);
+    const rects = range.getClientRects();
+    if (rects.length === 0) return;
+    const rect = rects[rects.length - 1];
+    const edRect = el.getBoundingClientRect();
+    const margin = Layout.fontSize * 3;
+    if (rect.left < edRect.left + margin) {
+      el.scrollLeft -= (edRect.left + margin - rect.left);
+    }
+  }
+
+  function init() {
+    el.addEventListener('compositionstart', () => {
+      State.set('isComposing', true);
+      requestAnimationFrame(() => ensureCaretVisible());
+    });
+    el.addEventListener('compositionend', () => {
+      State.set('isComposing', false);
+      markDirty();
+    });
+    el.addEventListener('input', () => {
+      if (!State.get('isComposing')) {
+        markDirty();
+        MetadataTracker.recordCharacterTyped();
+      }
+      ensureCaretLine();
+      updatePlaceholder();
+      requestAnimationFrame(() => ensureCaretVisible());
+    });
+    // Capture deletions before they happen
+    el.addEventListener('beforeinput', e => {
+      const deleteTypes = ['deleteContentBackward', 'deleteContentForward', 'deleteByCut', 'deleteByDrag', 'deleteWordBackward', 'deleteWordForward', 'deleteSoftLineBackward', 'deleteSoftLineForward', 'deleteHardLineBackward', 'deleteHardLineForward'];
+      if (!deleteTypes.includes(e.inputType)) return;
+      const sel = window.getSelection();
+      if (!sel || !sel.rangeCount) return;
+      const range = sel.getRangeAt(0);
+      if (!range.collapsed) {
+        // Selection deletion — capture the selected text
+        const text = range.toString();
+        if (text) MetadataTracker.recordSelectionDeletion(text);
+      } else {
+        // Single-char or word deletion
+        // For backward: get the character before cursor
+        // For forward: get the character after cursor
+        let deleted = '';
+        if (e.inputType.includes('Backward')) {
+          const r2 = range.cloneRange();
+          r2.setStart(el, 0);
+          const before = r2.toString();
+          if (e.inputType.includes('Word')) {
+            const m = before.match(/\S+\s*$/);
+            deleted = m ? m[0] : before.slice(-1);
+          } else {
+            deleted = before.slice(-1);
+          }
+        } else if (e.inputType.includes('Forward')) {
+          const r2 = range.cloneRange();
+          r2.setEndAfter(el.lastChild || el);
+          const after = r2.toString();
+          if (e.inputType.includes('Word')) {
+            const m = after.match(/^\s*\S+/);
+            deleted = m ? m[0] : after.slice(0, 1);
+          } else {
+            deleted = after.slice(0, 1);
+          }
+        }
+        const dir = e.inputType.includes('Backward') ? 'backward' : 'forward';
+        if (deleted) MetadataTracker.recordDeletion(deleted, dir);
+      }
+    });
+    el.addEventListener('keydown', e => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        triggerSave();
+      }
+    });
+  }
+
+  function markDirty() {
+    if (!_dirtyFlag) { _dirtyFlag = true; State.set('isDirty', true); }
+  }
+  function clearDirty() { _dirtyFlag = false; }
+  function getContent() {
+    return (el.innerText || '').replace(/^\u200B/, '');
+  }
+  function getHTML() {
+    // Exclude fake caret and sentinel from saved HTML
+    const clone = el.cloneNode(true);
+    const fc = clone.querySelector('.editor-fake-caret');
+    if (fc) fc.remove();
+    const sn = clone.querySelector('#_trace_sentinel');
+    if (sn) sn.remove();
+    return clone.innerHTML;
+  }
+  function setHTML(html) {
+    el.innerHTML = html;
+    EraserTrace.ensureSentinel();
+    ensureCaretLine();
+    updatePlaceholder();
+  }
+  function setContent(t) {
+    el.innerText = t;
+    EraserTrace.ensureSentinel();
+    ensureCaretLine();
+    updatePlaceholder();
+  }
+  // Show/hide a fake blinking caret when editor is empty
+  function ensureCaretLine() {
+    const text = (el.innerText || '').replace(/\u200B/g, '').trim();
+    const existing = el.querySelector('.editor-fake-caret');
+    if (text.length === 0 && !existing) {
+      const caret = document.createElement('span');
+      caret.className = 'editor-fake-caret';
+      caret.setAttribute('contenteditable', 'false');
+      el.appendChild(caret);
+    } else if (text.length > 0 && existing) {
+      existing.remove();
+    }
+  }
+  function focus() {
+    el.focus();
+    // Place cursor at the editable position (after sentinel, before fake caret)
+    const sel = window.getSelection();
+    if (sel) {
+      const range = document.createRange();
+      const fakeCaret = el.querySelector('.editor-fake-caret');
+      const sentinel = el.querySelector('#_trace_sentinel');
+      if (fakeCaret) {
+        range.setStartBefore(fakeCaret);
+      } else if (sentinel && sentinel.nextSibling) {
+        range.setStartBefore(sentinel.nextSibling);
+      } else if (el.childNodes.length > 0) {
+        range.setStartAfter(el.lastChild);
+      } else {
+        range.setStart(el, 0);
+      }
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }
+  function updatePlaceholder() {
+    const text = (el.innerText || '').replace(/\u200B/g, '').trim();
+    el.classList.toggle('is-empty', text.length === 0);
+  }
+
+  return { init, getContent, getHTML, setHTML, setContent, focus, clearDirty, updatePlaceholder, ensureCaretVisible };
+})();
+
+// ─── ui/theme ───────────────────────────────────────────────────────────────
+function applyWritingMode(m) {
+  const el = document.getElementById('editor');
+  if (m === 'vertical') {
+    el.style.writingMode = 'vertical-rl';
+    el.style.textOrientation = 'mixed';
+    el.classList.remove('wm-horizontal');
+  } else {
+    el.style.writingMode = 'horizontal-tb';
+    el.style.textOrientation = '';
+    el.classList.add('wm-horizontal');
+  }
+}
+function applyFont(f) {
+  const v = f === 'serif' ? "'Noto Serif JP', serif" : "'Noto Sans JP', sans-serif";
+  document.body.style.fontFamily = v;
+  document.getElementById('editor').style.fontFamily = v;
+}
+function applyDarkMode(on) {
+  document.body.classList.toggle('dark', on);
+  EraserTrace.requestRedraw();
+}
+
+function updateDateDisplay() {
+  const dateEl = document.getElementById('date-display');
+  const opened = State.get('openedAt');
+  if (!opened) { dateEl.textContent = ''; return; }
+  const d = new Date(opened);
+  const days = ['日曜日','月曜日','火曜日','水曜日','木曜日','金曜日','土曜日'];
+  const datePart = `${d.getFullYear()}.${d.getMonth()+1}.${d.getDate()} — ${days[d.getDay()]}`;
+  const openTime = `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
+  const now = new Date();
+  const nowTime = `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}`;
+  dateEl.textContent = `${datePart}  ${openTime} · ${nowTime}`;
+}
+// Periodically update the "now" time in the date display
+setInterval(() => { if (State.get('currentScreen') === 'editor') updateDateDisplay(); }, 30000);
+
+function updateEditorTitleDisplay() {
+  const el = document.getElementById('editor-title-display');
+  const title = State.get('currentTitle');
+  el.textContent = title || '';
+}
+State.on('currentTitle', () => updateEditorTitleDisplay());
+
+// ─── ui/toolbar ─────────────────────────────────────────────────────────────
+document.getElementById('btn-direction').addEventListener('click', () => {
+  State.set('writingMode', State.get('writingMode') === 'vertical' ? 'horizontal' : 'vertical');
+});
+State.on('writingMode', m => {
+  applyWritingMode(m);
+  document.getElementById('btn-direction').title = m === 'vertical' ? '横書きに切替' : '縦書きに切替';
+  Layout.calc();
+});
+
+document.getElementById('btn-font').addEventListener('click', () => {
+  State.set('font', State.get('font') === 'serif' ? 'sans' : 'serif');
+});
+State.on('font', f => {
+  applyFont(f);
+  document.getElementById('btn-font').title = f === 'serif' ? 'ゴシックに切替' : '明朝に切替';
+  EraserTrace.setEnabled(State.get('eraserTraceEnabled')); // clear smudge cache
+});
+
+document.getElementById('btn-darkmode').addEventListener('click', () => {
+  State.set('darkMode', !State.get('darkMode'));
+});
+State.on('darkMode', on => {
+  applyDarkMode(on);
+  document.getElementById('btn-darkmode').classList.toggle('active', on);
+  TimeInscription.refreshAllEBlocks();
+  PressureBleed.refreshAllPBlocks();
+});
+
+document.getElementById('btn-fullscreen').addEventListener('click', () => {
+  if (!document.fullscreenElement) document.documentElement.requestFullscreen().catch(() => {});
+  else document.exitFullscreen().catch(() => {});
+});
+document.addEventListener('fullscreenchange', () => {
+  const btn = document.getElementById('btn-fullscreen');
+  btn.classList.toggle('active', !!document.fullscreenElement);
+  btn.title = document.fullscreenElement ? 'フルスクリーン解除' : 'フルスクリーン';
+});
+
+// Mic button (voice dynamics)
+document.getElementById('btn-mic').addEventListener('click', () => {
+  State.set('voiceEnabled', !State.get('voiceEnabled'));
+});
+
+// ─── ui/settings-drawer ─────────────────────────────────────────────────────
+const Drawer = (() => {
+  const ov = document.getElementById('settings-overlay');
+  const dr = document.getElementById('settings-drawer');
+  const open = () => { ov.classList.add('open'); dr.classList.add('open'); };
+  const close = () => { ov.classList.remove('open'); dr.classList.remove('open'); };
+  document.getElementById('btn-settings').addEventListener('click', () => dr.classList.contains('open') ? close() : open());
+  ov.addEventListener('click', close);
+  return { open, close };
+})();
+
+// Font size slider
+document.getElementById('font-size-slider').addEventListener('input', e => {
+  State.set('userFontSize', parseInt(e.target.value));
+});
+State.on('userFontSize', v => {
+  document.getElementById('font-size-slider').value = v;
+  document.getElementById('font-size-value').textContent = v + 'px';
+  Layout.calc();
+  TimeInscription.refreshAllEBlocks();
+});
+
+// Time inscription toggle + sub-options
+document.getElementById('toggle-time-inscription').addEventListener('change', e => {
+  State.set('timeInscriptionEnabled', e.target.checked);
+});
+State.on('timeInscriptionEnabled', v => {
+  document.getElementById('toggle-time-inscription').checked = v;
+  const mode = State.get('timeInscriptionMode');
+  TimeInscription.setEnabled(v);
+  PressureBleed.setEnabled(v && mode === 'pressureBleed');
+  document.getElementById('ti-sub-options').classList.toggle('open', v);
+});
+
+// Time inscription mode radio (fontSize / fontWeight / pressureBleed)
+document.querySelectorAll('input[name="ti-mode"]').forEach(radio => {
+  radio.addEventListener('change', e => {
+    if (e.target.checked) State.set('timeInscriptionMode', e.target.value);
+  });
+});
+State.on('timeInscriptionMode', mode => {
+  const radio = document.querySelector(`input[name="ti-mode"][value="${mode}"]`);
+  if (radio) radio.checked = true;
+  TimeInscription.setMode(mode);
+  // Enable PressureBleed only when pressureBleed mode is selected
+  const tiEnabled = State.get('timeInscriptionEnabled');
+  PressureBleed.setEnabled(tiEnabled && mode === 'pressureBleed');
+  TimeInscription.refreshAllEBlocks();
+  PressureBleed.refreshAllPBlocks();
+});
+
+// Eraser trace toggle
+document.getElementById('toggle-eraser-trace').addEventListener('change', e => {
+  State.set('eraserTraceEnabled', e.target.checked);
+});
+State.on('eraserTraceEnabled', v => {
+  document.getElementById('toggle-eraser-trace').checked = v;
+  EraserTrace.setEnabled(v);
+});
+
+// Typing amplifier toggle
+document.getElementById('toggle-amp').addEventListener('change', e => {
+  State.set('ampEnabled', e.target.checked);
+});
+State.on('ampEnabled', v => {
+  document.getElementById('toggle-amp').checked = v;
+  TypingAmplifier.setEnabled(v);
+});
+
+// Voice dynamics toggle (both drawer toggle and mic button)
+document.getElementById('toggle-voice').addEventListener('change', e => {
+  State.set('voiceEnabled', e.target.checked);
+});
+State.on('voiceEnabled', v => {
+  document.getElementById('toggle-voice').checked = v;
+  VoiceDynamics.setEnabled(v);
+});
+
+// Ghost toggle
+document.getElementById('toggle-ghost').addEventListener('change', e => {
+  State.set('ghostEnabled', e.target.checked);
+});
+State.on('ghostEnabled', v => {
+  document.getElementById('toggle-ghost').checked = v;
+  Ghost.setEnabled(v);
+  document.getElementById('ghost-sub-options').classList.toggle('open', v);
+});
+
+// Ghost mode radio
+document.querySelectorAll('input[name="ghost-mode"]').forEach(radio => {
+  radio.addEventListener('change', e => {
+    if (e.target.checked) State.set('ghostMode', e.target.value);
+  });
+});
+State.on('ghostMode', m => {
+  const radio = document.querySelector(`input[name="ghost-mode"][value="${m}"]`);
+  if (radio) radio.checked = true;
+  Ghost.setMode(m);
+});
+
+// Ghost size slider
+document.getElementById('ghost-size-slider').addEventListener('input', e => {
+  State.set('ghostSize', parseInt(e.target.value));
+});
+State.on('ghostSize', v => {
+  document.getElementById('ghost-size-slider').value = v;
+  document.getElementById('ghost-size-value').textContent = v + '%';
+});
+
+// Ghost scatter slider
+document.getElementById('ghost-scatter-slider').addEventListener('input', e => {
+  State.set('ghostScatter', parseInt(e.target.value));
+});
+State.on('ghostScatter', v => {
+  document.getElementById('ghost-scatter-slider').value = v;
+  document.getElementById('ghost-scatter-value').textContent = v + '%';
+});
+
+// Ghost blur start slider
+document.getElementById('ghost-blur-start-slider').addEventListener('input', e => {
+  State.set('ghostBlurStart', parseFloat(e.target.value));
+});
+State.on('ghostBlurStart', v => {
+  document.getElementById('ghost-blur-start-slider').value = v;
+  document.getElementById('ghost-blur-start-value').textContent = Number(v).toFixed(1) + 'px';
+  Ghost.updateKeyframes();
+});
+
+// Ghost blur end slider
+document.getElementById('ghost-blur-end-slider').addEventListener('input', e => {
+  State.set('ghostBlurEnd', parseInt(e.target.value));
+});
+State.on('ghostBlurEnd', v => {
+  document.getElementById('ghost-blur-end-slider').value = v;
+  document.getElementById('ghost-blur-end-value').textContent = v + 'px';
+  Ghost.updateKeyframes();
+});
+
+// Ghost duration slider
+document.getElementById('ghost-duration-slider').addEventListener('input', e => {
+  State.set('ghostDuration', parseInt(e.target.value));
+});
+State.on('ghostDuration', v => {
+  document.getElementById('ghost-duration-slider').value = v;
+  document.getElementById('ghost-duration-value').textContent = v + '%';
+  Ghost.updateKeyframes();
+});
+
+// ─── ui/dialogs ─────────────────────────────────────────────────────────────
+const SaveTitleDialog = (() => {
+  const ov = document.getElementById('save-title-dialog');
+  const input = document.getElementById('save-title-input');
+  let _resolve = null;
+  function show(currentTitle) {
+    input.value = currentTitle || '';
+    ov.classList.add('open');
+    requestAnimationFrame(() => input.focus());
+    return new Promise(res => { _resolve = res; });
+  }
+  function hide(result) {
+    ov.classList.remove('open');
+    if (_resolve) { _resolve(result); _resolve = null; }
+  }
+  document.getElementById('save-title-ok').addEventListener('click', () => hide(input.value || '無題'));
+  document.getElementById('save-title-cancel').addEventListener('click', () => hide(null));
+  let _composing = false;
+  input.addEventListener('compositionstart', () => { _composing = true; });
+  input.addEventListener('compositionend', () => { _composing = false; });
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      if (e.isComposing || _composing) return; // IME確定のEnterは無視
+      e.preventDefault();
+      hide(input.value || '無題');
+    }
+    if (e.key === 'Escape') hide(null);
+  });
+  return { show };
+})();
+
+const UnsavedDialog = (() => {
+  const ov = document.getElementById('unsaved-dialog');
+  let _resolve = null;
+  function show() {
+    ov.classList.add('open');
+    return new Promise(res => { _resolve = res; });
+  }
+  function hide(r) { ov.classList.remove('open'); if (_resolve) { _resolve(r); _resolve = null; } }
+  document.getElementById('unsaved-save').addEventListener('click', () => hide('save'));
+  document.getElementById('unsaved-discard').addEventListener('click', () => hide('discard'));
+  document.getElementById('unsaved-cancel').addEventListener('click', () => hide('cancel'));
+  return { show };
+})();
+
+const OpenDialog = (() => {
+  const ov = document.getElementById('open-dialog');
+  const list = document.getElementById('entry-list');
+  async function show() {
+    const entries = await Storage.listAll();
+    list.innerHTML = '';
+    if (entries.length === 0) {
+      list.innerHTML = '<div class="entry-empty">保存済みのエントリはありません</div>';
+    } else {
+      entries.forEach(en => {
+        const d = document.createElement('div');
+        d.className = 'entry-item';
+        const title = esc(en.title || '無題');
+        const prev = esc((en.content || '').replace(/\n/g, ' ').slice(0, 50)) || '';
+        const date = new Date(en.updatedAt).toLocaleString('ja-JP');
+        d.innerHTML = `<div class="entry-title">${title}</div><div class="entry-preview">${prev}</div><div class="entry-date">${date}</div>`;
+        d.addEventListener('click', () => { loadEntry(en.id); hide(); });
+        list.appendChild(d);
+      });
+    }
+    ov.classList.add('open');
+  }
+  function hide() { ov.classList.remove('open'); }
+  document.getElementById('open-dialog-close').addEventListener('click', hide);
+  ov.addEventListener('click', e => { if (e.target === ov) hide(); });
+  return { show };
+})();
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+// ─── storage/actions ────────────────────────────────────────────────────────
+function genId() { return Date.now().toString(36) + Math.random().toString(36).slice(2, 8); }
+
+async function triggerSave() {
+  TimeInscription.flushDirect();
+  let title = State.get('currentTitle');
+  if (!title) {
+    title = await SaveTitleDialog.show(title);
+    if (title === null) return;
+    State.set('currentTitle', title);
+  }
+  await doSave(title);
+}
+
+async function doSave(title) {
+  const now = new Date().toISOString();
+  let id = State.get('currentEntryId');
+  if (!id) { id = genId(); State.set('currentEntryId', id); }
+
+  const entry = {
+    id, title,
+    toi: window.ToiManager ? window.ToiManager.get() : '',
+    content: Editor.getContent(),
+    contentHTML: Editor.getHTML(),
+    createdAt: now, updatedAt: now,
+    writingMode: State.get('writingMode'),
+    font: State.get('font'),
+    meta: {
+      openedAt: State.get('openedAt'),
+      darkMode: State.get('darkMode'),
+      userFontSize: State.get('userFontSize'),
+      timeInscriptionEnabled: State.get('timeInscriptionEnabled'),
+      timeInscriptionMode: State.get('timeInscriptionMode'),
+      eraserTraceEnabled: State.get('eraserTraceEnabled'),
+      erasureTraces: EraserTrace.getTraces(),
+      ampEnabled: false, // Don't persist audio state
+      voiceEnabled: false,
+      ghostEnabled: State.get('ghostEnabled'),
+      ghostMode: State.get('ghostMode'),
+      ghostSize: State.get('ghostSize'),
+      ghostScatter: State.get('ghostScatter'),
+      ghostBlurStart: State.get('ghostBlurStart'),
+      ghostBlurEnd: State.get('ghostBlurEnd'),
+      ghostDuration: State.get('ghostDuration'),
+      ...MetadataTracker.getMeta(),
+    },
+  };
+  const existing = await Storage.load(id);
+  if (existing) entry.createdAt = existing.createdAt;
+
+  await Storage.save(entry);
+  State.set('isDirty', false);
+  Editor.clearDirty();
+}
+
+async function loadEntry(id) {
+  const en = await Storage.load(id);
+  if (!en) return;
+  if (en.contentHTML) Editor.setHTML(en.contentHTML);
+  else Editor.setContent(en.content);
+
+  State.set('currentEntryId', en.id);
+  State.set('currentTitle', en.title || '');
+  if (window.ToiManager) window.ToiManager.set(en.toi || '');
+  State.set('writingMode', en.writingMode || 'vertical');
+  State.set('font', en.font || 'serif');
+  State.set('isDirty', false);
+  Editor.clearDirty();
+
+  const m = en.meta || {};
+  State.set('openedAt', new Date().toISOString());
+  State.set('darkMode', m.darkMode || false);
+  if (m.userFontSize) State.set('userFontSize', m.userFontSize);
+  State.set('timeInscriptionEnabled', m.timeInscriptionEnabled !== false);
+  State.set('timeInscriptionMode', m.timeInscriptionMode || 'fontSize');
+  State.set('eraserTraceEnabled', m.eraserTraceEnabled || false);
+  EraserTrace.setTraces(m.erasureTraces || []);
+  State.set('ghostEnabled', m.ghostEnabled || false);
+  State.set('ghostMode', m.ghostMode || 'block');
+  if (m.ghostSize != null) State.set('ghostSize', m.ghostSize);
+  if (m.ghostScatter != null) State.set('ghostScatter', m.ghostScatter);
+  if (m.ghostBlurStart != null) State.set('ghostBlurStart', m.ghostBlurStart);
+  if (m.ghostBlurEnd != null) State.set('ghostBlurEnd', m.ghostBlurEnd);
+  if (m.ghostDuration != null) State.set('ghostDuration', m.ghostDuration);
+  MetadataTracker.loadFromMeta(m);
+  updateDateDisplay();
+  Layout.calc();
+  TimeInscription.refreshAllEBlocks();
+}
+
+function startNewDocument() {
+  Editor.setContent('');
+  MetadataTracker.resetForNewEntry();
+  EraserTrace.clear();
+  if (window.ToiManager) window.ToiManager.clear();
+  State.set('currentEntryId', genId());
+  State.set('currentTitle', '');
+  State.set('isDirty', false);
+  Editor.clearDirty();
+  State.set('openedAt', new Date().toISOString());
+  updateDateDisplay();
+  Editor.focus();
+}
+
+async function promptUnsavedThen(action) {
+  if (State.get('isDirty')) {
+    const r = await UnsavedDialog.show();
+    if (r === 'save') await triggerSave();
+    else if (r === 'cancel') return;
+  }
+  action();
+}
+
+document.getElementById('btn-save').addEventListener('click', () => triggerSave());
+document.getElementById('btn-open').addEventListener('click', () => promptUnsavedThen(() => OpenDialog.show()));
+document.getElementById('btn-new').addEventListener('click', () => promptUnsavedThen(() => startNewDocument()));
+document.getElementById('btn-stats').addEventListener('click', () => StatsDialog.show());
+
+
+// ─── navigation ─────────────────────────────────────────────────────────────
+const Navigation = (() => {
+  const views = { board: 'view-board', list: 'view-list', editor: 'view-editor', jar: 'view-jar', jar2: 'view-jar2', timeline: 'view-timeline' };
+  const titles = { board: 'ORYZAE / BOARD', list: 'ORYZAE / LIST', editor: 'ORYZAE / EDITOR', jar: 'ORYZAE / JAR', jar2: 'ORYZAE / JAR v2', timeline: 'ORYZAE / 問い一覧' };
+  const footerModes = { board: 'Board', list: 'List', editor: 'Editing', jar: 'Fermenting', jar2: 'Fermenting', timeline: '問い一覧' };
+
+  function switchTo(screen) {
+    // Deactivate jar animation when leaving
+    if (State.get('currentScreen') === 'jar' && screen !== 'jar') {
+      if (typeof JarView !== 'undefined' && JarView.deactivate) JarView.deactivate();
+    }
+    if (State.get('currentScreen') === 'jar2' && screen !== 'jar2') {
+      if (typeof JarView2 !== 'undefined' && JarView2.deactivate) JarView2.deactivate();
+    }
+
+    // Hide all views
+    Object.values(views).forEach(id => {
+      document.getElementById(id).classList.remove('active');
+    });
+    // Show target
+    document.getElementById(views[screen]).classList.add('active');
+    State.set('currentScreen', screen);
+
+    // Update sidebar nav
+    document.querySelectorAll('.sidebar-btn[data-screen]').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.screen === screen);
+    });
+    // Update footer
+    document.getElementById('footer-mode').textContent = footerModes[screen] || '';
+
+    // Trigger screen-specific actions
+    if (screen === 'board') {
+      Board.refresh();
+      updateFooterStats('board');
+    } else if (screen === 'list') {
+      EntryList.render();
+      updateFooterStats('list');
+    } else if (screen === 'editor') {
+      Layout.calc();
+      Editor.focus();
+      updateFooterStats('editor');
+    } else if (screen === 'jar') {
+      JarView.activate();
+      updateFooterStats('jar');
+    } else if (screen === 'jar2') {
+      if (typeof JarView2 !== 'undefined' && JarView2.activate) JarView2.activate();
+      updateFooterStats('jar2');
+    } else if (screen === 'timeline') {
+      renderTimeline();
+      updateFooterStats('timeline');
+    }
+  }
+
+  function updateFooterStats(screen) {
+    const el = document.getElementById('footer-stats');
+    if (screen === 'editor') {
+      const text = Editor.getContent();
+      el.textContent = `${text.length} CHARS`;
+    } else if (screen === 'board') {
+      const canvas = document.getElementById('board-canvas');
+      const count = canvas.querySelectorAll('.board-item').length;
+      el.textContent = `${count} CARDS`;
+    } else if (screen === 'jar' || screen === 'jar2') {
+      el.textContent = 'FERMENTING';
+    } else {
+      el.textContent = '';
+    }
+  }
+
+  async function switchWithSaveCheck(screen) {
+    if (State.get('currentScreen') === 'editor' && State.get('isDirty')) {
+      const r = await UnsavedDialog.show();
+      if (r === 'save') await triggerSave();
+      else if (r === 'cancel') return;
+    }
+    switchTo(screen);
+  }
+
+  function init() {
+    document.querySelectorAll('.sidebar-btn[data-screen]').forEach(btn => {
+      btn.addEventListener('click', () => switchWithSaveCheck(btn.dataset.screen));
+    });
+  }
+
+  return { switchTo, switchWithSaveCheck, init, updateFooterStats };
+})();
+
+// ─── board ──────────────────────────────────────────────────────────────────
+const Board = (() => {
+  const canvas = document.getElementById('board-canvas');
+  let zCounter = 100;
+  let selected = null;
+  let dragState = null, rotateState = null, resizeState = null;
+  const MIN_SIZE = 120;
+  let saveTimer = null;
+  let didDrag = false; // true if pointer moved significantly during drag
+
+  function genCardId() { return 'c' + Date.now().toString(36) + Math.random().toString(36).slice(2,6); }
+
+  function getItemState(el) {
+    return { x: parseFloat(el.dataset.x)||0, y: parseFloat(el.dataset.y)||0, r: parseFloat(el.dataset.r)||0 };
+  }
+  function applyTransform(el, x, y, r) {
+    el.style.left = x+'px'; el.style.top = y+'px';
+    el.style.transform = 'rotate('+r+'deg)';
+    el.dataset.x = x; el.dataset.y = y; el.dataset.r = r;
+  }
+  function selectItem(el) {
+    if (selected && selected !== el) selected.classList.remove('is-selected');
+    selected = el;
+    if (el) { el.classList.add('is-selected'); el.style.zIndex = ++zCounter; }
+  }
+  function deselect() { if (selected) { selected.classList.remove('is-selected'); selected = null; } }
+  function deleteItemAnim(item) {
+    const r = (parseFloat(item.dataset.r)||0)+'deg';
+    item.style.setProperty('--r', r);
+    item.classList.add('is-removing');
+    if (selected === item) selected = null;
+    setTimeout(() => item.remove(), 280);
+  }
+
+  function initBoardItem(item) {
+    if (item.querySelector('.rotate-handle')) return;
+    // Delete button
+    const del = document.createElement('div');
+    del.className = 'delete-btn'; del.title = '削除';
+    del.innerHTML = '<svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#e05555" stroke-width="1.8" stroke-linecap="round"><line x1="2" y1="2" x2="8" y2="8"/><line x1="8" y1="2" x2="2" y2="8"/></svg>';
+    del.addEventListener('pointerdown', e => e.stopPropagation());
+    del.addEventListener('click', e => { e.stopPropagation(); removeCard(item); });
+    item.appendChild(del);
+    // Rotate handle
+    const handle = document.createElement('div');
+    handle.className = 'rotate-handle';
+    handle.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 256 256" fill="currentColor"><path d="M240,56v48a8,8,0,0,1-8,8H184a8,8,0,0,1,0-16H211.4L184.81,71.64l-.25-.24a80,80,0,1,0-1.67,114.78,8,8,0,0,1,11,11.63A95.44,95.44,0,0,1,128,224h-1.32A96,96,0,1,1,195.75,60L224,88.25V56a8,8,0,0,1,16,0Z"></path></svg>';
+    item.appendChild(handle);
+    // Resize handles
+    ['se','sw','ne','nw'].forEach(dir => {
+      const rh = document.createElement('div');
+      rh.className = 'resize-handle '+dir; rh.dataset.dir = dir;
+      item.appendChild(rh);
+    });
+  }
+
+  async function removeCard(item) {
+    const cardId = item.dataset.cardId;
+    const cardType = item.dataset.cardType;
+    deleteItemAnim(item);
+    // Remove from board data
+    const dateKey = State.get('boardDateKey');
+    const viewType = State.get('boardViewType');
+    const boardData = await Storage.loadBoard(dateKey, viewType);
+    if (boardData) {
+      boardData.cards = boardData.cards.filter(c => c.cardId !== cardId);
+      boardData.updatedAt = new Date().toISOString();
+      await Storage.saveBoard(boardData);
+    }
+    // For snippet/photo, also delete the underlying data
+    if (cardType === 'snippet' && item.dataset.refId) {
+      await Storage.removeSnippet(item.dataset.refId);
+    }
+    if (cardType === 'photo' && item.dataset.refId) {
+      await Storage.removePhoto(item.dataset.refId);
+    }
+  }
+
+  function scheduleSave() {
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(saveCurrentBoard, 500);
+  }
+
+  async function saveCurrentBoard() {
+    const dateKey = State.get('boardDateKey');
+    const viewType = State.get('boardViewType');
+    if (!dateKey) return;
+    const items = canvas.querySelectorAll('.board-item');
+    const cards = [];
+    items.forEach(item => {
+      cards.push({
+        cardId: item.dataset.cardId,
+        type: item.dataset.cardType,
+        refId: item.dataset.refId || '',
+        x: parseFloat(item.dataset.x)||0,
+        y: parseFloat(item.dataset.y)||0,
+        rotation: parseFloat(item.dataset.r)||0,
+        width: item.offsetWidth,
+        height: item.offsetHeight,
+      });
+    });
+    let boardData = await Storage.loadBoard(dateKey, viewType);
+    if (!boardData) {
+      boardData = { id: dateKey + '_' + viewType, dateKey, viewType, cards: [], updatedAt: '' };
+    }
+    boardData.cards = cards;
+    boardData.updatedAt = new Date().toISOString();
+    await Storage.saveBoard(boardData);
+  }
+
+  // Create DOM element for a card
+  function createCardEl(card, content) {
+    const div = document.createElement('div');
+    div.className = 'board-item paper-shadow';
+    div.dataset.cardId = card.cardId;
+    div.dataset.cardType = card.type;
+    div.dataset.refId = card.refId || '';
+    div.style.width = (card.width || 260) + 'px';
+    if (card.height) div.style.height = card.height + 'px';
+    applyTransform(div, card.x, card.y, card.rotation || 0);
+    div.innerHTML = content;
+    canvas.appendChild(div);
+    initBoardItem(div);
+    return div;
+  }
+
+  function renderEntryCard(entry, card) {
+    const title = entry.title || '無題';
+    const preview = (entry.content || '').slice(0, 100);
+    const dateStr = entry.createdAt ? entry.createdAt.slice(0, 10) : '';
+    const html = `
+      <div class="card-entry" style="width:100%;height:100%;">
+        <div class="entry-header">
+          <span class="entry-header-date">Entry ${dateStr}</span>
+          <div class="entry-header-dot"></div>
+        </div>
+        <div class="entry-title-text">${esc(title)}</div>
+        <div class="entry-body-text">${esc(preview)}</div>
+        <div class="entry-fade"></div>
+      </div>`;
+    const el = createCardEl(card, html);
+    // Click center → open in editor (only if not dragged)
+    el.querySelector('.card-entry').addEventListener('click', (e) => {
+      if (didDrag) return;
+      if (e.target.closest('.delete-btn') || e.target.closest('.rotate-handle') || e.target.closest('.resize-handle')) return;
+      loadEntry(entry.id);
+      Navigation.switchTo('editor');
+    });
+    return el;
+  }
+
+  function renderSnippetCard(snippet, card) {
+    const html = `
+      <div class="card-snippet" style="width:100%;min-height:80px;">
+        <div style="display:flex;justify-content:space-between;align-items:start;margin-bottom:12px;">
+          <div style="width:8px;height:8px;border-radius:50%;background:#E5D5A0;"></div>
+          <span class="snippet-badge"><span style="font-size:10px;">✦</span> Snippet</span>
+        </div>
+        <div class="snippet-text">${esc(snippet.text)}</div>
+      </div>`;
+    const el = createCardEl(card, html);
+    // Click snippet text → edit
+    el.querySelector('.card-snippet').addEventListener('click', (e) => {
+      if (didDrag) return;
+      if (e.target.closest('.delete-btn') || e.target.closest('.rotate-handle') || e.target.closest('.resize-handle')) return;
+      SnippetCreateDialog.showEdit(snippet, el);
+    });
+    return el;
+  }
+
+  function renderPhotoCard(photo, card) {
+    const caption = photo.caption || '';
+    const html = `
+      <div class="card-photo" style="width:100%;">
+        <img src="${photo.dataUrl}" alt="" />
+        <div class="photo-caption">${esc(caption)}</div>
+      </div>`;
+    const el = createCardEl(card, html);
+    // Click image → lightbox
+    el.querySelector('img').addEventListener('click', (e) => {
+      if (e.target.closest('.delete-btn') || e.target.closest('.rotate-handle') || e.target.closest('.resize-handle')) return;
+      Lightbox.show(photo.dataUrl, caption);
+    });
+    return el;
+  }
+
+  // Random position for new card
+  function randomPos() {
+    const w = canvas.clientWidth || 800, h = canvas.clientHeight || 600;
+    return {
+      x: 60 + Math.floor(Math.random() * (w - 360)),
+      y: 60 + Math.floor(Math.random() * (h - 300)),
+      rotation: Math.floor(Math.random() * 10) - 5,
+    };
+  }
+
+  async function refresh() {
+    canvas.innerHTML = '';
+    const dateKey = State.get('boardDateKey');
+    const viewType = State.get('boardViewType');
+    if (!dateKey) return;
+
+    // Update date display
+    document.getElementById('board-date-label').textContent = DateUtils.formatDisplayDate(dateKey);
+
+    // Load or create board
+    let boardData = await Storage.loadBoard(dateKey, viewType);
+    const existingCardMap = new Map();
+    if (boardData) {
+      boardData.cards.forEach(c => existingCardMap.set(c.cardId, c));
+    }
+
+    // Auto-add entry cards for this day/week
+    const allEntries = await Storage.listAll();
+    let relevantEntries;
+    if (viewType === 'daily') {
+      relevantEntries = allEntries.filter(en => DateUtils.isSameDay(en.createdAt, dateKey));
+    } else {
+      const weekDates = DateUtils.getWeekDates(dateKey);
+      relevantEntries = allEntries.filter(en => en.createdAt && weekDates.includes(en.createdAt.slice(0,10)));
+    }
+
+    // Track which refIds already have cards
+    const existingRefIds = new Set();
+    if (boardData) boardData.cards.forEach(c => existingRefIds.add(c.refId));
+
+    // Add missing entry cards
+    const newCards = [];
+    for (const entry of relevantEntries) {
+      if (!existingRefIds.has(entry.id)) {
+        const pos = randomPos();
+        const card = { cardId: genCardId(), type: 'entry', refId: entry.id, x: pos.x, y: pos.y, rotation: pos.rotation, width: 340, height: 280 };
+        newCards.push(card);
+      }
+    }
+
+    // Auto-add snippet cards for this day/week
+    const allSnippets = await Storage.listAllSnippets();
+    let relevantSnippets;
+    if (viewType === 'daily') {
+      relevantSnippets = allSnippets.filter(s => DateUtils.isSameDay(s.createdAt, dateKey));
+    } else {
+      const weekDatesSnip = DateUtils.getWeekDates(dateKey);
+      relevantSnippets = allSnippets.filter(s => s.createdAt && weekDatesSnip.includes(s.createdAt.slice(0,10)));
+    }
+    for (const snippet of relevantSnippets) {
+      if (!existingRefIds.has(snippet.id)) {
+        const pos = randomPos();
+        newCards.push({ cardId: genCardId(), type: 'snippet', refId: snippet.id, x: pos.x, y: pos.y, rotation: pos.rotation, width: 260 });
+      }
+    }
+
+    // Auto-add photo cards for this day/week
+    const allPhotos = await Storage.listAllPhotos();
+    let relevantPhotos;
+    if (viewType === 'daily') {
+      relevantPhotos = allPhotos.filter(p => DateUtils.isSameDay(p.createdAt, dateKey));
+    } else {
+      const weekDatesPhoto = DateUtils.getWeekDates(dateKey);
+      relevantPhotos = allPhotos.filter(p => p.createdAt && weekDatesPhoto.includes(p.createdAt.slice(0,10)));
+    }
+    for (const photo of relevantPhotos) {
+      if (!existingRefIds.has(photo.id)) {
+        const pos = randomPos();
+        newCards.push({ cardId: genCardId(), type: 'photo', refId: photo.id, x: pos.x, y: pos.y, rotation: pos.rotation, width: 200 });
+      }
+    }
+
+    // Merge new cards into board data
+    const allCards = boardData ? [...boardData.cards, ...newCards] : newCards;
+
+    // Render all cards
+    for (const card of allCards) {
+      if (card.type === 'entry') {
+        const entry = allEntries.find(e => e.id === card.refId);
+        if (entry) renderEntryCard(entry, card);
+      } else if (card.type === 'snippet') {
+        const snippet = await Storage.loadSnippet(card.refId);
+        if (snippet) renderSnippetCard(snippet, card);
+      } else if (card.type === 'photo') {
+        const photo = await Storage.loadPhoto(card.refId);
+        if (photo) renderPhotoCard(photo, card);
+      }
+    }
+
+    // Save if we added new cards
+    if (newCards.length > 0) {
+      if (!boardData) boardData = { id: dateKey+'_'+viewType, dateKey, viewType, cards: [], updatedAt: '' };
+      boardData.cards = allCards;
+      boardData.updatedAt = new Date().toISOString();
+      await Storage.saveBoard(boardData);
+    }
+
+    // Update daily/weekly toggle
+    document.getElementById('board-view-daily').classList.toggle('active', viewType === 'daily');
+    document.getElementById('board-view-weekly').classList.toggle('active', viewType === 'weekly');
+  }
+
+  async function addSnippetToBoard(text, sourceEntryId) {
+    const snippet = {
+      id: Date.now().toString(36) + Math.random().toString(36).slice(2,6),
+      text: text.slice(0, 50),
+      sourceEntryId: sourceEntryId || null,
+      createdAt: new Date().toISOString(),
+    };
+    await Storage.saveSnippet(snippet);
+    const pos = randomPos();
+    const card = { cardId: genCardId(), type: 'snippet', refId: snippet.id, x: pos.x, y: pos.y, rotation: pos.rotation, width: 260 };
+    // Add to current board
+    const dateKey = State.get('boardDateKey');
+    const viewType = State.get('boardViewType');
+    let boardData = await Storage.loadBoard(dateKey, viewType);
+    if (!boardData) boardData = { id: dateKey+'_'+viewType, dateKey, viewType, cards: [], updatedAt: '' };
+    boardData.cards.push(card);
+    boardData.updatedAt = new Date().toISOString();
+    await Storage.saveBoard(boardData);
+    // Render
+    renderSnippetCard(snippet, card);
+  }
+
+  async function addPhotoToBoard(dataUrl, caption) {
+    const photo = {
+      id: Date.now().toString(36) + Math.random().toString(36).slice(2,6),
+      dataUrl, caption: (caption || '').slice(0, 20),
+      createdAt: new Date().toISOString(),
+    };
+    await Storage.savePhoto(photo);
+    const pos = randomPos();
+    const card = { cardId: genCardId(), type: 'photo', refId: photo.id, x: pos.x, y: pos.y, rotation: pos.rotation, width: 200 };
+    const dateKey = State.get('boardDateKey');
+    const viewType = State.get('boardViewType');
+    let boardData = await Storage.loadBoard(dateKey, viewType);
+    if (!boardData) boardData = { id: dateKey+'_'+viewType, dateKey, viewType, cards: [], updatedAt: '' };
+    boardData.cards.push(card);
+    boardData.updatedAt = new Date().toISOString();
+    await Storage.saveBoard(boardData);
+    renderPhotoCard(photo, card);
+  }
+
+  function init() {
+    // Pointer events for drag/rotate/resize
+    canvas.addEventListener('pointerdown', e => {
+      const item = e.target.closest('.board-item');
+      if (!item) { deselect(); return; }
+      const rotHandle = e.target.closest('.rotate-handle');
+      const resHandle = e.target.closest('.resize-handle');
+      e.preventDefault();
+      selectItem(item);
+      const state = getItemState(item);
+      const canvasRect = canvas.getBoundingClientRect();
+
+      if (rotHandle) {
+        const cx = item.offsetLeft + item.offsetWidth/2;
+        const cy = item.offsetTop + item.offsetHeight/2;
+        rotateState = {
+          item, cx, cy, startAngle: state.r,
+          startPointerAngle: Math.atan2(e.clientY - canvasRect.top - cy, e.clientX - canvasRect.left - cx) * 180 / Math.PI
+        };
+        rotHandle.setPointerCapture(e.pointerId);
+      } else if (resHandle) {
+        resizeState = {
+          item, dir: resHandle.dataset.dir,
+          startW: item.offsetWidth, startH: item.offsetHeight,
+          startX: state.x, startY: state.y,
+          pointerStartX: e.clientX - canvasRect.left,
+          pointerStartY: e.clientY - canvasRect.top,
+        };
+        resHandle.setPointerCapture(e.pointerId);
+      } else {
+        didDrag = false;
+        dragState = {
+          item, startX: state.x, startY: state.y,
+          pointerStartX: e.clientX - canvasRect.left,
+          pointerStartY: e.clientY - canvasRect.top,
+        };
+        item.setPointerCapture(e.pointerId);
+        item.classList.add('is-dragging');
+      }
+    });
+
+    canvas.addEventListener('pointermove', e => {
+      const canvasRect = canvas.getBoundingClientRect();
+      if (dragState) {
+        const dx = (e.clientX - canvasRect.left) - dragState.pointerStartX;
+        const dy = (e.clientY - canvasRect.top) - dragState.pointerStartY;
+        if (Math.abs(dx) > 4 || Math.abs(dy) > 4) didDrag = true;
+        const st = getItemState(dragState.item);
+        applyTransform(dragState.item, dragState.startX + dx, dragState.startY + dy, st.r);
+      }
+      if (rotateState) {
+        const mx = e.clientX - canvasRect.left - rotateState.cx;
+        const my = e.clientY - canvasRect.top - rotateState.cy;
+        const angle = Math.atan2(my, mx) * 180 / Math.PI;
+        const delta = angle - rotateState.startPointerAngle;
+        const newR = rotateState.startAngle + delta;
+        const st = getItemState(rotateState.item);
+        applyTransform(rotateState.item, st.x, st.y, Math.round(newR*10)/10);
+      }
+      if (resizeState) {
+        const rdx = (e.clientX - canvasRect.left) - resizeState.pointerStartX;
+        const rdy = (e.clientY - canvasRect.top) - resizeState.pointerStartY;
+        const dir = resizeState.dir;
+        const item = resizeState.item;
+        let newW = resizeState.startW, newH = resizeState.startH;
+        let newX = resizeState.startX, newY = resizeState.startY;
+        if (dir === 'se') { newW = Math.max(MIN_SIZE, resizeState.startW + rdx); newH = Math.max(MIN_SIZE, resizeState.startH + rdy); }
+        else if (dir === 'sw') { newW = Math.max(MIN_SIZE, resizeState.startW - rdx); newH = Math.max(MIN_SIZE, resizeState.startH + rdy); if (newW > MIN_SIZE) newX = resizeState.startX + rdx; }
+        else if (dir === 'ne') { newW = Math.max(MIN_SIZE, resizeState.startW + rdx); newH = Math.max(MIN_SIZE, resizeState.startH - rdy); if (newH > MIN_SIZE) newY = resizeState.startY + rdy; }
+        else if (dir === 'nw') { newW = Math.max(MIN_SIZE, resizeState.startW - rdx); newH = Math.max(MIN_SIZE, resizeState.startH - rdy); if (newW > MIN_SIZE) newX = resizeState.startX + rdx; if (newH > MIN_SIZE) newY = resizeState.startY + rdy; }
+        item.style.width = newW+'px'; item.style.height = newH+'px';
+        applyTransform(item, newX, newY, getItemState(item).r);
+      }
+    });
+
+    canvas.addEventListener('pointerup', () => {
+      if (dragState) { dragState.item.classList.remove('is-dragging'); dragState = null; scheduleSave(); }
+      if (rotateState) { rotateState = null; scheduleSave(); }
+      if (resizeState) { resizeState = null; scheduleSave(); }
+    });
+    canvas.addEventListener('pointercancel', () => {
+      if (dragState) { dragState.item.classList.remove('is-dragging'); dragState = null; }
+      rotateState = null; resizeState = null;
+    });
+
+    // Delete key (ignore when focus is in any text input, textarea, contenteditable, or dialog)
+    document.addEventListener('keydown', e => {
+      if (State.get('currentScreen') !== 'board') return;
+      const tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
+      if (e.target.closest('.dialog-overlay') || e.target.closest('#snippet-create-dialog') || e.target.closest('#photo-upload-dialog')) return;
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selected) {
+        e.preventDefault(); removeCard(selected);
+      }
+    });
+
+    // Board controls
+    document.getElementById('board-view-daily').addEventListener('click', () => {
+      State.set('boardViewType', 'daily');
+      Board.refresh();
+    });
+    document.getElementById('board-view-weekly').addEventListener('click', () => {
+      State.set('boardViewType', 'weekly');
+      const dateKey = State.get('boardDateKey');
+      State.set('boardDateKey', dateKey); // keep same date, just switch view
+      Board.refresh();
+    });
+    document.getElementById('board-prev-day').addEventListener('click', () => {
+      const dk = State.get('boardDateKey');
+      State.set('boardDateKey', DateUtils.shiftDate(dk, -1));
+      Board.refresh();
+    });
+    document.getElementById('board-next-day').addEventListener('click', () => {
+      const dk = State.get('boardDateKey');
+      State.set('boardDateKey', DateUtils.shiftDate(dk, 1));
+      Board.refresh();
+    });
+    document.getElementById('board-add-snippet').addEventListener('click', () => {
+      SnippetCreateDialog.show();
+    });
+    document.getElementById('board-add-photo').addEventListener('click', () => {
+      PhotoUploadDialog.show();
+    });
+  }
+
+  return { init, refresh, addSnippetToBoard, addPhotoToBoard, saveCurrentBoard };
+})();
+
+// ─── entry-list ─────────────────────────────────────────────────────────────
+const EntryList = (() => {
+  const container = document.getElementById('entry-list-container');
+
+  function formatTime(seconds) {
+    if (!seconds) return '0秒';
+    seconds = Math.floor(seconds);
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}時間${m}分`;
+    if (m > 0) return `${m}分${s}秒`;
+    return `${s}秒`;
+  }
+
+  async function render() {
+    const entries = await Storage.listAll();
+    container.innerHTML = '';
+    if (entries.length === 0) {
+      container.innerHTML = '<div style="text-align:center;padding:60px 0;color:var(--date-color);font-size:13px;">エントリーはまだありません</div>';
+      return;
+    }
+
+    // Group by month, then week
+    const monthGroups = new Map();
+    for (const en of entries) {
+      const d = en.updatedAt || en.createdAt;
+      const monthLabel = DateUtils.getMonthLabel(d);
+      if (!monthGroups.has(monthLabel)) monthGroups.set(monthLabel, []);
+      monthGroups.get(monthLabel).push(en);
+    }
+
+    for (const [month, monthEntries] of monthGroups) {
+      const monthDiv = document.createElement('div');
+      monthDiv.className = 'list-month-group';
+      const monthH = document.createElement('div');
+      monthH.className = 'list-month-label';
+      monthH.textContent = month;
+      monthDiv.appendChild(monthH);
+
+      // Group by week within month
+      const weekGroups = new Map();
+      for (const en of monthEntries) {
+        const d = (en.updatedAt || en.createdAt).slice(0,10);
+        const weekLabel = DateUtils.getWeekLabel(d);
+        if (!weekGroups.has(weekLabel)) weekGroups.set(weekLabel, []);
+        weekGroups.get(weekLabel).push(en);
+      }
+
+      for (const [week, weekEntries] of weekGroups) {
+        const weekH = document.createElement('div');
+        weekH.className = 'list-week-label';
+        weekH.textContent = week;
+        monthDiv.appendChild(weekH);
+
+        for (const en of weekEntries) {
+          const item = document.createElement('div');
+          item.className = 'list-entry-item';
+          const dateStr = (en.updatedAt || en.createdAt || '').slice(0,10);
+          const title = en.title || '無題';
+          const preview = (en.content || '').slice(0, 200);
+          const meta = en.meta || {};
+          const charCount = (en.content || '').length;
+          const timeStr = formatTime(meta.activeTypingTime || 0);
+          item.innerHTML = `
+            <div class="list-entry-date">${esc(dateStr)}</div>
+            <div class="list-entry-title">${esc(title)}</div>
+            <div class="list-entry-preview">${esc(preview)}</div>
+            <div class="list-entry-meta">
+              <span>執筆時間: ${timeStr}</span>
+              <span>文字数: ${charCount.toLocaleString()}</span>
+            </div>`;
+          item.addEventListener('click', () => {
+            loadEntry(en.id);
+            Navigation.switchTo('editor');
+          });
+          monthDiv.appendChild(item);
+        }
+      }
+      container.appendChild(monthDiv);
+    }
+  }
+
+  function init() {
+    document.getElementById('list-new-entry').addEventListener('click', async () => {
+      if (State.get('isDirty')) {
+        const r = await UnsavedDialog.show();
+        if (r === 'save') await triggerSave();
+        else if (r === 'cancel') return;
+      }
+      startNewDocument();
+      Navigation.switchTo('editor');
+    });
+  }
+
+  return { render, init };
+})();
+
+// ─── snippet-create-dialog ──────────────────────────────────────────────────
+const SnippetCreateDialog = (() => {
+  const overlay = document.getElementById('snippet-create-dialog');
+  const textarea = document.getElementById('snippet-textarea');
+  const charCount = document.getElementById('snippet-char-count');
+  const okBtn = document.getElementById('snippet-create-ok');
+  const cancelBtn = document.getElementById('snippet-create-cancel');
+  const titleEl = overlay.querySelector('h3');
+  let editingSnippet = null;  // null = create mode, object = edit mode
+  let editingCardEl = null;
+
+  function show(prefill) {
+    editingSnippet = null;
+    editingCardEl = null;
+    titleEl.textContent = 'スニペットを作成';
+    okBtn.textContent = '作成';
+    textarea.value = prefill || '';
+    charCount.textContent = (prefill || '').length;
+    overlay.classList.add('open');
+    textarea.focus();
+  }
+
+  function showEdit(snippet, cardEl) {
+    editingSnippet = snippet;
+    editingCardEl = cardEl;
+    titleEl.textContent = 'スニペットを編集';
+    okBtn.textContent = '更新';
+    textarea.value = snippet.text || '';
+    charCount.textContent = (snippet.text || '').length;
+    overlay.classList.add('open');
+    textarea.focus();
+  }
+
+  function hide() { overlay.classList.remove('open'); textarea.value = ''; editingSnippet = null; editingCardEl = null; }
+
+  textarea.addEventListener('input', () => {
+    charCount.textContent = textarea.value.length;
+  });
+  okBtn.addEventListener('click', async () => {
+    const text = textarea.value.trim();
+    if (!text || text.length > 50) return;
+    if (editingSnippet) {
+      // Edit mode: update existing snippet
+      editingSnippet.text = text;
+      await Storage.saveSnippet(editingSnippet);
+      // Update card DOM
+      if (editingCardEl) {
+        const textEl = editingCardEl.querySelector('.snippet-text');
+        if (textEl) textEl.textContent = text;
+      }
+      hide();
+    } else {
+      // Create mode
+      await Board.addSnippetToBoard(text, State.get('currentEntryId'));
+      hide();
+      if (State.get('currentScreen') !== 'board') Navigation.switchTo('board');
+    }
+  });
+  cancelBtn.addEventListener('click', hide);
+  overlay.addEventListener('click', e => { if (e.target === overlay) hide(); });
+
+  return { show, showEdit, hide };
+})();
+
+// ─── photo-upload-dialog ────────────────────────────────────────────────────
+const PhotoUploadDialog = (() => {
+  const overlay = document.getElementById('photo-upload-dialog');
+  const fileInput = document.getElementById('photo-file-input');
+  const previewArea = document.getElementById('photo-preview-area');
+  const previewImg = document.getElementById('photo-preview-img');
+  const captionInput = document.getElementById('photo-caption-input');
+  const okBtn = document.getElementById('photo-upload-ok');
+  const cancelBtn = document.getElementById('photo-upload-cancel');
+  let currentDataUrl = null;
+
+  function show() {
+    currentDataUrl = null;
+    previewImg.style.display = 'none';
+    previewImg.src = '';
+    previewArea.querySelector('.placeholder-text').style.display = '';
+    captionInput.value = '';
+    overlay.classList.add('open');
+  }
+  function hide() { overlay.classList.remove('open'); currentDataUrl = null; }
+
+  function resizeImage(file, maxW, quality) {
+    return new Promise(res => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          let w = img.width, h = img.height;
+          if (w > maxW) { h = Math.round(h * maxW / w); w = maxW; }
+          const c = document.createElement('canvas');
+          c.width = w; c.height = h;
+          c.getContext('2d').drawImage(img, 0, 0, w, h);
+          res(c.toDataURL('image/jpeg', quality));
+        };
+        img.src = reader.result;
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  previewArea.addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', async () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    currentDataUrl = await resizeImage(file, 800, 0.7);
+    previewImg.src = currentDataUrl;
+    previewImg.style.display = 'block';
+    previewArea.querySelector('.placeholder-text').style.display = 'none';
+    fileInput.value = '';
+  });
+
+  okBtn.addEventListener('click', async () => {
+    if (!currentDataUrl) return;
+    const caption = captionInput.value.trim().slice(0, 20);
+    await Board.addPhotoToBoard(currentDataUrl, caption);
+    hide();
+  });
+  cancelBtn.addEventListener('click', hide);
+  overlay.addEventListener('click', e => { if (e.target === overlay) hide(); });
+
+  return { show, hide };
+})();
+
+// ─── lightbox ───────────────────────────────────────────────────────────────
+const Lightbox = (() => {
+  const overlay = document.getElementById('lightbox-overlay');
+  const img = document.getElementById('lightbox-img');
+  const caption = document.getElementById('lightbox-caption');
+  const closeBtn = document.getElementById('lightbox-close');
+
+  function show(src, cap) {
+    img.src = src;
+    caption.textContent = cap || '';
+    overlay.classList.add('open');
+  }
+  function hide() { overlay.classList.remove('open'); img.src = ''; }
+
+  closeBtn.addEventListener('click', e => { e.stopPropagation(); hide(); });
+  overlay.addEventListener('click', e => { if (e.target === overlay) hide(); });
+
+  return { show, hide };
+})();
+
+// ─── snippet selection in editor ────────────────────────────────────────────
+const EditorSnippetSelection = (() => {
+  const toolbar = document.getElementById('selection-toolbar');
+  const btnSnippet = document.getElementById('btn-snippet');
+  const warning = document.getElementById('snippet-warning');
+  const editorEl = document.getElementById('editor');
+  const viewEditor = document.getElementById('view-editor');
+  let selectedText = '';
+
+  function handleSelection() {
+    if (State.get('currentScreen') !== 'editor') return;
+    const selection = window.getSelection();
+    if (!editorEl.contains(selection.anchorNode) || selection.isCollapsed) { hide(); return; }
+    const text = selection.toString().trim();
+    if (!text) { hide(); return; }
+    selectedText = text;
+    showToolbar(selection, text.length);
+  }
+
+  function showToolbar(selection, length) {
+    const range = selection.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    const editorRect = viewEditor.getBoundingClientRect();
+    const relTop = rect.top - editorRect.top;
+    const relLeft = rect.left - editorRect.left + (rect.width / 2);
+    toolbar.style.left = relLeft + 'px';
+    toolbar.style.top = (relTop - 10) + 'px';
+    toolbar.classList.add('visible');
+    if (length > 50) {
+      btnSnippet.style.opacity = '0.5';
+      btnSnippet.style.pointerEvents = 'none';
+      warning.classList.add('show');
+    } else {
+      btnSnippet.style.opacity = '1';
+      btnSnippet.style.pointerEvents = 'auto';
+      warning.classList.remove('show');
+    }
+  }
+
+  function hide() { toolbar.classList.remove('visible'); selectedText = ''; }
+
+  function init() {
+    document.addEventListener('selectionchange', handleSelection);
+    editorEl.addEventListener('mouseup', handleSelection);
+    btnSnippet.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      if (selectedText && selectedText.length <= 50) {
+        await Board.addSnippetToBoard(selectedText, State.get('currentEntryId'));
+        window.getSelection().removeAllRanges();
+        hide();
+        Navigation.switchTo('board');
+      }
+    });
+  }
+
+  return { init };
+})();
+
+// ─── app init (extended) ────────────────────────────────────────────────────
+function initApp() {
+  // Set initial board date
+  State.set('boardDateKey', DateUtils.getTodayKey());
+  State.set('boardViewType', 'daily');
+
+  applyWritingMode(State.get('writingMode'));
+  applyFont(State.get('font'));
+  applyDarkMode(State.get('darkMode'));
+  Layout.calc();
+  Editor.init();
+
+  // Strip external styles on paste — always insert plain text only
+  document.getElementById('editor').addEventListener('paste', (e) => {
+    e.preventDefault();
+    const text = (e.clipboardData || window.clipboardData).getData('text/plain');
+    if (text) {
+      document.execCommand('insertText', false, text);
+    }
+  });
+
+  TimeInscription.init();
+  PressureBleed.init();
+  EraserTrace.init();
+  Ghost.init();
+  MetadataTracker.init();
+  Navigation.init();
+  Board.init();
+  EntryList.init();
+  EditorSnippetSelection.init();
+  Editor.updatePlaceholder();
+
+  // Sync initial slider & toggle states
+  const initFontSize = State.get('userFontSize');
+  document.getElementById('font-size-slider').value = initFontSize;
+  document.getElementById('font-size-value').textContent = initFontSize + 'px';
+  document.getElementById('toggle-time-inscription').checked = State.get('timeInscriptionEnabled');
+  document.getElementById('ti-sub-options').classList.toggle('open', State.get('timeInscriptionEnabled'));
+  const initMode = State.get('timeInscriptionMode');
+  const initRadio = document.querySelector(`input[name="ti-mode"][value="${initMode}"]`);
+  if (initRadio) initRadio.checked = true;
+  TimeInscription.setMode(initMode);
+  PressureBleed.setEnabled(State.get('timeInscriptionEnabled') && initMode === 'pressureBleed');
+  document.getElementById('toggle-eraser-trace').checked = State.get('eraserTraceEnabled');
+  document.getElementById('toggle-amp').checked = State.get('ampEnabled');
+  document.getElementById('toggle-voice').checked = State.get('voiceEnabled');
+
+  // Ghost init sync
+  document.getElementById('toggle-ghost').checked = State.get('ghostEnabled');
+  document.getElementById('ghost-sub-options').classList.toggle('open', State.get('ghostEnabled'));
+  const initGhostMode = State.get('ghostMode');
+  const initGhostRadio = document.querySelector(`input[name="ghost-mode"][value="${initGhostMode}"]`);
+  if (initGhostRadio) initGhostRadio.checked = true;
+  Ghost.setMode(initGhostMode);
+  Ghost.setEnabled(State.get('ghostEnabled'));
+  document.getElementById('ghost-size-slider').value = State.get('ghostSize');
+  document.getElementById('ghost-size-value').textContent = State.get('ghostSize') + '%';
+  document.getElementById('ghost-scatter-slider').value = State.get('ghostScatter');
+  document.getElementById('ghost-scatter-value').textContent = State.get('ghostScatter') + '%';
+  document.getElementById('ghost-blur-start-slider').value = State.get('ghostBlurStart');
+  document.getElementById('ghost-blur-start-value').textContent = Number(State.get('ghostBlurStart')).toFixed(1) + 'px';
+  document.getElementById('ghost-blur-end-slider').value = State.get('ghostBlurEnd');
+  document.getElementById('ghost-blur-end-value').textContent = State.get('ghostBlurEnd') + 'px';
+  document.getElementById('ghost-duration-slider').value = State.get('ghostDuration');
+  document.getElementById('ghost-duration-value').textContent = State.get('ghostDuration') + '%';
+
+  State.set('currentEntryId', genId());
+  State.set('openedAt', new Date().toISOString());
+  updateDateDisplay();
+
+  let resizeTimer;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      Layout.calc();
+      TimeInscription.refreshAllEBlocks();
+    }, 60);
+  });
+
+  // Initial screen will be set after jar-view-new.js loads (see below)
+}
+initApp();
+
+// ─── toi (問い) link handling ─────────────────────────────────────────────────
+(() => {
+  const linkedContainer = document.getElementById('toi-linked-questions');
+  const selectEl = document.getElementById('toi-question-select');
+  const linkBtn = document.getElementById('toi-link-btn');
+
+  function refreshSelect() {
+    const entryId = State.get('currentEntryId');
+    const linkedIds = (OryzaeData.getQuestionsForEntry(entryId) || []).map(q => q.id);
+    const allQ = OryzaeData.getAllQuestions();
+    selectEl.innerHTML = '<option value="">問いを紐づける…</option>';
+    allQ.filter(q => !linkedIds.includes(q.id)).forEach(q => {
+      const opt = document.createElement('option');
+      opt.value = q.id;
+      opt.textContent = q.current_string;
+      selectEl.appendChild(opt);
+    });
+    // Hide controls if no more questions available or all linked
+    const remaining = allQ.filter(q => !linkedIds.includes(q.id));
+    document.getElementById('toi-link-controls').style.display = remaining.length > 0 ? 'flex' : 'none';
+  }
+
+  function renderLinked() {
+    const entryId = State.get('currentEntryId');
+    const questions = OryzaeData.getQuestionsForEntry(entryId) || [];
+    linkedContainer.innerHTML = '';
+    questions.forEach(q => {
+      const str = OryzaeData.getQuestionString(q.id);
+      const tag = document.createElement('span');
+      tag.className = 'toi-linked-tag';
+      tag.innerHTML = `<span>${str}</span><span class="toi-unlink" data-qid="${q.id}">&times;</span>`;
+      linkedContainer.appendChild(tag);
+    });
+    // Unlink handlers
+    linkedContainer.querySelectorAll('.toi-unlink').forEach(btn => {
+      btn.addEventListener('click', () => {
+        OryzaeData.unlinkQuestionFromEntry(entryId, btn.dataset.qid);
+        renderLinked();
+        refreshSelect();
+      });
+    });
+    refreshSelect();
+  }
+
+  linkBtn.addEventListener('click', () => {
+    const qId = selectEl.value;
+    if (!qId) return;
+    const entryId = State.get('currentEntryId');
+    OryzaeData.linkQuestionToEntry(entryId, qId);
+    renderLinked();
+  });
+
+  // Expose for save/load
+  window.ToiManager = {
+    get() {
+      const entryId = State.get('currentEntryId');
+      const qs = OryzaeData.getQuestionsForEntry(entryId) || [];
+      return qs.map(q => OryzaeData.getQuestionString(q.id)).join(', ');
+    },
+    set(val) { /* compatibility - no-op, links are managed via OryzaeData */ },
+    clear() { /* compatibility - no-op */ },
+    refresh() { renderLinked(); },
+  };
+
+  // Initial render when switching to editor
+  const origSwitchTo = Navigation.switchTo;
+  const _origSwitchTo = origSwitchTo.bind ? origSwitchTo : origSwitchTo;
+  // We'll call renderLinked whenever the editor is shown - hook into Navigation
+  const editorView = document.getElementById('view-editor');
+  const observer = new MutationObserver(() => {
+    if (editorView.classList.contains('active')) renderLinked();
+  });
+  observer.observe(editorView, { attributes: true, attributeFilter: ['class'] });
+})();
+
+// ─── questions timeline ──────────────────────────────────────────────────────
+const QUESTION_COLORS = ['#d97706', '#2563eb', '#059669', '#7c3aed', '#dc2626', '#0891b2'];
+
+function renderTimeline() {
+  const container = document.getElementById('timeline-content');
+  if (!container) return;
+
+  // Build timeline events from questions and transactions
+  const events = [];
+  const allQuestions = OryzaeData.questions;
+
+  allQuestions.forEach((q, qIdx) => {
+    const transactions = OryzaeData.getTransactionsForQuestion(q.id);
+    const color = QUESTION_COLORS[qIdx % QUESTION_COLORS.length];
+
+    // Question creation event
+    if (transactions.length > 0) {
+      const first = transactions[0];
+      const isProposed = q.is_proposed_by_oryzae;
+      events.push({
+        date: new Date(q.created_at),
+        type: isProposed ? 'proposed' : 'created',
+        label: isProposed ? 'PROPOSED BY ORYZAE' : 'CREATED',
+        labelJa: isProposed ? 'Oryzaeが提案' : '作成',
+        questionId: q.id,
+        questionString: first.string,
+        color: color,
+        detail: isProposed ? 'Oryzaeの発酵プロセスによる提案' : 'ユーザーが作成'
+      });
+    }
+
+    // Update events (version > 1)
+    transactions.filter(t => t.question_version > 1).forEach(t => {
+      const prevVersion = transactions.find(
+        pt => pt.question_version === t.question_version - 1
+      );
+      const isProposed = t.is_proposed_by_oryzae;
+      events.push({
+        date: new Date(t.created_at),
+        type: isProposed ? 'proposed' : 'updated',
+        label: isProposed ? 'UPDATE PROPOSED' : 'UPDATED',
+        labelJa: isProposed ? '更新提案（Oryzae）' : '更新',
+        questionId: q.id,
+        questionString: t.string,
+        prevString: prevVersion ? prevVersion.string : null,
+        color: color,
+        detail: isProposed
+          ? '発酵プロセスによる更新提案' + (t.is_validated_by_user ? '（承認済み）' : '（未承認）')
+          : 'ユーザーが更新'
+      });
+    });
+
+    // Archive event
+    if (q.is_archived) {
+      const lastTx = transactions[transactions.length - 1];
+      events.push({
+        date: new Date(q.updated_at),
+        type: 'archived',
+        label: 'ARCHIVED',
+        labelJa: 'アーカイブ',
+        questionId: q.id,
+        questionString: lastTx ? lastTx.string : '(不明)',
+        color: color,
+        canUnarchive: true
+      });
+    }
+  });
+
+  // Sort by date descending (newest first)
+  events.sort((a, b) => b.date - a.date);
+
+  // Group by date (YYYY.M.D)
+  const groups = {};
+  events.forEach(ev => {
+    const key = ev.date.getFullYear() + '.' + (ev.date.getMonth() + 1) + '.' + ev.date.getDate();
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(ev);
+  });
+
+  // Render
+  container.innerHTML = '';
+
+  Object.entries(groups).forEach(([dateStr, evts]) => {
+    const groupDiv = document.createElement('div');
+    groupDiv.className = 'timeline-date-group';
+
+    const label = document.createElement('div');
+    label.className = 'timeline-date-label';
+    label.textContent = dateStr;
+    groupDiv.appendChild(label);
+
+    evts.forEach(ev => {
+      const eventDiv = document.createElement('div');
+      eventDiv.className = 'timeline-event event-' + ev.type;
+
+      let html = `<div class="timeline-event-type">
+        <span class="timeline-question-color" style="background:${ev.color}"></span>
+        ${ev.labelJa}
+      </div>`;
+
+      if (ev.type === 'updated' || ev.type === 'proposed') {
+        if (ev.prevString) {
+          html += `<div class="timeline-event-arrow">
+            <span class="timeline-event-prev">${esc(ev.prevString)}</span>
+          </div>
+          <div class="timeline-event-question">→ ${esc(ev.questionString)}</div>`;
+        } else {
+          html += `<div class="timeline-event-question">${esc(ev.questionString)}</div>`;
+        }
+      } else {
+        html += `<div class="timeline-event-question">${esc(ev.questionString)}</div>`;
+      }
+
+      if (ev.detail) {
+        html += `<div class="timeline-event-detail">${esc(ev.detail)}</div>`;
+      }
+
+      eventDiv.innerHTML = html;
+
+      // Add unarchive button for archived events
+      if (ev.canUnarchive) {
+        const btn = document.createElement('button');
+        btn.className = 'timeline-unarchive-btn';
+        btn.textContent = '復活させる';
+        btn.addEventListener('click', () => {
+          OryzaeData.unarchiveQuestion(ev.questionId);
+          renderTimeline();
+        });
+        eventDiv.appendChild(btn);
+      }
+
+      groupDiv.appendChild(eventDiv);
+    });
+
+    container.appendChild(groupDiv);
+  });
+
+  if (events.length === 0) {
+    container.innerHTML = '<div style="text-align:center;color:var(--date-color);font-family:\'Noto Serif JP\',serif;font-size:14px;margin-top:60px;">まだ問いの記録はありません。</div>';
+  }
+}
+
+// ─── jar view controller (new) ── loaded from jar-view-new.js ────────────────
+// JarView is defined in jar-view-new.js, loaded below
+
+// ─── editor→jar save transition (発酵トランジション) ────────────────────────
+// 4-phase animation: scatter → background swap → condense circle → float + fade
+const SaveTransition = (() => {
+  const overlay = document.createElement('div');
+  overlay.id = 'save-transition-overlay';
+  document.body.appendChild(overlay);
+
+  let isRunning = false;
+
+  /**
+   * Run the full editor→jar transition animation.
+   * @param {string} text - The editor text to animate
+   */
+  function run(text) {
+    if (isRunning) return;
+    isRunning = true;
+
+    // Clean the text — limit to ~200 chars for performance
+    const rawChars = Array.from(text.replace(/[\n\r\t]/g, '').replace(/\s+/g, ' '));
+    const chars = rawChars.length > 200
+      ? rawChars.filter((_, i) => i % Math.ceil(rawChars.length / 200) === 0)
+      : rawChars;
+
+    if (chars.length === 0) {
+      // No text — just switch directly
+      Navigation.switchTo('jar');
+      isRunning = false;
+      return;
+    }
+
+    // ── Step 0: Build character DOM in the overlay ──
+    overlay.innerHTML = '';
+    overlay.classList.remove('phase-scatter', 'phase-condense', 'phase-float');
+    overlay.classList.add('active');
+
+    // Get editor element positions for initial character placement
+    const editorEl = document.getElementById('editor');
+    const editorRect = editorEl.getBoundingClientRect();
+    const fontSize = parseFloat(getComputedStyle(editorEl).fontSize);
+    const isVertical = getComputedStyle(editorEl).writingMode.includes('vertical');
+
+    // Create char elements at their approximate editor positions
+    const charEls = [];
+    chars.forEach((char, i) => {
+      if (char === ' ' || char === '　') return; // skip spaces
+
+      const el = document.createElement('span');
+      el.className = 'st-char';
+      el.style.fontSize = fontSize + 'px';
+      el.style.fontFamily = getComputedStyle(editorEl).fontFamily;
+      el.style.color = getComputedStyle(editorEl).color;
+
+      const inner = document.createElement('span');
+      inner.className = 'st-char-inner';
+      inner.textContent = char;
+      el.appendChild(inner);
+
+      // Calculate approximate position in editor
+      const lineHeight = fontSize * 1.85;
+      let x, y;
+      if (isVertical) {
+        // vertical-rl: columns go right to left, chars go top to bottom
+        const col = Math.floor(i / Math.floor(editorRect.height / lineHeight));
+        const row = i % Math.floor(editorRect.height / lineHeight);
+        x = editorRect.right - (col + 1) * lineHeight;
+        y = editorRect.top + row * fontSize;
+      } else {
+        const row = Math.floor(i / Math.floor(editorRect.width / fontSize));
+        const col = i % Math.floor(editorRect.width / fontSize);
+        x = editorRect.left + col * fontSize;
+        y = editorRect.top + row * lineHeight;
+      }
+
+      el.style.left = x + 'px';
+      el.style.top = y + 'px';
+
+      overlay.appendChild(el);
+      charEls.push(el);
+    });
+
+    // ── Compute animation variables ──
+    const screenCX = window.innerWidth / 2;
+    const screenCY = window.innerHeight / 2;
+    const jarCY = screenCY + 40; // jar center is slightly below viewport center
+    const jarRadius = 30;
+    const total = charEls.length;
+
+    // Decide which 70% will fade out
+    const shuffled = [...charEls].sort(() => Math.random() - 0.5);
+    const fadeChars = shuffled.slice(0, Math.floor(total * 0.7));
+
+    charEls.forEach((el, i) => {
+      const rect = el.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+
+      // Direction from center
+      const dx = cx - screenCX;
+      const dy = cy - screenCY;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const nx = dx / dist, ny = dy / dist;
+
+      // Scatter: fly outward
+      const scatterMag = 300 + Math.random() * 500;
+      const sx = nx * scatterMag + (Math.random() - 0.5) * 200;
+      const sy = ny * scatterMag + (Math.random() - 0.5) * 200;
+      const sr = (Math.random() - 0.5) * 720;
+
+      // Condense: circle formation inside jar
+      const angle = (i / total) * Math.PI * 2;
+      const r = jarRadius + (Math.random() - 0.5) * 20;
+      const circleX = Math.cos(angle) * r;
+      const circleY = Math.sin(angle) * r;
+      const circleRot = (angle * 180 / Math.PI) + (Math.random() - 0.5) * 30;
+
+      // Float: small drift from condensed position
+      const floatDx = (Math.random() - 0.5) * 20;
+      const floatDy = (Math.random() - 0.5) * 20;
+      const fx = (screenCX - cx) + circleX + floatDx;
+      const fy = (jarCY - cy) + circleY + floatDy;
+      const fr = (Math.random() - 0.5) * 30;
+
+      // Gentle float animation timing
+      const fdur = 3 + Math.random() * 4;
+      const fdel = Math.random() * 2;
+
+      el.style.setProperty('--tx', `${sx}px`);
+      el.style.setProperty('--ty', `${sy}px`);
+      el.style.setProperty('--r', `${sr}deg`);
+
+      el.style.setProperty('--cx', `${(screenCX - cx) + circleX}px`);
+      el.style.setProperty('--cy', `${(jarCY - cy) + circleY}px`);
+      el.style.setProperty('--cr', `${circleRot}deg`);
+
+      el.style.setProperty('--fx', `${fx}px`);
+      el.style.setProperty('--fy', `${fy}px`);
+      el.style.setProperty('--fr', `${fr}deg`);
+
+      const innerEl = el.querySelector('.st-char-inner');
+      if (innerEl) {
+        innerEl.style.setProperty('--fdur', `${fdur}s`);
+        innerEl.style.setProperty('--fdel', `-${fdel}s`);
+      }
+    });
+
+    // ── Execute animation timeline ──
+
+    // Phase 1 (0s): Scatter — chars fly outward
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        overlay.classList.add('phase-scatter');
+      });
+    });
+
+    // Phase 2 (1.5s): Background swap — hide editor, show jar
+    setTimeout(() => {
+      // Switch view to jar but keep editor visible briefly for crossfade
+      const editorView = document.getElementById('view-editor');
+      const jarView = document.getElementById('view-jar');
+
+      // Show jar view underneath
+      jarView.classList.add('active');
+      jarView.style.opacity = '0';
+      jarView.style.transition = 'opacity 1s ease';
+      if (typeof JarView !== 'undefined' && JarView.activate) JarView.activate();
+
+      // Crossfade
+      requestAnimationFrame(() => {
+        jarView.style.opacity = '1';
+        editorView.style.opacity = '0';
+        editorView.style.transition = 'opacity 1s ease';
+      });
+
+      // After crossfade completes, clean up editor view
+      setTimeout(() => {
+        editorView.classList.remove('active');
+        editorView.style.opacity = '';
+        editorView.style.transition = '';
+        jarView.style.opacity = '';
+        jarView.style.transition = '';
+        State.set('currentScreen', 'jar');
+        // Update sidebar
+        document.querySelectorAll('.sidebar-btn[data-screen]').forEach(btn => {
+          btn.classList.toggle('active', btn.dataset.screen === 'jar');
+        });
+        document.getElementById('footer-mode').textContent = 'Fermenting';
+      }, 1000);
+    }, 1500);
+
+    // Phase 3 (2s): Condense — chars form tight circle inside jar
+    setTimeout(() => {
+      overlay.classList.remove('phase-scatter');
+      overlay.classList.add('phase-condense');
+    }, 2000);
+
+    // Phase 4 (3.5s): Float — 70% fade out, rest gently float
+    setTimeout(() => {
+      overlay.classList.remove('phase-condense');
+      overlay.classList.add('phase-float');
+
+      // Fade out 70%
+      fadeChars.forEach(el => el.classList.add('st-hidden'));
+
+      // Start gentle float animation on remaining chars
+      setTimeout(() => {
+        charEls.forEach(el => {
+          if (!el.classList.contains('st-hidden')) {
+            el.classList.add('st-float-anim');
+          }
+        });
+      }, 1000);
+    }, 3500);
+
+    // Phase 5 (6.5s): Clean up — fade out overlay entirely
+    setTimeout(() => {
+      overlay.style.transition = 'opacity 1.5s ease';
+      overlay.style.opacity = '0';
+      setTimeout(() => {
+        overlay.classList.remove('active', 'phase-scatter', 'phase-condense', 'phase-float');
+        overlay.style.opacity = '';
+        overlay.style.transition = '';
+        overlay.innerHTML = '';
+        isRunning = false;
+      }, 1500);
+    }, 6500);
+  }
+
+  return { run, get isRunning() { return isRunning; } };
+})();
+
+// ─── wire save transition into triggerSave ──────────────────────────────────
+(() => {
+  const origTriggerSave = window.triggerSave || triggerSave;
+  window.triggerSave = async function() {
+    const currentText = Editor.getContent();
+
+    // Save normally (includes title dialog)
+    await origTriggerSave();
+
+    // After save completes, run the transition if we have text
+    if (currentText && currentText.trim().length > 0 && State.get('currentScreen') === 'editor') {
+      SaveTransition.run(currentText);
+    } else if (State.get('currentScreen') === 'editor') {
+      // No text — just switch to jar
+      Navigation.switchTo('jar');
+    }
+  };
+})();
+
+
+</script>
+<script src="jar-view-new.js"></script>
+<script src="jar-view2.js"></script>
+<script>
+  // Start on jar screen (after jar-view-new.js is loaded)
+  Navigation.switchTo('jar');
+</script>
+</body>
+</html>

--- a/docs/reference-ui/jar-view-new.js
+++ b/docs/reference-ui/jar-view-new.js
@@ -1,0 +1,1493 @@
+/**
+ * Jar View for Oryzae Web App
+ * Three.js jar bottle with circular graphics for questions, zoom/detail UI
+ */
+
+// ============================================================================
+// GLOBAL STATE
+// ============================================================================
+
+window.jarRenderer = null;
+let jarRenderer = null;
+let jarScene = null;
+let jarCamera = null;
+let jarClock = null;
+let animationFrameId = null;
+let jarIsAnimating = false;
+
+const jarState = {
+  currentZoomedQuestionId: null,
+  currentDetailElementType: null, // 'snippet', 'keyword', 'letter'
+  circleInstances: {}, // { questionId: CircleGraphic }
+};
+
+const textParticleWords = [
+  '発酵','記憶','静寂','問い','秋','醸す','澱','季節',
+  '時間','思考','沈殿','麹','息','熱','言葉','微生物',
+  '風','心','光','闇','朝','夜','蔵','水','塩','米','土','菌'
+];
+
+// ============================================================================
+// JAR BOTTLE (Three.js)
+// ============================================================================
+
+class JarBottle {
+  constructor(container) {
+    this.container = container;
+    this.width = container.offsetWidth || 260;
+    this.height = container.offsetHeight || 340;
+    this.sprites = [];
+    this.microbes = [];
+
+    this.initRenderer();
+    this.initScene();
+    this.buildJar();
+    this.createTextParticles();
+    this.createMicrobes();
+  }
+
+  initRenderer() {
+    const canvas = document.createElement('canvas');
+    this.container.appendChild(canvas);
+
+    this.renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+    this.renderer.setSize(this.width, this.height);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.outputEncoding = THREE.sRGBEncoding;
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.shadowMap.enabled = false;
+  }
+
+  initScene() {
+    this.scene = new THREE.Scene();
+    this.scene.background = null;
+
+    // Camera
+    this.camera = new THREE.PerspectiveCamera(60, this.width / this.height, 0.1, 100);
+    this.camera.position.set(0, 2.0, 16);
+    this.camera.lookAt(0, 0, 0);
+
+    // Lighting
+    this.scene.add(new THREE.AmbientLight(0xfff5e6, 1.0));
+    const topLight = new THREE.PointLight(0xffedd5, 2.5, 20);
+    topLight.position.set(2, 6, 4);
+    this.scene.add(topLight);
+    const rimLight = new THREE.DirectionalLight(0xffffff, 1.2);
+    rimLight.position.set(-3, 2, -3);
+    this.scene.add(rimLight);
+    const internalLight = new THREE.PointLight(0xd97706, 2.5, 5);
+    internalLight.position.set(0, -0.5, 0);
+    this.scene.add(internalLight);
+  }
+
+  buildJar() {
+    // Materials
+    const glassMat = new THREE.MeshPhysicalMaterial({
+      color: 0xfafffe,
+      transmission: 0.92,
+      roughness: 0.04,
+      ior: 1.52,
+      thickness: 0.12,
+      side: THREE.DoubleSide,
+      transparent: true
+    });
+
+    const outlineMat = new THREE.MeshBasicMaterial({
+      color: 0x7a9e8e,
+      side: THREE.BackSide,
+      transparent: true,
+      opacity: 0.65
+    });
+
+    const lidMat = new THREE.MeshPhysicalMaterial({
+      color: 0xeef6ff,
+      transmission: 0.82,
+      roughness: 0.06,
+      ior: 1.52,
+      thickness: 0.10,
+      side: THREE.DoubleSide,
+      transparent: true
+    });
+
+    this.jarGroup = new THREE.Group();
+    this.scene.add(this.jarGroup);
+
+    const jarBottomY = -3.64, jarTopY = 3.64;
+    const profile = [
+      [0.00, jarBottomY],       [2.288, jarBottomY],
+      [2.340, jarBottomY+0.312],[2.444, jarBottomY+1.300],
+      [2.652, jarBottomY+2.600],[2.704, jarBottomY+3.900],
+      [2.548, jarBottomY+4.820],[2.132, jarBottomY+5.668],
+      [1.612, jarBottomY+6.448],[1.508, jarBottomY+6.812],
+      [1.560, jarBottomY+7.072],[1.768, jarTopY],
+    ];
+
+    const profilePoints = profile.map(([r,y]) => new THREE.Vector2(r,y));
+    this.jarGroup.add(new THREE.Mesh(new THREE.LatheGeometry(profilePoints, 72), glassMat));
+
+    const outlinePts = profile.map(([r,y]) => new THREE.Vector2(r*1.025, y));
+    this.jarGroup.add(new THREE.Mesh(new THREE.LatheGeometry(outlinePts, 72), outlineMat));
+
+    const baseDisc = new THREE.Mesh(new THREE.CircleGeometry(2.288, 64), glassMat);
+    baseDisc.rotation.x = Math.PI/2;
+    baseDisc.position.y = jarBottomY+0.01;
+    this.jarGroup.add(baseDisc);
+
+    const lidDisc = new THREE.Mesh(new THREE.CylinderGeometry(2.04,2.04,0.21,64), lidMat);
+    lidDisc.position.y = jarTopY+0.106;
+    this.jarGroup.add(lidDisc);
+
+    const lidOutline = new THREE.Mesh(new THREE.CylinderGeometry(2.11,2.11,0.25,64), outlineMat);
+    lidOutline.position.y = jarTopY+0.106;
+    this.jarGroup.add(lidOutline);
+
+    // Liquid
+    this.liqHeight = 4.42;
+    this.liqBottomY = jarBottomY+0.34;
+    this.liqTopY = this.liqBottomY + this.liqHeight;
+
+    const liqPoints = [
+      [0.00, this.liqBottomY],[2.132, this.liqBottomY],[2.236, this.liqBottomY+1.04],
+      [2.444, this.liqBottomY+2.34],[2.470, this.liqBottomY+3.64],[2.288, this.liqTopY]
+    ].map(([r,y]) => new THREE.Vector2(r,y));
+
+    const liqVolMat = new THREE.MeshBasicMaterial({
+      color: 0x5db85a,
+      transparent: true,
+      opacity: 0.15,
+      side: THREE.FrontSide,
+      depthTest: false,
+      depthWrite: false
+    });
+
+    const liqVolMesh = new THREE.Mesh(new THREE.LatheGeometry(liqPoints, 64), liqVolMat);
+    liqVolMesh.renderOrder = 2;
+    this.scene.add(liqVolMesh);
+
+    const liqCapMat = new THREE.MeshBasicMaterial({
+      color: 0x5db85a,
+      transparent: true,
+      opacity: 0.15,
+      side: THREE.FrontSide,
+      depthTest: false,
+      depthWrite: false
+    });
+
+    const liqCapMesh = new THREE.Mesh(new THREE.CircleGeometry(liqPoints[0].x * 0.98, 64), liqCapMat);
+    liqCapMesh.rotation.x = Math.PI / 2;
+    liqCapMesh.position.y = liqPoints[0].y + 0.01;
+    liqCapMesh.renderOrder = 2;
+    this.scene.add(liqCapMesh);
+
+    const liqTopCapMat = new THREE.MeshBasicMaterial({
+      color: 0x5db85a,
+      transparent: true,
+      opacity: 0.15,
+      side: THREE.FrontSide,
+      depthTest: false,
+      depthWrite: false
+    });
+
+    const liqTopCapMesh = new THREE.Mesh(new THREE.CircleGeometry(2.288 * 0.98, 64), liqTopCapMat);
+    liqTopCapMesh.rotation.x = -Math.PI / 2;
+    liqTopCapMesh.position.y = this.liqTopY;
+    liqTopCapMesh.renderOrder = 2;
+    this.scene.add(liqTopCapMesh);
+
+    this.jarRadiusBot = 2.132;
+  }
+
+  createTextParticles() {
+    // Create sprite text particles (the main word set)
+    const mainWords = textParticleWords.slice(0, 8);
+    mainWords.forEach(word => {
+      const sprite = this.mkSprite(word, {
+        fontSize: 28,
+        opacity: 0.72,
+        weight: 500
+      });
+      sprite.scale.set(0.7, 0.35, 1);
+      sprite.renderOrder = 3;
+
+      const r = Math.random() * (this.jarRadiusBot - 0.2);
+      const th = Math.random() * Math.PI * 2;
+      const y = this.liqBottomY + 0.2 + Math.random() * (this.liqHeight - 0.4);
+
+      sprite.position.set(r * Math.cos(th), y, r * Math.sin(th));
+      sprite.userData = {
+        baseY: y,
+        baseX: sprite.position.x,
+        baseZ: sprite.position.z,
+        speed: 0.35 + Math.random() * 0.4,
+        offset: Math.random() * Math.PI * 2,
+        amplitude: 0.04 + Math.random() * 0.04,
+        speedX: 0.22 + Math.random() * 0.3,
+        offsetX: Math.random() * Math.PI * 2,
+        amplitudeX: 0.03 + Math.random() * 0.03,
+        speedZ: 0.18 + Math.random() * 0.28,
+        offsetZ: Math.random() * Math.PI * 2,
+        amplitudeZ: 0.03 + Math.random() * 0.03
+      };
+
+      this.scene.add(sprite);
+      this.sprites.push(sprite);
+    });
+
+    // Additional filler particles
+    const kana = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん';
+    for (let i = 0; i < 100; i++) {
+      const isW = Math.random() > 0.55;
+      const txt = isW ? textParticleWords[Math.floor(Math.random() * textParticleWords.length)] : kana[Math.floor(Math.random() * kana.length)];
+      const fs = isW ? (10 + Math.random() * 8) : (7 + Math.random() * 5);
+      const al = 0.18 + Math.random() * 0.38;
+
+      const sprite = this.mkSprite(txt, {
+        fontSize: Math.round(fs * 3.5),
+        width: 128,
+        height: 56,
+        opacity: al,
+        weight: 300
+      });
+
+      const sw = isW ? (0.38 + Math.random() * 0.28) : (0.16 + Math.random() * 0.14);
+      sprite.scale.set(sw, sw * 0.5, 1);
+
+      const an = Math.random() * Math.PI * 2;
+      const rd = Math.random() * (this.jarRadiusBot - 0.08);
+      const y = this.liqBottomY + 0.08 + Math.pow(Math.random(), 1.6) * (this.liqHeight - 0.12);
+
+      sprite.position.set(Math.cos(an) * rd, y, Math.sin(an) * rd);
+      sprite.userData = {
+        baseY: y,
+        baseX: sprite.position.x,
+        baseZ: sprite.position.z,
+        speed: 0.15 + Math.random() * 0.3,
+        offset: Math.random() * Math.PI * 2,
+        amplitude: 0.02 + Math.random() * 0.03,
+        speedX: 0.10 + Math.random() * 0.2,
+        offsetX: Math.random() * Math.PI * 2,
+        amplitudeX: 0.015 + Math.random() * 0.02,
+        speedZ: 0.08 + Math.random() * 0.18,
+        offsetZ: Math.random() * Math.PI * 2,
+        amplitudeZ: 0.015 + Math.random() * 0.02
+      };
+
+      this.scene.add(sprite);
+      this.sprites.push(sprite);
+    }
+  }
+
+  mkSprite(text, opts = {}) {
+    const c = document.createElement('canvas');
+    const fs = opts.fontSize || 28;
+    c.width = opts.width || 192;
+    c.height = opts.height || 80;
+
+    const ctx = c.getContext('2d');
+    ctx.font = `${opts.weight || 400} ${fs}px "Noto Serif JP"`;
+    ctx.fillStyle = opts.color || '#4a3f35';
+    ctx.globalAlpha = 1;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, c.width / 2, c.height / 2);
+
+    const tex = new THREE.CanvasTexture(c);
+    tex.needsUpdate = true;
+
+    return new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: tex,
+        transparent: true,
+        opacity: opts.opacity ?? 0.75,
+        depthTest: false
+      })
+    );
+  }
+
+  createMicrobes() {
+    // Load SVG files as sprite textures
+    const svgFiles = [
+      { file: 'lab.svg', count: 3 },
+      { file: 'yeast.svg', count: 3 },
+      { file: 'koji.svg', count: 3 },
+    ];
+
+    svgFiles.forEach(({ file, count }) => {
+      const img = new Image();
+      img.onload = () => {
+        for (let i = 0; i < count; i++) {
+          const canvas = document.createElement('canvas');
+          canvas.width = 64;
+          canvas.height = 64;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0, 64, 64);
+
+          const tex = new THREE.CanvasTexture(canvas);
+          tex.needsUpdate = true;
+
+          const sprite = new THREE.Sprite(
+            new THREE.SpriteMaterial({
+              map: tex,
+              transparent: true,
+              opacity: 0.5 + Math.random() * 0.2,
+              depthTest: false
+            })
+          );
+
+          const scale = 0.25 + Math.random() * 0.15;
+          sprite.scale.set(scale, scale, 1);
+          sprite.renderOrder = 3;
+
+          // Position near text particles within the liquid
+          const ref = this.sprites[Math.floor(Math.random() * Math.min(8, this.sprites.length))];
+          const offR = 0.12 + Math.random() * 0.25;
+          const offTh = Math.random() * Math.PI * 2;
+
+          sprite.position.set(
+            ref.position.x + Math.cos(offTh) * offR,
+            ref.position.y + (Math.random() - 0.5) * 0.15,
+            ref.position.z + Math.sin(offTh) * offR
+          );
+
+          sprite.userData = {
+            basePos: sprite.position.clone(),
+            driftSpeed: 0.18 + Math.random() * 0.22,
+            driftOffset: Math.random() * Math.PI * 2,
+            driftAmpY: 0.04 + Math.random() * 0.04,
+            driftAmpX: 0.025 + Math.random() * 0.025,
+            rotSpeed: (Math.random() - 0.5) * 0.4,
+            wobbleFreq: 0.8 + Math.random() * 0.6,
+            wobbleAmp: 0.008 + Math.random() * 0.01,
+          };
+
+          this.scene.add(sprite);
+          this.microbes.push(sprite);
+        }
+      };
+      img.src = file;
+    });
+  }
+
+  mkMicrobeMat(color, opacity) {
+    return new THREE.MeshPhysicalMaterial({
+      color,
+      transparent: true,
+      opacity,
+      roughness: 0.25,
+      metalness: 0.0,
+      side: THREE.DoubleSide,
+      depthTest: false,
+      depthWrite: false
+    });
+  }
+
+  makeLacto(scale = 1) {
+    const g = new THREE.Group();
+    const mat = this.mkMicrobeMat(0xd4e8c2, 0.4);
+
+    const bodyGeo = new THREE.CylinderGeometry(0.045 * scale, 0.045 * scale, 0.24 * scale, 16);
+    const capGeo = new THREE.SphereGeometry(0.045 * scale, 16, 8);
+
+    const body = new THREE.Mesh(bodyGeo, mat);
+    body.renderOrder = 3;
+
+    const capTop = new THREE.Mesh(capGeo, mat);
+    capTop.position.y = 0.12 * scale;
+    capTop.renderOrder = 3;
+
+    const capBot = new THREE.Mesh(capGeo, mat);
+    capBot.position.y = -0.12 * scale;
+    capBot.renderOrder = 3;
+
+    g.add(body, capTop, capBot);
+    g.rotation.z = (Math.random() - 0.5) * 0.6;
+    g.rotation.x = (Math.random() - 0.5) * 0.3;
+
+    return g;
+  }
+
+  makeYeast(scale = 1) {
+    const g = new THREE.Group();
+    const mat = this.mkMicrobeMat(0xf5d9a0, 0.4);
+
+    const bodyGeo = new THREE.SphereGeometry(0.11 * scale, 20, 16);
+    const body = new THREE.Mesh(bodyGeo, mat);
+    body.renderOrder = 3;
+    body.scale.set(1, 1.22, 1);
+
+    const budGeo = new THREE.SphereGeometry(0.055 * scale, 14, 10);
+    const bud = new THREE.Mesh(budGeo, mat);
+    bud.renderOrder = 3;
+    bud.position.set(0.10 * scale, 0.10 * scale, 0);
+
+    g.add(body, bud);
+    return g;
+  }
+
+  makeKoji(scale = 1) {
+    const g = new THREE.Group();
+    const stalkMat = this.mkMicrobeMat(0xc8b4e0, 0.4);
+    const headMat = this.mkMicrobeMat(0xe8d4f8, 0.4);
+
+    const stalkGeo = new THREE.CylinderGeometry(0.018 * scale, 0.022 * scale, 0.28 * scale, 10);
+    const stalk = new THREE.Mesh(stalkGeo, stalkMat);
+    stalk.renderOrder = 3;
+    stalk.position.y = 0.0;
+
+    const headGeo = new THREE.SphereGeometry(0.075 * scale, 18, 12);
+    const head = new THREE.Mesh(headGeo, headMat);
+    head.renderOrder = 3;
+    head.position.y = 0.17 * scale;
+
+    const sporeCount = 10;
+    for (let i = 0; i < sporeCount; i++) {
+      const phi = (i / sporeCount) * Math.PI * 2;
+      const sGeo = new THREE.SphereGeometry(0.018 * scale, 8, 6);
+      const s = new THREE.Mesh(sGeo, headMat);
+      s.renderOrder = 3;
+      s.position.set(
+        Math.cos(phi) * 0.105 * scale,
+        0.17 * scale + Math.sin(phi) * 0.012 * scale,
+        Math.sin(phi) * 0.105 * scale
+      );
+      g.add(s);
+    }
+
+    g.add(stalk, head);
+    g.rotation.z = (Math.random() - 0.5) * 0.4;
+
+    return g;
+  }
+
+  update(elapsedTime) {
+    const speedMult = 2.0;
+    const ampMult = 2.0;
+
+    // Update sprites
+    this.sprites.forEach(s => {
+      const u = s.userData;
+      s.position.y = u.baseY + Math.sin(elapsedTime * u.speed * speedMult + u.offset) * u.amplitude * ampMult;
+      s.position.x = u.baseX + Math.sin(elapsedTime * u.speedX * speedMult + u.offsetX) * u.amplitudeX * ampMult;
+      s.position.z = u.baseZ + Math.cos(elapsedTime * u.speedZ * speedMult + u.offsetZ) * u.amplitudeZ * ampMult;
+      s.lookAt(this.camera.position);
+    });
+
+    // Update microbes
+    this.microbes.forEach(m => {
+      const u = m.userData;
+      m.position.y = u.basePos.y + Math.sin(elapsedTime * u.driftSpeed + u.driftOffset) * u.driftAmpY;
+      m.position.x = u.basePos.x + Math.sin(elapsedTime * u.driftSpeed * 0.7 + u.driftOffset + 1.3) * u.driftAmpX;
+      m.rotation.y += 0.003 * u.rotSpeed;
+
+      if (m.position.y > this.liqTopY - 0.1) m.position.y = this.liqTopY - 0.1;
+      if (m.position.y < this.liqBottomY + 0.1) m.position.y = this.liqBottomY + 0.1;
+    });
+
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  // Animate new words falling into the jar (漬け込む effect)
+  feedWords(words) {
+    if (!words || words.length === 0) return;
+
+    words.forEach((word, i) => {
+      const sprite = this.mkSprite(word, {
+        fontSize: 24 + Math.random() * 8,
+        opacity: 0,
+        weight: 500
+      });
+      sprite.scale.set(0.5 + Math.random() * 0.3, 0.25 + Math.random() * 0.15, 1);
+      sprite.renderOrder = 4;
+
+      // Start above the jar opening
+      const startX = (Math.random() - 0.5) * 1.5;
+      const startY = this.liqTopY + 3 + Math.random() * 1.5;
+      const startZ = (Math.random() - 0.5) * 0.5;
+      sprite.position.set(startX, startY, startZ);
+
+      // Target: random position within the liquid
+      const targetAngle = Math.random() * Math.PI * 2;
+      const targetR = Math.random() * (this.jarRadiusBot - 0.3);
+      const targetY = this.liqBottomY + 0.2 + Math.random() * (this.liqHeight - 0.4);
+      const targetX = Math.cos(targetAngle) * targetR;
+      const targetZ = Math.sin(targetAngle) * targetR;
+
+      this.scene.add(sprite);
+
+      // Animate with delay per word
+      const delay = i * 180;
+      const duration = 1800 + Math.random() * 600;
+      const startTime = performance.now() + delay;
+
+      const animateEntry = () => {
+        const now = performance.now();
+        const elapsed = now - startTime;
+        if (elapsed < 0) {
+          requestAnimationFrame(animateEntry);
+          return;
+        }
+
+        const t = Math.min(1, elapsed / duration);
+        // Ease-out cubic
+        const ease = 1 - Math.pow(1 - t, 3);
+
+        sprite.position.x = startX + (targetX - startX) * ease;
+        sprite.position.y = startY + (targetY - startY) * ease;
+        sprite.position.z = startZ + (targetZ - startZ) * ease;
+
+        // Fade in during first half, then settle at final opacity
+        const finalOpacity = 0.3 + Math.random() * 0.35;
+        if (t < 0.3) {
+          sprite.material.opacity = (t / 0.3) * finalOpacity;
+        } else {
+          sprite.material.opacity = finalOpacity;
+        }
+
+        if (t < 1) {
+          requestAnimationFrame(animateEntry);
+        } else {
+          // Settled - add to sprites array for ongoing floating animation
+          sprite.userData = {
+            baseY: targetY,
+            baseX: targetX,
+            baseZ: targetZ,
+            speed: 0.2 + Math.random() * 0.3,
+            offset: Math.random() * Math.PI * 2,
+            amplitude: 0.03 + Math.random() * 0.03,
+            speedX: 0.15 + Math.random() * 0.2,
+            offsetX: Math.random() * Math.PI * 2,
+            amplitudeX: 0.02 + Math.random() * 0.02,
+            speedZ: 0.12 + Math.random() * 0.18,
+            offsetZ: Math.random() * Math.PI * 2,
+            amplitudeZ: 0.02 + Math.random() * 0.02
+          };
+          this.sprites.push(sprite);
+        }
+      };
+      requestAnimationFrame(animateEntry);
+    });
+  }
+
+  dispose() {
+    this.renderer.dispose();
+    this.container.removeChild(this.renderer.domElement);
+  }
+}
+
+// ============================================================================
+// CIRCLE GRAPHICS
+// ============================================================================
+
+class CircleGraphic {
+  constructor(questionId, position, size = 200) {
+    this.questionId = questionId;
+    this.position = position;
+    this.size = size;
+    this.element = document.createElement('div');
+    this.element.className = 'jar-circle';
+    this.element.dataset.questionId = questionId;
+    this.element.style.cssText = `
+      position: absolute;
+      left: ${position.x}px;
+      top: ${position.y}px;
+      width: ${size}px;
+      height: ${size}px;
+      transform: translateX(-50%) translateY(-50%);
+      cursor: pointer;
+    `;
+
+    this.bobOffset = Math.random() * Math.PI * 2;
+    this.floatingElements = [];
+    this.render();
+  }
+
+  render() {
+    const question = OryzaeData.getQuestionString(this.questionId);
+    const fermentation = OryzaeData.getFermentationForQuestion(this.questionId);
+
+    this.element.innerHTML = '';
+
+    const svgNS = 'http://www.w3.org/2000/svg';
+
+    // Circle border SVG (fits exactly in the element)
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${this.size} ${this.size}`);
+    svg.setAttribute('class', 'jar-circle-svg');
+    svg.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;';
+
+    // Gradient definition
+    const defs = document.createElementNS(svgNS, 'defs');
+    const grad = document.createElementNS(svgNS, 'linearGradient');
+    grad.setAttribute('id', `grad-${this.questionId}`);
+    grad.setAttribute('x1', '0%');
+    grad.setAttribute('y1', '0%');
+    grad.setAttribute('x2', '100%');
+    grad.setAttribute('y2', '100%');
+    const stop1 = document.createElementNS(svgNS, 'stop');
+    stop1.setAttribute('offset', '0%');
+    stop1.setAttribute('stop-color', '#d97706');
+    stop1.setAttribute('stop-opacity', '0.6');
+    const stop2 = document.createElementNS(svgNS, 'stop');
+    stop2.setAttribute('offset', '100%');
+    stop2.setAttribute('stop-color', '#f59e0b');
+    stop2.setAttribute('stop-opacity', '0.3');
+    grad.appendChild(stop1);
+    grad.appendChild(stop2);
+    defs.appendChild(grad);
+    svg.appendChild(defs);
+
+    // Circle border
+    const circle = document.createElementNS(svgNS, 'circle');
+    circle.setAttribute('cx', this.size / 2);
+    circle.setAttribute('cy', this.size / 2);
+    circle.setAttribute('r', this.size / 2 - 10);
+    circle.setAttribute('fill', 'none');
+    circle.setAttribute('stroke', `url(#grad-${this.questionId})`);
+    circle.setAttribute('stroke-width', '1');
+    // Inner decorative circle
+    const innerCircle = document.createElementNS(svgNS, 'circle');
+    innerCircle.setAttribute('cx', this.size / 2);
+    innerCircle.setAttribute('cy', this.size / 2);
+    innerCircle.setAttribute('r', this.size / 2 - 18);
+    innerCircle.setAttribute('fill', 'none');
+    innerCircle.setAttribute('stroke', `url(#grad-${this.questionId})`);
+    innerCircle.setAttribute('stroke-width', '0.5');
+    innerCircle.setAttribute('stroke-opacity', '0.5');
+    svg.appendChild(circle);
+    svg.appendChild(innerCircle);
+    this.element.appendChild(svg);
+
+    // Separate OUTER SVG for question text (larger than circle, positioned outside)
+    // Uses percentage-based sizing so it scales when circle zooms (width/height change)
+    const marginPct = 25; // percentage overshoot on each side
+    const textSvg = document.createElementNS(svgNS, 'svg');
+    textSvg.setAttribute('class', 'jar-circle-text-svg');
+    // viewBox is based on original circle size with margin
+    const margin = this.size * marginPct / 100;
+    const outerSvgSize = this.size + margin * 2;
+    textSvg.setAttribute('viewBox', `-${margin} -${margin} ${outerSvgSize} ${outerSvgSize}`);
+    textSvg.style.cssText = `position:absolute;top:-${marginPct}%;left:-${marginPct}%;width:${100 + marginPct * 2}%;height:${100 + marginPct * 2}%;pointer-events:none;z-index:5;overflow:visible;`;
+
+    const textDefs = document.createElementNS(svgNS, 'defs');
+    // Arc path OUTSIDE the circle border (radius larger than circle)
+    const cx = this.size / 2;
+    const cy = this.size / 2;
+    const textR = this.size / 2 + 4; // outside the border
+    const path = document.createElementNS(svgNS, 'path');
+    path.setAttribute('id', `path-${this.questionId}`);
+    path.setAttribute('d', `M ${cx - textR},${cy} A ${textR},${textR} 0 0,1 ${cx + textR},${cy}`);
+    path.setAttribute('fill', 'none');
+    textDefs.appendChild(path);
+    textSvg.appendChild(textDefs);
+
+    const textEl = document.createElementNS(svgNS, 'text');
+    textEl.setAttribute('fill', '#6b2c2c');
+    textEl.setAttribute('font-size', '13');
+    textEl.setAttribute('font-family', 'Noto Serif JP');
+    textEl.setAttribute('font-weight', '500');
+    textEl.setAttribute('letter-spacing', '0.12em');
+    textEl.style.textShadow = '0 0 4px rgba(250,248,245,1), 0 0 8px rgba(250,248,245,1), 0 0 12px rgba(250,248,245,0.8)';
+    const tpath = document.createElementNS(svgNS, 'textPath');
+    tpath.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `#path-${this.questionId}`);
+    tpath.setAttribute('startOffset', '50%');
+    tpath.setAttribute('text-anchor', 'middle');
+    tpath.textContent = question || '未タイトル';
+    textEl.appendChild(tpath);
+    textSvg.appendChild(textEl);
+
+    this.element.appendChild(textSvg);
+
+    // Inner content container (no clipping - circle is just a visual SVG border)
+    // Elements float freely within/around the circle like in circle-zoom.html
+    const innerDiv = document.createElement('div');
+    innerDiv.className = 'jar-circle-inner';
+    innerDiv.style.cssText = `
+      position: absolute;
+      inset: 0;
+    `;
+
+    this.floatingElements = [];
+
+    // Pre-defined scattered positions (as % of circle, relative to center)
+    // Must stay within ~20-80% to avoid circular clipping
+    // Order: 5 keywords, 3 snippets, 1 letter
+    const scatteredPositions = [
+      // Keyword positions - spread wide across circle for 2x scale
+      { x: 50, y: 18 },  // top center
+      { x: 78, y: 32 },  // top-right
+      { x: 75, y: 65 },  // bottom-right
+      { x: 24, y: 62 },  // bottom-left
+      { x: 22, y: 32 },  // top-left
+      // Snippet positions - spread in center with more spacing
+      { x: 36, y: 42 },
+      { x: 64, y: 46 },
+      { x: 50, y: 58 },
+      // Letter position - bottom center
+      { x: 50, y: 76 },
+    ];
+
+    let posIdx = 0;
+
+    if (fermentation) {
+      const snippets = OryzaeData.getSnippetsForFermentation(fermentation.id);
+      const keywords = OryzaeData.getKeywordsForFermentation(fermentation.id);
+      const letter = OryzaeData.getLetterForFermentation(fermentation.id);
+
+      // Yeast SVG inline (golden ellipse with bud)
+      const yeastSvgStr = `<svg viewBox="0 0 40 40" class="microbe-icon-svg"><ellipse cx="20" cy="22" rx="12" ry="14" fill="#e8a020"/><ellipse cx="20" cy="20" rx="12" ry="14" fill="#f5d9a0"/><circle cx="28" cy="12" r="6" fill="#f5d9a0"/></svg>`;
+      // Koji SVG inline (purple branching)
+      const kojiSvgStr = `<svg viewBox="0 0 40 40" class="microbe-icon-svg"><path d="M 20 35 L 20 15" stroke="#9955cc" stroke-width="3" stroke-linecap="round"/><circle cx="20" cy="12" r="8" fill="#bb88ee"/><circle cx="12" cy="8" r="3" fill="#bb88ee"/><circle cx="28" cy="8" r="3" fill="#bb88ee"/><circle cx="20" cy="4" r="3" fill="#bb88ee"/></svg>`;
+      // Lacto SVG inline (green ellipses)
+      const lactoSvgStr = `<svg viewBox="0 0 40 40" class="microbe-icon-svg"><ellipse cx="20" cy="24" rx="8" ry="10" fill="#5db85a"/><ellipse cx="20" cy="22" rx="8" ry="10" fill="#7dd87a"/><ellipse cx="20" cy="20" rx="6" ry="8" fill="#9ee89a"/></svg>`;
+
+      // Corner positions for microbe icon attachment
+      const cornerPositions = [
+        { cls: 'icon-top-right', style: 'right:-4px;top:-4px;' },
+        { cls: 'icon-top-left', style: 'left:-4px;top:-4px;' },
+        { cls: 'icon-bottom-right', style: 'right:-4px;bottom:-4px;' },
+        { cls: 'icon-bottom-left', style: 'left:-4px;bottom:-4px;' },
+      ];
+
+      // Add keywords (first 5) - brown fill, white text, yeast icon
+      keywords.slice(0, 5).forEach((keyword, idx) => {
+        const pos = scatteredPositions[posIdx++] || { x: 10 + Math.random() * 60, y: 30 + Math.random() * 40 };
+        const isVertical = idx % 3 === 1; // some vertical for shape variation
+        const rotations = [-5, 8, -3, 6, -7];
+        const tag = document.createElement('div');
+        tag.className = 'jar-circle-keyword jar-circle-element';
+        tag.dataset.type = 'keyword';
+        tag.dataset.index = idx;
+        // Yeast icon at random corner
+        const corner = cornerPositions[idx % cornerPositions.length];
+        tag.innerHTML = `<span class="kw-text" ${isVertical ? 'style="writing-mode:vertical-rl;"' : ''}>${keyword.keyword}</span><div class="microbe-attach" style="position:absolute;width:16px;height:16px;${corner.style}">${yeastSvgStr}</div>`;
+        tag.style.cssText = `
+          left: ${pos.x}%;
+          top: ${pos.y}%;
+          transform: translate(-50%, -50%) rotate(${rotations[idx]}deg) scale(var(--el-scale));
+          cursor: pointer;
+          user-select: none;
+        `;
+        tag._baseRotation = `rotate(${rotations[idx]}deg)`;
+        innerDiv.appendChild(tag);
+        this.floatingElements.push(tag);
+      });
+
+      // Add snippets (first 3) - white cards with koji icon
+      snippets.slice(0, 3).forEach((snippet, idx) => {
+        const pos = scatteredPositions[posIdx++] || { x: 30 + Math.random() * 40, y: 20 + Math.random() * 50 };
+        const rotations = [-12, 8, -5];
+        const card = document.createElement('div');
+        card.className = 'jar-circle-snippet jar-circle-element';
+        card.dataset.type = 'snippet';
+        card.dataset.index = idx;
+        // Koji icon at random corner
+        const corner = cornerPositions[(idx + 2) % cornerPositions.length];
+        card.innerHTML = `<span class="snippet-text-inner">${snippet.original_text.substring(0, 20)}...</span><div class="microbe-attach" style="position:absolute;width:12px;height:12px;${corner.style}">${kojiSvgStr}</div>`;
+        card.style.cssText = `
+          left: ${pos.x}%;
+          top: ${pos.y}%;
+          transform: translate(-50%, -50%) rotate(${rotations[idx]}deg) scale(var(--el-scale));
+          cursor: pointer;
+          user-select: none;
+        `;
+        card._baseRotation = `rotate(${rotations[idx]}deg)`;
+        innerDiv.appendChild(card);
+        this.floatingElements.push(card);
+      });
+
+      // Add letter icon - envelope SVG with lactobacillus icon
+      if (letter) {
+        const pos = scatteredPositions[posIdx++] || { x: 40, y: 75 };
+        const letterEl = document.createElement('div');
+        letterEl.className = 'jar-circle-letter jar-circle-element';
+        letterEl.dataset.type = 'letter';
+        letterEl.innerHTML = `
+          <div class="letter-envelope-mini">
+            <svg viewBox="0 0 100 80" class="w-full h-full"><rect x="5" y="20" width="90" height="55" rx="2" fill="#f5f0e8" stroke="#e6dec3" stroke-width="1"/><path d="M 5 20 L 50 55 L 95 20" fill="#e8e3d5" stroke="#d4c9b8" stroke-width="1"/><path d="M 5 75 L 50 40 L 95 75" fill="#faf8f5" stroke="#e6dec3" stroke-width="1"/><circle cx="50" cy="48" r="10" fill="#c855a0"/><circle cx="50" cy="48" r="7" fill="none" stroke="#a03070" stroke-width="1" opacity="0.5"/><path d="M 46 48 L 50 44 L 54 48 L 50 52 Z" fill="#f5f0e8"/></svg>
+          </div>
+          <div class="microbe-attach" style="position:absolute;width:18px;height:18px;left:-6px;top:-8px;">${lactoSvgStr}</div>
+        `;
+        letterEl.style.cssText = `
+          left: ${pos.x}%;
+          top: ${pos.y}%;
+          transform: translate(-50%, -50%) rotate(3deg) scale(var(--el-scale));
+          cursor: pointer;
+          user-select: none;
+        `;
+        letterEl._baseRotation = 'rotate(3deg)';
+        innerDiv.appendChild(letterEl);
+        this.floatingElements.push(letterEl);
+      }
+    } else {
+      // Empty state: floating microbe SVGs (lab, yeast, koji)
+      const microbeSpecs = [
+        { icon: 'lab.svg',   x: 35, y: 28, size: 36, rot: -10, opacity: 0.5 },
+        { icon: 'yeast.svg', x: 62, y: 35, size: 32, rot: 15,  opacity: 0.45 },
+        { icon: 'koji.svg',  x: 45, y: 52, size: 38, rot: -5,  opacity: 0.5 },
+        { icon: 'lab.svg',   x: 28, y: 62, size: 28, rot: 20,  opacity: 0.35 },
+        { icon: 'yeast.svg', x: 58, y: 65, size: 30, rot: -12, opacity: 0.4 },
+        { icon: 'koji.svg',  x: 68, y: 48, size: 26, rot: 8,   opacity: 0.35 },
+      ];
+      microbeSpecs.forEach((spec, idx) => {
+        const microbe = document.createElement('div');
+        microbe.className = 'jar-circle-microbe jar-circle-element';
+        microbe.innerHTML = `<img src="${spec.icon}" alt="" style="width:100%;height:100%;pointer-events:none;">`;
+        microbe.style.cssText = `
+          left: ${spec.x}%;
+          top: ${spec.y}%;
+          width: ${spec.size}px;
+          height: ${spec.size}px;
+          opacity: ${spec.opacity};
+          transform: translate(-50%, -50%) rotate(${spec.rot}deg) scale(var(--el-scale));
+          pointer-events: none;
+        `;
+        microbe._baseRotation = `rotate(${spec.rot}deg)`;
+        innerDiv.appendChild(microbe);
+        this.floatingElements.push(microbe);
+      });
+    }
+
+    this.element.appendChild(innerDiv);
+  }
+
+  update(elapsedTime) {
+    // Skip bobbing/floating animation when zoomed (would conflict with zoom CSS transition)
+    if (this.element.classList.contains('zoomed')) return;
+
+    // Circle container: bob up/down + subtle rotation (matching circle-zoom.html floatDrift)
+    const bobY = Math.sin(elapsedTime * 0.25 + this.bobOffset) * 6;
+    const bobX = Math.sin(elapsedTime * 0.18 + this.bobOffset + 1.5) * 3;
+    const bobRotate = Math.sin(elapsedTime * 0.2 + this.bobOffset + 0.8) * 0.5;
+
+    // Floating animation for inner elements (gentle drift + micro-rotation)
+    this.floatingElements.forEach((el, idx) => {
+      const phaseX = idx * Math.PI * 0.4 + 0.7;
+      const phaseY = idx * Math.PI * 0.3;
+      const offsetX = Math.sin(elapsedTime * (0.2 + idx * 0.03) + phaseX) * 4;
+      const offsetY = Math.sin(elapsedTime * (0.3 + idx * 0.05) + phaseY) * 4;
+      // Each element gets its own subtle rotation wobble
+      const elRotate = Math.sin(elapsedTime * (0.15 + idx * 0.02) + idx * 2.1) * 1.5;
+      const baseRotate = el._baseRotation || '';
+      el.style.transform = `translate(calc(-50% + ${offsetX}px), calc(-50% + ${offsetY}px)) ${baseRotate} rotate(${elRotate}deg) scale(var(--el-scale))`;
+    });
+
+    this.element.style.transform = `translateX(calc(-50% + ${bobX}px)) translateY(calc(-50% + ${bobY}px)) rotate(${bobRotate}deg)`;
+  }
+
+  getContainerElement() {
+    return document.getElementById('jar-circles-container');
+  }
+
+  mount() {
+    this.getContainerElement().appendChild(this.element);
+  }
+
+  unmount() {
+    if (this.element.parentNode) {
+      this.element.parentNode.removeChild(this.element);
+    }
+  }
+
+  attachClickHandler(callback) {
+    this.element.addEventListener('click', (e) => {
+      // If already zoomed, don't re-trigger zoom; stop propagation to prevent backdrop close
+      if (this.element.classList.contains('zoomed')) {
+        e.stopPropagation();
+        return;
+      }
+      e.stopPropagation();
+      callback(this.questionId);
+    });
+  }
+}
+
+// ============================================================================
+// CONNECTION LINES (SVG)
+// ============================================================================
+
+function updateConnectionLines() {
+  const svg = document.getElementById('jar-connection-lines');
+  if (!svg) return;
+
+  svg.innerHTML = '';
+
+  const viewJar = document.getElementById('view-jar');
+  const jarContainer = document.getElementById('jar-bottle-container');
+  const circlesContainer = document.getElementById('jar-circles-container');
+
+  if (!viewJar || !jarContainer || !circlesContainer) return;
+
+  const viewRect = viewJar.getBoundingClientRect();
+  const jarRect = jarContainer.getBoundingClientRect();
+
+  // Set SVG viewBox to match the view dimensions
+  const vW = viewJar.offsetWidth;
+  const vH = viewJar.offsetHeight;
+  svg.setAttribute('viewBox', `0 0 ${vW} ${vH}`);
+
+  // Jar center X relative to view-jar
+  const jarCX = jarRect.left - viewRect.left + jarRect.width / 2;
+
+  // Simple seeded random: generates a stable pseudo-random value from a string seed
+  function seededRandom(seed) {
+    let h = 0;
+    for (let i = 0; i < seed.length; i++) {
+      h = ((h << 5) - h + seed.charCodeAt(i)) | 0;
+    }
+    // Two separate hashes for x and y
+    const h1 = Math.abs(((h * 2654435761) >>> 0) / 4294967296);
+    const h2 = Math.abs(((h * 340573321) >>> 0) / 4294967296);
+    return { rx: h1, ry: h2 };
+  }
+
+  // Liquid region constraints (as fractions of jar rect)
+  // x: center ± 15% of jar width (stay inside the curved body)
+  // y: 45%–65% of jar height (below liquid surface, above bottom curve)
+  const liquidXRange = { min: -0.15, max: 0.15 };
+  const liquidYRange = { min: 0.45, max: 0.65 };
+
+  // Line segment intersection test (returns true if segments AB and CD intersect)
+  function segmentsIntersect(ax, ay, bx, by, cx, cy, dx, dy) {
+    const cross = (v1x, v1y, v2x, v2y) => v1x * v2y - v1y * v2x;
+    const d1 = cross(dx - cx, dy - cy, ax - cx, ay - cy);
+    const d2 = cross(dx - cx, dy - cy, bx - cx, by - cy);
+    const d3 = cross(bx - ax, by - ay, cx - ax, cy - ay);
+    const d4 = cross(bx - ax, by - ay, dx - ax, dy - ay);
+    if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+        ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+      return true;
+    }
+    return false;
+  }
+
+  const circles = circlesContainer.querySelectorAll('.jar-circle');
+
+  // Phase 1: compute circle centers and random target points
+  const lineData = [];
+  circles.forEach((circleEl, idx) => {
+    const qId = circleEl.dataset.questionId || `circle-${idx}`;
+    const { rx, ry } = seededRandom(qId);
+    const xOffset = liquidXRange.min + rx * (liquidXRange.max - liquidXRange.min);
+    const yFraction = liquidYRange.min + ry * (liquidYRange.max - liquidYRange.min);
+
+    const targetX = jarCX + jarRect.width * xOffset;
+    const targetY = jarRect.top - viewRect.top + jarRect.height * yFraction;
+
+    const circleRect = circleEl.getBoundingClientRect();
+    const cCX = circleRect.left - viewRect.left + circleRect.width / 2;
+    const cCY = circleRect.top - viewRect.top + circleRect.height / 2;
+
+    lineData.push({ cCX, cCY, targetX, targetY, circleRect });
+  });
+
+  // Phase 2: resolve intersections by swapping target points
+  // Repeat until no crossings remain (max 3 passes for safety)
+  for (let pass = 0; pass < 3; pass++) {
+    let swapped = false;
+    for (let i = 0; i < lineData.length; i++) {
+      for (let j = i + 1; j < lineData.length; j++) {
+        const a = lineData[i], b = lineData[j];
+        if (segmentsIntersect(
+          a.cCX, a.cCY, a.targetX, a.targetY,
+          b.cCX, b.cCY, b.targetX, b.targetY
+        )) {
+          // Swap target points to uncross
+          const tmpX = a.targetX, tmpY = a.targetY;
+          a.targetX = b.targetX; a.targetY = b.targetY;
+          b.targetX = tmpX; b.targetY = tmpY;
+          swapped = true;
+        }
+      }
+    }
+    if (!swapped) break;
+  }
+
+  // Phase 3: draw the lines
+  lineData.forEach(({ cCX, cCY, targetX, targetY, circleRect }) => {
+    const dx = targetX - cCX;
+    const dy = targetY - cCY;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const circleR = circleRect.width / 2;
+    const nx = dx / dist;
+    const ny = dy / dist;
+    const startX = cCX + nx * circleR;
+    const startY = cCY + ny * circleR;
+    // Control point for a gentle curve
+    const midX = (startX + targetX) / 2 + dy * 0.15;
+    const midY = (startY + targetY) / 2 - dx * 0.15;
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', `M ${startX},${startY} Q ${midX},${midY} ${targetX},${targetY}`);
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', 'var(--accent, #d97706)');
+    path.setAttribute('stroke-width', '1');
+    path.setAttribute('stroke-dasharray', '4 4');
+    path.setAttribute('opacity', '0.3');
+    svg.appendChild(path);
+  });
+}
+
+// ============================================================================
+// ZOOM OVERLAY
+// ============================================================================
+
+// ============================================================================
+// ZOOM (circle-zoom.html approach: circle itself transitions to center)
+// ============================================================================
+
+function openZoomOverlay(questionId) {
+  const circle = jarState.circleInstances[questionId];
+  if (!circle) return;
+
+  jarState.currentZoomedQuestionId = questionId;
+
+  const container = document.getElementById('jar-circles-container');
+  const viewJar = document.getElementById('view-jar');
+  if (!container || !viewJar) return;
+
+  // Calculate target: center of the view, scaled up
+  const viewW = viewJar.offsetWidth;
+  const viewH = viewJar.offsetHeight;
+  const targetSize = Math.min(viewW * 0.5, viewH * 0.75, 500);
+  const targetX = viewW / 2;
+  const targetY = viewH / 2;
+
+  // Apply zoomed state
+  const el = circle.element;
+  el.classList.add('zoomed');
+  el.style.left = targetX + 'px';
+  el.style.top = targetY + 'px';
+  el.style.width = targetSize + 'px';
+  el.style.height = targetSize + 'px';
+  el.style.transform = 'translate(-50%, -50%)';
+
+  // Show backdrop, hide other elements
+  container.classList.add('has-zoomed');
+  document.getElementById('jar-zoom-backdrop').classList.add('active');
+
+  // Attach click handlers to inner elements for detail pane
+  setupZoomedClickHandlers(circle);
+}
+
+function closeZoomOverlay() {
+  const questionId = jarState.currentZoomedQuestionId;
+  if (!questionId) return;
+
+  const circle = jarState.circleInstances[questionId];
+  if (!circle) return;
+
+  const container = document.getElementById('jar-circles-container');
+  const el = circle.element;
+
+  // Restore original position and size
+  el.classList.remove('zoomed');
+  el.style.left = circle.position.x + 'px';
+  el.style.top = circle.position.y + 'px';
+  el.style.width = circle.size + 'px';
+  el.style.height = circle.size + 'px';
+  el.style.transform = 'translateX(-50%) translateY(-50%)';
+
+  // Hide backdrop, show other elements
+  container.classList.remove('has-zoomed');
+  document.getElementById('jar-zoom-backdrop').classList.remove('active');
+
+  jarState.currentZoomedQuestionId = null;
+  closeDetailPane();
+  removeEmptyStateUI(circle);
+}
+
+function removeEmptyStateUI(circle) {
+  const existing = circle.element.querySelector('.jar-empty-state');
+  if (existing) existing.remove();
+}
+
+function setupEmptyStateUI(circle) {
+  removeEmptyStateUI(circle);
+  const questionId = circle.questionId;
+  const questionStr = OryzaeData.getQuestionString(questionId) || '';
+
+  const emptyDiv = document.createElement('div');
+  emptyDiv.className = 'jar-empty-state';
+  emptyDiv.innerHTML = `
+    <div class="jar-empty-state-message">この問いはまだ発酵が始まっていません。<br>しばらくの間、この問いに関するエントリを書き続けてください。</div>
+    <button class="jar-empty-state-btn">この問いのエントリを書く</button>
+  `;
+  circle.element.appendChild(emptyDiv);
+
+  // Fade in after zoom animation completes (~1.2s)
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      emptyDiv.classList.add('visible');
+    }, 1200);
+  });
+
+  emptyDiv.querySelector('.jar-empty-state-btn').addEventListener('click', (e) => {
+    e.stopPropagation();
+    // Close zoom overlay first
+    closeZoomOverlay();
+    // Create new entry and link this question
+    startNewDocument();
+    const entryId = State.get('currentEntryId');
+    OryzaeData.linkQuestionToEntry(entryId, questionId);
+    if (window.ToiManager) window.ToiManager.refresh();
+    Navigation.switchTo('editor');
+  });
+}
+
+function setupZoomedClickHandlers(circle) {
+  const questionId = circle.questionId;
+  const fermentation = OryzaeData.getFermentationForQuestion(questionId);
+  if (!fermentation) {
+    setupEmptyStateUI(circle);
+    return;
+  }
+
+  const snippets = OryzaeData.getSnippetsForFermentation(fermentation.id);
+  const keywords = OryzaeData.getKeywordsForFermentation(fermentation.id);
+
+  // Attach click handlers to elements inside the circle
+  circle.element.querySelectorAll('.jar-circle-element').forEach(el => {
+    // Remove old listeners by cloning
+    const newEl = el.cloneNode(true);
+    el.parentNode.replaceChild(newEl, el);
+
+    newEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const type = newEl.dataset.type;
+      const idx = parseInt(newEl.dataset.index) || 0;
+
+      if (type === 'keyword') {
+        showDetailPane(questionId, 'keyword', keywords, idx);
+      } else if (type === 'snippet') {
+        showDetailPane(questionId, 'snippet', snippets, idx);
+      } else if (type === 'letter') {
+        showDetailPane(questionId, 'letter', null, null);
+      }
+    });
+  });
+}
+
+// ============================================================================
+// DETAIL PANE
+// ============================================================================
+
+function showDetailPane(questionId, type, data, index) {
+  const pane = document.getElementById('jar-detail-pane');
+  const questionDiv = document.getElementById('jar-detail-question');
+  const header = document.getElementById('jar-detail-header');
+  const body = document.getElementById('jar-detail-body');
+  const writeBtn = document.getElementById('jar-detail-write-btn');
+
+  const question = OryzaeData.getQuestionString(questionId);
+  questionDiv.textContent = question || '未タイトル';
+
+  jarState.currentDetailElementType = type;
+
+  if (type === 'snippet') {
+    header.textContent = 'Oryzae が切り取った文章';
+    body.innerHTML = '';
+
+    const snippet = (index != null && data) ? data[index] : (data ? data[0] : null);
+    if (snippet) {
+      const item = document.createElement('div');
+      item.className = 'snippet-item';
+      item.innerHTML = `
+        <div class="snippet-text">${snippet.original_text}</div>
+        <div class="snippet-source">出典: ${snippet.source_date}</div>
+        <div class="snippet-reason">${snippet.selection_reason}</div>
+      `;
+      body.appendChild(item);
+    }
+  } else if (type === 'keyword') {
+    header.textContent = 'Yeast が生成したキーワード';
+    body.innerHTML = '';
+
+    const keyword = (index != null && data) ? data[index] : (data ? data[0] : null);
+    if (keyword) {
+      const item = document.createElement('div');
+      item.className = 'keyword-item';
+      item.innerHTML = `
+        <div class="keyword-name">${keyword.keyword}</div>
+        <div class="keyword-desc">${keyword.description}</div>
+      `;
+      body.appendChild(item);
+    }
+  } else if (type === 'letter') {
+    header.textContent = 'Lab からの手紙';
+    body.innerHTML = '';
+
+    const fermentation = OryzaeData.getFermentationForQuestion(questionId);
+    const letter = OryzaeData.getLetterForFermentation(fermentation.id);
+
+    const letterText = document.createElement('div');
+    letterText.className = 'letter-text';
+    letterText.innerHTML = letter.body_text.split('\n\n').map(p => `<p>${p}</p>`).join('');
+    body.appendChild(letterText);
+  }
+
+  pane.classList.add('active');
+
+  // Write button handler
+  writeBtn.onclick = () => {
+    OryzaeData.linkQuestionToEntry(State.get('currentEntryId'), questionId);
+    Navigation.switchTo('editor');
+  };
+}
+
+function closeDetailPane() {
+  const pane = document.getElementById('jar-detail-pane');
+  pane.classList.remove('active');
+}
+
+// ============================================================================
+// QUESTION MANAGEMENT
+// ============================================================================
+
+function renderQuestionList() {
+  const container = document.getElementById('jar-question-items');
+  const addBtn = document.getElementById('jar-add-question-btn');
+
+  const questions = OryzaeData.getActiveQuestions();
+
+  container.innerHTML = '';
+  questions.forEach(q => {
+    const text = OryzaeData.getQuestionString(q.id);
+    const tag = document.createElement('div');
+    tag.className = 'jar-question-tag';
+    tag.textContent = text || '未タイトル';
+    tag.style.cursor = 'pointer';
+    tag.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openEditQuestionModal(q.id);
+    });
+    container.appendChild(tag);
+  });
+
+  addBtn.style.display = questions.length < 3 ? 'block' : 'none';
+}
+
+function openAddQuestionModal() {
+  const modal = document.getElementById('jar-modal-overlay');
+  const input = document.getElementById('jar-modal-input');
+  const saveBtn = document.getElementById('jar-modal-save');
+  const cancelBtn = document.getElementById('jar-modal-cancel');
+
+  modal.style.display = 'flex';
+  setTimeout(() => modal.classList.add('active'), 10);
+  input.focus();
+
+  const save = () => {
+    const text = input.value.trim();
+    if (text) {
+      OryzaeData.addQuestion(text);
+      input.value = '';
+      closeAddQuestionModal();
+      renderJar();
+    }
+  };
+
+  saveBtn.onclick = save;
+  input.onkeypress = (e) => {
+    if (e.key === 'Enter') save();
+  };
+
+  cancelBtn.onclick = closeAddQuestionModal;
+}
+
+function closeAddQuestionModal() {
+  const modal = document.getElementById('jar-modal-overlay');
+  modal.classList.remove('active');
+  setTimeout(() => modal.style.display = 'none', 300);
+}
+
+// ============================================================================
+// EDIT/ARCHIVE QUESTION MODAL
+// ============================================================================
+
+function openEditQuestionModal(questionId) {
+  const modal = document.getElementById('jar-edit-modal-overlay');
+  const input = document.getElementById('jar-edit-modal-input');
+  const saveBtn = document.getElementById('jar-edit-modal-save');
+  const cancelBtn = document.getElementById('jar-edit-modal-cancel');
+  const archiveBtn = document.getElementById('jar-edit-modal-archive');
+  const charCount = document.getElementById('jar-edit-char-count');
+
+  const currentString = OryzaeData.getQuestionString(questionId) || '';
+  input.value = currentString;
+  if (charCount) charCount.textContent = currentString.length + '/64';
+
+  modal.style.display = 'flex';
+  setTimeout(() => modal.classList.add('active'), 10);
+  input.focus();
+  input.setSelectionRange(input.value.length, input.value.length);
+
+  input.oninput = () => {
+    if (charCount) charCount.textContent = input.value.length + '/64';
+  };
+
+  const save = () => {
+    const text = input.value.trim();
+    if (text && text !== currentString) {
+      OryzaeData.updateQuestion(questionId, text);
+      closeEditQuestionModal();
+      renderJar();
+    } else {
+      closeEditQuestionModal();
+    }
+  };
+
+  saveBtn.onclick = save;
+  cancelBtn.onclick = closeEditQuestionModal;
+
+  archiveBtn.onclick = () => {
+    OryzaeData.archiveQuestion(questionId);
+    closeEditQuestionModal();
+    renderJar();
+  };
+
+  // Close on backdrop click
+  modal.onclick = (e) => {
+    if (e.target === modal) closeEditQuestionModal();
+  };
+}
+
+function closeEditQuestionModal() {
+  const modal = document.getElementById('jar-edit-modal-overlay');
+  modal.classList.remove('active');
+  setTimeout(() => modal.style.display = 'none', 300);
+}
+
+// ============================================================================
+// MAIN JAR VIEW
+// ============================================================================
+
+function renderJar() {
+  const container = document.getElementById('jar-circles-container');
+  if (!container) return;
+
+  // Clear existing circles
+  Object.values(jarState.circleInstances).forEach(circle => circle.unmount());
+  jarState.circleInstances = {};
+
+  const questions = OryzaeData.getActiveQuestions();
+  // Calculate circle size based on container height to avoid overflow
+  const containerH = container.offsetHeight || 600;
+  const containerW = container.offsetWidth || 1000;
+  const circleSize = Math.min(240, containerH * 0.38);
+
+  const positions = [
+    { x: 80, y: 22 },  // top-right (further from jar)
+    { x: 72, y: 72 },  // bottom center-right (below jar, offset right)
+    { x: 14, y: 46 }   // center-left (further from jar)
+  ];
+
+  questions.forEach((q, idx) => {
+    if (idx < positions.length) {
+      const pos = positions[idx];
+      const x = containerW * (pos.x / 100);
+      const y = containerH * (pos.y / 100);
+
+      const circle = new CircleGraphic(q.id, { x, y }, circleSize);
+      circle.mount();
+      circle.attachClickHandler(openZoomOverlay);
+
+      jarState.circleInstances[q.id] = circle;
+    }
+  });
+
+  renderQuestionList();
+  updateConnectionLines();
+}
+
+function animateJar(currentTime) {
+  if (!jarRenderer) return;
+
+  const elapsedTime = jarClock.getElapsedTime();
+
+  // Update jar bottle
+  jarRenderer.update(elapsedTime);
+
+  // Update circles
+  Object.values(jarState.circleInstances).forEach(circle => {
+    circle.update(elapsedTime);
+  });
+
+  updateConnectionLines();
+
+  if (jarIsAnimating) {
+    animationFrameId = requestAnimationFrame(animateJar);
+  }
+}
+
+// ============================================================================
+// JAR VIEW CONTROLLER
+// ============================================================================
+
+let jarListenersAttached = false;
+
+const JarView = {
+  activate() {
+    const jarContainer = document.getElementById('jar-bottle-container');
+
+    if (!jarContainer) {
+      console.error('jar-bottle-container not found');
+      return;
+    }
+
+    // Initialize Three.js renderer (once)
+    if (!jarRenderer) {
+      jarRenderer = new JarBottle(jarContainer);
+      window.jarRenderer = jarRenderer;
+      jarClock = new THREE.Clock();
+    }
+
+    // Render circles
+    renderJar();
+
+    // Setup event listeners (once)
+    if (!jarListenersAttached) {
+      jarListenersAttached = true;
+
+      const zoomBackdrop = document.getElementById('jar-zoom-backdrop');
+      zoomBackdrop.addEventListener('click', (e) => {
+        if (e.target === zoomBackdrop) {
+          closeDetailPane();
+          closeZoomOverlay();
+        }
+      });
+
+      document.getElementById('jar-detail-close').addEventListener('click', closeDetailPane);
+      document.getElementById('jar-add-question-btn').addEventListener('click', openAddQuestionModal);
+
+      // Close modal overlay on click outside
+      document.getElementById('jar-modal-overlay').addEventListener('click', (e) => {
+        if (e.target === document.getElementById('jar-modal-overlay')) closeAddQuestionModal();
+      });
+    }
+
+    // Start animation
+    jarIsAnimating = true;
+    animationFrameId = requestAnimationFrame(animateJar);
+  },
+
+  deactivate() {
+    jarIsAnimating = false;
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+    }
+  },
+
+  dispose() {
+    this.deactivate();
+    if (jarRenderer) {
+      jarRenderer.dispose();
+      jarRenderer = null;
+      window.jarRenderer = null;
+    }
+  }
+};
+
+// Export for use by Navigation
+if (typeof window !== 'undefined') {
+  window.JarView = JarView;
+}

--- a/docs/reference-ui/jar-view2.js
+++ b/docs/reference-ui/jar-view2.js
@@ -1,0 +1,765 @@
+/**
+ * JarView2 — Redesigned Jar view using SVG/CSS (no Three.js)
+ * Ported from new_jar_14.html mockup design.
+ *
+ * This module mirrors the same data/interaction contract as JarView (jar-view-new.js)
+ * but renders with a completely different visual style.
+ */
+
+const JarView2 = (() => {
+  // ── State ──
+  let isActive = false;
+  let animFrame = null;
+  let initialised = false;
+  let jarState = { zoomedQuestion: null, detailType: null, detailElement: null };
+  let resizeHandler = null;
+
+  // ── DOM references ──
+  const $ = id => document.getElementById(id);
+
+  // ── Helpers ──
+  function seededRandom(seed) {
+    let s = 0;
+    for (let i = 0; i < seed.length; i++) s = ((s << 5) - s + seed.charCodeAt(i)) | 0;
+    return function() { s = (s * 16807 + 0) % 2147483647; return (s & 0x7fffffff) / 2147483647; };
+  }
+
+  // Microbe SVG templates (shared between jar & circles)
+  const microbeSVG = {
+    koji: `<svg viewBox="0 0 28 28"><g fill="none"><path d="M14,24 C10,20 8,14 12,8 C14,6 16,6 18,8 C22,12 22,18 18,22" stroke="#A3B8A8" stroke-width="2" stroke-linecap="round" opacity="0.65"/><ellipse cx="14" cy="6" rx="3.5" ry="5" fill="#A3B8A8" opacity="0.35"/><ellipse cx="9" cy="10" rx="2" ry="3" fill="#8EA89C" opacity="0.45"/><ellipse cx="19" cy="14" rx="1.5" ry="2.5" fill="#8EA89C" opacity="0.3"/></g></svg>`,
+    yeast: `<svg viewBox="0 0 24 36"><g fill="#D9B48F" opacity="0.55"><rect x="8" y="4" width="8" height="20" rx="4" fill="#D9B48F" opacity="0.6"/><rect x="6" y="2" width="5" height="14" rx="2.5" fill="#E2C28E" opacity="0.7"/><rect x="14" y="8" width="4" height="12" rx="2" fill="#D9B48F" opacity="0.45"/><rect x="10" y="20" width="4" height="10" rx="2" fill="#E2C28E" opacity="0.5"/></g></svg>`,
+    lab: `<svg viewBox="0 0 32 20"><g fill="none"><path d="M6,14 Q12,6 18,12 Q26,18 30,10" stroke="#A3B8A8" stroke-width="2.5" stroke-linecap="round" opacity="0.6"/><circle cx="6" cy="14" r="3" fill="#A3B8A8" opacity="0.4"/><circle cx="18" cy="12" r="2.5" fill="#8EA89C" opacity="0.35"/><circle cx="30" cy="10" r="2" fill="#A3B8A8" opacity="0.3"/></g></svg>`
+  };
+  const microbeTypes = ['koji', 'yeast', 'lab'];
+
+  // Circle positions (keep same as jar-view-new.js — NOT overlapping jar)
+  const circlePositions = [
+    { x: 80, y: 22 }, // top-right
+    { x: 72, y: 72 }, // bottom center-right
+    { x: 14, y: 46 }, // center-left
+  ];
+
+  // ── SVG Jar Bottle ──
+  function renderBottle() {
+    const container = $('j2-bottle-container');
+    if (!container) return;
+    container.innerHTML = `
+      <div class="j2-jar-glow"></div>
+      <svg class="j2-jar-svg" viewBox="0 0 480 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M190,100 C190,60 290,60 290,100 C290,130 270,140 270,170 C270,270 410,330 410,480 C410,580 70,580 70,480 C70,330 210,270 210,170 C210,140 190,130 190,100 Z"
+              fill="rgba(253,251,247,0.2)" stroke="rgba(255,255,255,0.8)" stroke-width="1.5" class="j2-jar-glass"/>
+        <path d="M78,450 C78,350 180,310 200,240 C220,240 270,310 402,450 C410,580 70,580 78,450 Z"
+              fill="url(#j2-fermentGradient)" opacity="0.6" filter="blur(12px)"/>
+        <path d="M100,460 C100,340 220,270 220,180" stroke="url(#j2-highlightGradient)" stroke-width="4" stroke-linecap="round" filter="blur(2px)" opacity="0.7"/>
+        <path d="M380,480 C380,380 260,280 260,190" stroke="rgba(255,255,255,0.4)" stroke-width="2" stroke-linecap="round" filter="blur(1px)"/>
+        <path d="M210,100 Q 240,110 270,100" stroke="rgba(255,255,255,0.9)" stroke-width="3" stroke-linecap="round" filter="blur(1px)"/>
+        <g stroke="rgba(226,194,142,0.4)" stroke-width="0.75" fill="none" opacity="0.8">
+          <path d="M240,280 Q 280,350 250,420 T 320,520" class="j2-float-1"/>
+          <path d="M320,320 Q 290,380 340,440 T 260,540" class="j2-float-2"/>
+          <path d="M200,220 Q 240,290 180,350 T 210,480" class="j2-float-3"/>
+          <path d="M160,360 Q 140,420 200,460 T 140,530" class="j2-float-1"/>
+          <path d="M260,200 Q 270,250 240,290"/>
+        </g>
+        <defs>
+          <linearGradient id="j2-fermentGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="rgba(226,194,142,0.1)"/>
+            <stop offset="50%" stop-color="rgba(142,168,156,0.2)"/>
+            <stop offset="100%" stop-color="rgba(226,194,142,0.4)"/>
+          </linearGradient>
+          <linearGradient id="j2-highlightGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="rgba(255,255,255,0.8)"/>
+            <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+          </linearGradient>
+        </defs>
+      </svg>
+      <div class="j2-jar-content" id="j2-jar-content"></div>
+    `;
+  }
+
+  // ── Text particles inside jar ──
+  const textParticleWords = ['発酵', '記憶', '静寂', '光', '闇', '朝', '麹', '息'];
+  const fillerWords = ['米', '水', '土壌', '醸す', '問い', '時間', '沈殿', '風', '季節', '菌', '熱', '繁殖', '心', '秋', '瀬'];
+
+  function renderJarContent() {
+    const container = $('j2-jar-content');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const allWords = [...textParticleWords, ...fillerWords];
+    const floatClasses = ['j2-float-1', 'j2-float-2', 'j2-float-3'];
+    const blurLevels = [0.6, 0.8, 1.2, 1.8, 2.2, 2.5, 3.5, 4];
+
+    allWords.forEach((word, i) => {
+      const span = document.createElement('span');
+      span.className = `j2-jar-text ${floatClasses[i % 3]}`;
+      span.textContent = word;
+      const top = 18 + (i * 37 % 65);
+      const left = 22 + (i * 53 % 60);
+      const blur = blurLevels[i % blurLevels.length];
+      const fontSize = [11, 12, 14, 16, 18, 22, 26][i % 7];
+      const opacity = 0.3 + (i % 5) * 0.12;
+      span.style.cssText = `position:absolute;top:${top}%;left:${left}%;filter:blur(${blur}px);font-size:${fontSize}px;opacity:${opacity};cursor:default;letter-spacing:0.15em;transition:color 0.3s;`;
+      container.appendChild(span);
+    });
+
+    // Microbes inside jar
+    const jarMicrobes = [
+      { type: 'koji', top: '32%', left: '55%', size: 32, anim: 'j2-float-2', opacity: 0.5 },
+      { type: 'yeast', top: '52%', left: '22%', size: 24, anim: 'j2-float-3', opacity: 0.45 },
+      { type: 'lab', top: '75%', left: '60%', size: 36, anim: 'j2-float-1', opacity: 0.4 },
+      { type: 'koji', top: '15%', left: '68%', size: 28, anim: 'j2-float-2', opacity: 0.5 },
+      { type: 'yeast', top: '45%', left: '78%', size: 24, anim: 'j2-float-1', opacity: 0.55 },
+      { type: 'lab', top: '65%', left: '35%', size: 32, anim: 'j2-float-3', opacity: 0.4 },
+    ];
+    jarMicrobes.forEach(m => {
+      const div = document.createElement('div');
+      div.className = `j2-jar-microbe ${m.anim}`;
+      div.style.cssText = `position:absolute;top:${m.top};left:${m.left};width:${m.size}px;height:${m.size}px;opacity:${m.opacity};pointer-events:none;`;
+      div.innerHTML = microbeSVG[m.type] || '';
+      container.appendChild(div);
+    });
+  }
+
+  // ── Data Access (OryzaeData) ──
+  function getActiveQuestions() {
+    if (typeof OryzaeData === 'undefined') return [];
+    return OryzaeData.getActiveQuestions().map(q => ({
+      ...q,
+      text: OryzaeData.getQuestionString(q.id) || '(問い)'
+    }));
+  }
+
+  function getFermentationData(questionId) {
+    if (typeof OryzaeData === 'undefined') return { keywords: [], snippets: [], letters: [], entryIds: [] };
+    try {
+      const ferm = OryzaeData.getFermentationForQuestion(questionId);
+      if (!ferm) return { keywords: [], snippets: [], letters: [], entryIds: [] };
+
+      const keywords = OryzaeData.getKeywordsForFermentation(ferm.id).map(kw => ({
+        text: kw.keyword || '', description: kw.description || '', ...kw
+      }));
+      const snippets = OryzaeData.getSnippetsForFermentation(ferm.id).map(sn => ({
+        text: sn.original_text || '', reason: sn.selection_reason || '', ...sn
+      }));
+      const letter = OryzaeData.getLetterForFermentation(ferm.id);
+      const letters = letter ? [{ text: letter.body_text || '', ...letter }] : [];
+
+      const links = OryzaeData.entryQuestionLinks
+        ? OryzaeData.entryQuestionLinks.filter(l => l.question_id === questionId)
+        : [];
+      const entryIds = links.map(l => l.entry_id);
+
+      return { keywords, snippets, letters, entryIds };
+    } catch {
+      return { keywords: [], snippets: [], letters: [], entryIds: [] };
+    }
+  }
+
+  // ── Question Circles ──
+  function renderCircles() {
+    const container = $('j2-circles-container');
+    if (!container) return;
+
+    // Don't re-render while zoomed — would destroy zoom state
+    if (jarState.zoomedQuestion) return;
+
+    container.innerHTML = '';
+
+    const questions = getActiveQuestions();
+    if (questions.length === 0) return;
+
+    questions.slice(0, 3).forEach((q, i) => {
+      const pos = circlePositions[i];
+      const circle = createCircleElement(q, i, pos);
+      container.appendChild(circle);
+    });
+
+    // Wait for layout before computing connection line positions
+    requestAnimationFrame(() => {
+      renderConnectionLines(questions);
+    });
+  }
+
+  function createCircleElement(question, index, pos) {
+    const el = document.createElement('div');
+    el.className = 'j2-circle';
+    el.dataset.questionId = question.id;
+    el.dataset.posIndex = index;
+
+    const size = 280 + index * 10;
+
+    el.style.cssText = `position:absolute;left:${pos.x}%;top:${pos.y}%;transform:translate(-50%,-50%);width:${size}px;height:${size}px;`;
+
+    // Build circle SVG layers
+    el.innerHTML = `
+      <div class="j2-circle-glow"></div>
+      <!-- Rotating question text ring -->
+      <div class="j2-circle-text-ring" style="width:${size}px;height:${size}px;">
+        <svg viewBox="0 0 ${size} ${size}" class="j2-circle-text-svg">
+          <path id="j2-ring-${question.id}" d="M ${size/2},${size/2} m ${-(size/2-12)},0 a ${size/2-12},${size/2-12} 0 1,1 ${(size-24)},0 a ${size/2-12},${size/2-12} 0 1,1 ${-(size-24)},0" fill="transparent"/>
+          <text class="j2-ring-text"><textPath href="#j2-ring-${question.id}" startOffset="0%">${question.text} • </textPath></text>
+        </svg>
+      </div>
+      <!-- Mycelium lines from center -->
+      <svg class="j2-mycelium-svg" viewBox="0 0 ${size} ${size}" style="width:${size}px;height:${size}px;">
+        <g stroke="rgba(226,194,142,0.6)" stroke-width="1.2" fill="none" stroke-linecap="round">
+          ${generateMyceliumPaths(size, question.id)}
+        </g>
+      </svg>
+      <!-- Inner content — positioned ABOVE circle (no overflow hidden) -->
+      <div class="j2-circle-inner" style="width:${size}px;height:${size}px;">
+        <!-- Content rendered separately -->
+      </div>
+    `;
+
+    // Render contents into the inner div
+    const inner = el.querySelector('.j2-circle-inner');
+    renderCircleContentsDom(inner, question, index, size);
+
+    // Click handler for zoom
+    el.addEventListener('click', (e) => {
+      e.stopPropagation(); // Always prevent backdrop from closing
+      if (jarState.zoomedQuestion === question.id) return;
+      openZoomOverlay(el, question);
+    });
+
+    return el;
+  }
+
+  function generateMyceliumPaths(size, qId) {
+    const cx = size / 2, cy = size / 2;
+    const rng = seededRandom(qId + '_mycelium');
+    const paths = [];
+    const count = 5;
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + 0.3;
+      const endR = size / 2 - 20;
+      const midR = endR * (0.35 + rng() * 0.3);
+      const midAngle = angle + (rng() - 0.5) * 0.6;
+      const mx = cx + Math.cos(midAngle) * midR;
+      const my = cy + Math.sin(midAngle) * midR;
+      const ex = cx + Math.cos(angle) * endR;
+      const ey = cy + Math.sin(angle) * endR;
+      paths.push(`<path d="M${cx},${cy} C ${mx},${my} ${mx},${my} ${ex},${ey}" stroke-dasharray="4 4"/>`);
+    }
+    return paths.join('\n');
+  }
+
+  function renderCircleContentsDom(inner, question, index, size) {
+    const ferm = getFermentationData(question.id);
+    const isEmpty = !ferm || (ferm.keywords.length === 0 && ferm.snippets.length === 0 && ferm.letters.length === 0);
+
+    if (isEmpty) {
+      // Empty circle — floating microbes
+      const positions = [
+        { top: 30, left: 40, size: 28 }, { top: 50, left: 25, size: 24 },
+        { top: 60, left: 60, size: 32 }, { top: 25, left: 65, size: 24 },
+        { top: 70, left: 38, size: 28 }, { top: 40, left: 70, size: 20 },
+      ];
+      positions.forEach((p, i) => {
+        const type = microbeTypes[i % 3];
+        const div = document.createElement('div');
+        div.className = `j2-circle-microbe j2-float-${(i % 3) + 1}`;
+        div.style.cssText = `position:absolute;top:${p.top}%;left:${p.left}%;width:${p.size}px;height:${p.size}px;opacity:0.45;pointer-events:none;`;
+        div.innerHTML = microbeSVG[type];
+        inner.appendChild(div);
+      });
+      return;
+    }
+
+    // Keywords with attached microbe — spread evenly across circle
+    const kwPositions = [
+      { top: 20, left: 55 },
+      { top: 38, left: 18 },
+      { top: 55, left: 65 },
+      { top: 72, left: 28 },
+      { top: 45, left: 45 },
+    ];
+    ferm.keywords.slice(0, 5).forEach((kw, i) => {
+      const kwPos = kwPositions[i] || { top: 35 + i * 12, left: 20 + i * 15 };
+      const top = kwPos.top;
+      const left = kwPos.left;
+      const floatClass = ['j2-float-1', 'j2-float-2', 'j2-float-3'][i % 3];
+      const mType = microbeTypes[i % 3];
+
+      const wrapper = document.createElement('div');
+      wrapper.className = `j2-circle-element-wrapper ${floatClass}`;
+      wrapper.style.cssText = `position:absolute;top:${top}%;left:${left}%;`;
+      wrapper.innerHTML = `
+        <div class="j2-circle-keyword" data-type="keyword" data-index="${i}">
+          ${kw.text}
+          <span class="j2-element-microbe">${microbeSVG[mType]}</span>
+        </div>
+      `;
+      inner.appendChild(wrapper);
+    });
+
+    // Snippets with attached microbe — positioned to avoid keyword overlap
+    const snPositions = [
+      { top: 30, left: 35 },
+      { top: 60, left: 15 },
+      { top: 50, left: 75 },
+    ];
+    ferm.snippets.slice(0, 3).forEach((sn, i) => {
+      const snPos = snPositions[i] || { top: 40 + i * 18, left: 25 + i * 20 };
+      const top = snPos.top;
+      const left = snPos.left;
+      const floatClass = ['j2-float-1', 'j2-float-2', 'j2-float-3'][(i + 1) % 3];
+      const mType = microbeTypes[(i + 1) % 3];
+      const rawText = typeof sn.text === 'string' ? sn.text : '';
+      const displayText = rawText.substring(0, 60) + (rawText.length > 60 ? '…' : '');
+
+      const wrapper = document.createElement('div');
+      wrapper.className = `j2-circle-element-wrapper ${floatClass}`;
+      wrapper.style.cssText = `position:absolute;top:${top}%;left:${left}%;`;
+      wrapper.innerHTML = `
+        <div class="j2-circle-snippet" data-type="snippet" data-index="${i}">
+          <p class="j2-snippet-text">「${displayText}</p>
+          <div class="j2-snippet-dot"></div>
+          <span class="j2-element-microbe j2-microbe-bottom">${microbeSVG[mType]}</span>
+        </div>
+      `;
+      inner.appendChild(wrapper);
+    });
+
+    // Letter with attached microbe
+    if (ferm.letters.length > 0) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'j2-circle-element-wrapper j2-float-2';
+      wrapper.style.cssText = 'position:absolute;top:72%;left:52%;';
+      wrapper.innerHTML = `
+        <div class="j2-circle-letter" data-type="letter" data-index="0">
+          <svg class="j2-letter-icon" viewBox="0 0 16 16" fill="none">
+            <path d="M1 4L8 9L15 4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M1 4V12H15V4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M5 8L1 12" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.6"/>
+            <path d="M11 8L15 12" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.6"/>
+          </svg>
+          <div class="j2-letter-dot"></div>
+          <span class="j2-element-microbe">${microbeSVG.lab}</span>
+        </div>
+      `;
+      inner.appendChild(wrapper);
+    }
+  }
+
+  // ── Connection Lines (responsive to resize) ──
+  function getJarCenter() {
+    const bottle = $('j2-bottle-container');
+    if (!bottle) return { x: window.innerWidth * 0.5, y: window.innerHeight * 0.42 };
+    const rect = bottle.getBoundingClientRect();
+    // The visual center of the jar body (lower than geometric center)
+    return { x: rect.left + rect.width * 0.5, y: rect.top + rect.height * 0.55 };
+  }
+
+  function getCircleCenter(questionId) {
+    const circleEl = document.querySelector(`#j2-circles-container .j2-circle[data-question-id="${questionId}"]`);
+    if (!circleEl) return null;
+    const rect = circleEl.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  }
+
+  function renderConnectionLines(questions) {
+    const svg = $('j2-connection-lines');
+    if (!svg) return;
+    svg.innerHTML = '';
+
+    // Get view container offset to convert viewport coords to SVG-relative coords
+    const viewContainer = $('view-jar2');
+    const viewRect = viewContainer ? viewContainer.getBoundingClientRect() : { left: 0, top: 0 };
+
+    const jarC = getJarCenter();
+    // Convert to SVG-relative coordinates
+    jarC.x -= viewRect.left;
+    jarC.y -= viewRect.top;
+
+    questions.slice(0, 3).forEach((q, i) => {
+      const circleC = getCircleCenter(q.id);
+      if (!circleC) return;
+
+      // Convert to SVG-relative coordinates
+      circleC.x -= viewRect.left;
+      circleC.y -= viewRect.top;
+
+      // Start point: seeded random inside jar
+      const rng = seededRandom(q.id);
+      const startX = jarC.x + (rng() - 0.5) * 100;
+      const startY = jarC.y + (rng() - 0.5) * 60;
+
+      // End point: circle center
+      const endX = circleC.x;
+      const endY = circleC.y;
+
+      // Control point
+      const cpX = (startX + endX) / 2 + (rng() - 0.5) * 100;
+      const cpY = (startY + endY) / 2 + (rng() - 0.5) * 60;
+
+      // Glow line
+      const glow = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      glow.setAttribute('d', `M ${startX} ${startY} Q ${cpX} ${cpY} ${endX} ${endY}`);
+      glow.setAttribute('fill', 'none');
+      glow.setAttribute('stroke', 'rgba(142,168,156,0.08)');
+      glow.setAttribute('stroke-width', '10');
+      glow.setAttribute('filter', 'blur(8px)');
+      svg.appendChild(glow);
+
+      // Animated dashed line
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      line.setAttribute('d', `M ${startX} ${startY} Q ${cpX} ${cpY} ${endX} ${endY}`);
+      line.setAttribute('fill', 'none');
+      line.setAttribute('stroke', 'rgba(142,168,156,0.25)');
+      line.setAttribute('stroke-width', '1');
+      line.setAttribute('stroke-dasharray', '4 10');
+      line.setAttribute('stroke-linecap', 'round');
+      line.classList.add('j2-flow-line');
+      line.style.animationDuration = `${60 + i * 10}s`;
+      svg.appendChild(line);
+    });
+  }
+
+  // ── Question List (bottom) ──
+  function renderQuestionList() {
+    const container = $('j2-question-items');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const questions = getActiveQuestions();
+    questions.forEach(q => {
+      const tag = document.createElement('div');
+      tag.className = 'j2-question-tag';
+      tag.textContent = q.text;
+      tag.dataset.questionId = q.id;
+      tag.addEventListener('click', () => handleQuestionTagClick(q));
+      container.appendChild(tag);
+    });
+
+    const addBtn = $('j2-add-question-btn');
+    if (addBtn) addBtn.style.display = questions.length < 3 ? '' : 'none';
+  }
+
+  function handleQuestionTagClick(question) {
+    const overlay = $('j2-edit-modal-overlay');
+    const input = $('j2-edit-modal-input');
+    const charCount = $('j2-edit-char-count');
+    if (!overlay || !input) return;
+
+    input.value = question.text;
+    charCount.textContent = `${question.text.length}/64`;
+    overlay.style.display = '';
+    overlay._questionId = question.id;
+    input.focus();
+  }
+
+  // ── Zoom Overlay ──
+  function openZoomOverlay(circleEl, question) {
+    jarState.zoomedQuestion = question.id;
+
+    // Store original size for restoration
+    circleEl._origWidth = circleEl.style.width;
+    circleEl._origHeight = circleEl.style.height;
+    circleEl._origLeft = circleEl.style.left || circleEl.dataset.origLeft;
+    circleEl._origTop = circleEl.style.top || circleEl.dataset.origTop;
+
+    circleEl.classList.add('zoomed');
+
+    const backdrop = $('j2-zoom-backdrop');
+    if (backdrop) backdrop.classList.add('active');
+
+    // Add has-zoomed to container so it sits above backdrop
+    const container = $('j2-circles-container');
+    if (container) container.classList.add('has-zoomed');
+
+    // Hide question list and connection lines
+    const questionList = $('j2-question-list');
+    if (questionList) questionList.style.opacity = '0';
+    const connLines = $('j2-connection-lines');
+    if (connLines) connLines.style.opacity = '0';
+
+    // Hide other circles
+    document.querySelectorAll('#j2-circles-container .j2-circle').forEach(c => {
+      if (c !== circleEl) {
+        c.style.opacity = '0';
+        c.style.pointerEvents = 'none';
+      }
+    });
+
+    // Calculate zoom target size — large enough to read snippet text
+    const viewJar = $('view-jar2');
+    const viewW = viewJar ? viewJar.offsetWidth : window.innerWidth;
+    const viewH = viewJar ? viewJar.offsetHeight : window.innerHeight;
+    const targetSize = Math.min(viewW * 0.6, viewH * 0.8, 650);
+
+    // Animate to center with enlarged size
+    circleEl.style.transition = 'all 1.2s cubic-bezier(0.4, 0, 0.2, 1)';
+    circleEl.style.left = '50%';
+    circleEl.style.top = '50%';
+    circleEl.style.width = targetSize + 'px';
+    circleEl.style.height = targetSize + 'px';
+    circleEl.style.zIndex = '55';
+    circleEl.style.pointerEvents = 'auto';
+
+    // Update inner content sizing to match new circle size
+    const inner = circleEl.querySelector('.j2-circle-inner');
+    if (inner) {
+      inner.style.width = targetSize + 'px';
+      inner.style.height = targetSize + 'px';
+      inner.style.pointerEvents = 'auto';
+    }
+
+    // Update text ring and mycelium SVGs to match new size
+    const textRing = circleEl.querySelector('.j2-circle-text-ring');
+    if (textRing) {
+      textRing.style.width = targetSize + 'px';
+      textRing.style.height = targetSize + 'px';
+    }
+    const myceliumSvg = circleEl.querySelector('.j2-mycelium-svg');
+    if (myceliumSvg) {
+      myceliumSvg.style.width = targetSize + 'px';
+      myceliumSvg.style.height = targetSize + 'px';
+    }
+
+    // Wire element clicks (only once)
+    circleEl.querySelectorAll('[data-type]').forEach(el => {
+      if (!el._j2ClickWired) {
+        el._j2ClickWired = true;
+        el.style.pointerEvents = 'auto';
+        el.style.cursor = 'pointer';
+        el.addEventListener('click', (e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          openDetailPane(question, el.dataset.type, parseInt(el.dataset.index));
+        });
+      }
+    });
+
+    // Also wire wrappers to stop propagation
+    circleEl.querySelectorAll('.j2-circle-element-wrapper').forEach(wrapper => {
+      if (!wrapper._j2ClickWired) {
+        wrapper._j2ClickWired = true;
+        wrapper.style.pointerEvents = 'auto';
+        wrapper.addEventListener('click', (e) => {
+          e.stopPropagation();
+        });
+      }
+    });
+  }
+
+  function closeZoomOverlay() {
+    if (!jarState.zoomedQuestion) return;
+    jarState.zoomedQuestion = null;
+
+    const backdrop = $('j2-zoom-backdrop');
+    if (backdrop) backdrop.classList.remove('active');
+
+    // Remove has-zoomed from container
+    const container = $('j2-circles-container');
+    if (container) container.classList.remove('has-zoomed');
+
+    // Show question list and connection lines again
+    const questionList = $('j2-question-list');
+    if (questionList) { questionList.style.transition = 'opacity 0.6s'; questionList.style.opacity = ''; }
+    const connLines = $('j2-connection-lines');
+    if (connLines) { connLines.style.transition = 'opacity 0.6s'; connLines.style.opacity = ''; }
+
+    const questions = getActiveQuestions();
+    document.querySelectorAll('#j2-circles-container .j2-circle').forEach(c => {
+      c.classList.remove('zoomed');
+      c.style.opacity = '';
+      c.style.zIndex = '';
+      c.style.pointerEvents = '';
+      c.style.transition = 'all 0.8s cubic-bezier(0.4, 0, 0.2, 1)';
+
+      // Restore original size
+      const idx = parseInt(c.dataset.posIndex);
+      const origSize = 280 + idx * 10;
+      c.style.width = origSize + 'px';
+      c.style.height = origSize + 'px';
+
+      // Restore inner, text ring, mycelium sizes
+      const inner = c.querySelector('.j2-circle-inner');
+      if (inner) { inner.style.width = origSize + 'px'; inner.style.height = origSize + 'px'; inner.style.pointerEvents = ''; }
+      const textRing = c.querySelector('.j2-circle-text-ring');
+      if (textRing) { textRing.style.width = origSize + 'px'; textRing.style.height = origSize + 'px'; }
+      const myceliumSvg = c.querySelector('.j2-mycelium-svg');
+      if (myceliumSvg) { myceliumSvg.style.width = origSize + 'px'; myceliumSvg.style.height = origSize + 'px'; }
+
+      // Reset position
+      const qId = c.dataset.questionId;
+      const qIdx = questions.findIndex(q => q.id === qId);
+      if (qIdx >= 0 && circlePositions[qIdx]) {
+        c.style.left = circlePositions[qIdx].x + '%';
+        c.style.top = circlePositions[qIdx].y + '%';
+      }
+    });
+
+    closeDetailPane();
+
+    // Re-render connection lines after animation
+    setTimeout(() => {
+      if (isActive) renderConnectionLines(questions);
+    }, 900);
+  }
+
+  // ── Detail Pane ──
+  function openDetailPane(question, type, index) {
+    const pane = $('j2-detail-pane');
+    if (!pane) return;
+
+    const ferm = getFermentationData(question.id);
+    let title = '', body = '';
+
+    if (type === 'keyword') {
+      title = 'Yeast keyword';
+      const kw = ferm.keywords[index];
+      body = kw ? `${kw.text}\n\n${kw.description || ''}` : '';
+    } else if (type === 'snippet') {
+      title = 'Oryzae snippet';
+      const sn = ferm.snippets[index];
+      body = sn ? `${sn.text}\n\n${sn.reason || ''}` : '';
+    } else if (type === 'letter') {
+      title = 'Lab letter';
+      const lt = ferm.letters[index];
+      body = lt ? lt.text : '';
+    }
+
+    $('j2-detail-question').textContent = question.text;
+    $('j2-detail-header').textContent = title;
+    $('j2-detail-body').innerText = body;
+
+    pane._currentQuestion = question;
+    pane.classList.add('open');
+    jarState.detailType = type;
+    jarState.detailElement = index;
+  }
+
+  function closeDetailPane() {
+    const pane = $('j2-detail-pane');
+    if (pane) pane.classList.remove('open');
+    jarState.detailType = null;
+    jarState.detailElement = null;
+  }
+
+  // ── Modal Handlers ──
+  function initModals() {
+    const addBtn = $('j2-add-question-btn');
+    const modalOverlay = $('j2-modal-overlay');
+    const modalInput = $('j2-modal-input');
+    const modalCancel = $('j2-modal-cancel');
+    const modalSave = $('j2-modal-save');
+
+    if (addBtn) addBtn.addEventListener('click', () => {
+      modalOverlay.style.display = '';
+      modalInput.value = '';
+      modalInput.focus();
+    });
+    if (modalCancel) modalCancel.addEventListener('click', () => { modalOverlay.style.display = 'none'; });
+    if (modalSave) modalSave.addEventListener('click', () => {
+      const text = modalInput.value.trim();
+      if (!text) return;
+      addNewQuestion(text);
+      modalOverlay.style.display = 'none';
+      refresh();
+    });
+
+    const editOverlay = $('j2-edit-modal-overlay');
+    const editInput = $('j2-edit-modal-input');
+    const editCharCount = $('j2-edit-char-count');
+    const editCancel = $('j2-edit-modal-cancel');
+    const editSave = $('j2-edit-modal-save');
+    const editArchive = $('j2-edit-modal-archive');
+
+    if (editInput) editInput.addEventListener('input', () => {
+      editCharCount.textContent = `${editInput.value.length}/64`;
+    });
+    if (editCancel) editCancel.addEventListener('click', () => { editOverlay.style.display = 'none'; });
+    if (editSave) editSave.addEventListener('click', () => {
+      const text = editInput.value.trim();
+      if (!text || !editOverlay._questionId) return;
+      updateQuestion(editOverlay._questionId, text);
+      editOverlay.style.display = 'none';
+      refresh();
+    });
+    if (editArchive) editArchive.addEventListener('click', () => {
+      if (!editOverlay._questionId) return;
+      archiveQuestion(editOverlay._questionId);
+      editOverlay.style.display = 'none';
+      refresh();
+    });
+
+    // Detail pane
+    const detailClose = $('j2-detail-close');
+    if (detailClose) detailClose.addEventListener('click', closeDetailPane);
+
+    const detailWrite = $('j2-detail-write-btn');
+    if (detailWrite) detailWrite.addEventListener('click', () => {
+      const pane = $('j2-detail-pane');
+      if (pane && pane._currentQuestion) {
+        if (window.ToiManager) window.ToiManager.set(pane._currentQuestion.id);
+        closeDetailPane();
+        closeZoomOverlay();
+        Navigation.switchTo('editor');
+      }
+    });
+
+    // Zoom backdrop
+    const backdrop = $('j2-zoom-backdrop');
+    if (backdrop) backdrop.addEventListener('click', () => closeZoomOverlay());
+  }
+
+  // ── Question CRUD (delegates to OryzaeData) ──
+  function addNewQuestion(text) {
+    if (typeof OryzaeData !== 'undefined' && OryzaeData.addQuestion) OryzaeData.addQuestion(text);
+  }
+  function updateQuestion(id, text) {
+    if (typeof OryzaeData !== 'undefined' && OryzaeData.updateQuestionString) OryzaeData.updateQuestionString(id, text);
+  }
+  function archiveQuestion(id) {
+    if (typeof OryzaeData !== 'undefined' && OryzaeData.archiveQuestion) OryzaeData.archiveQuestion(id);
+  }
+
+  // ── Refresh ──
+  function refresh() {
+    renderCircles();
+    renderQuestionList();
+  }
+
+  // ── Resize handler ──
+  function onResize() {
+    if (!isActive || jarState.zoomedQuestion) return;
+    renderConnectionLines(getActiveQuestions());
+  }
+
+  // ── Public API ──
+  function activate() {
+    if (!initialised) {
+      renderBottle();
+      renderJarContent();
+      initModals();
+      initialised = true;
+    }
+    refresh();
+    isActive = true;
+
+    // Debounced resize handler for connection lines
+    if (!resizeHandler) {
+      let resizeTimer;
+      resizeHandler = () => { clearTimeout(resizeTimer); resizeTimer = setTimeout(onResize, 150); };
+      window.addEventListener('resize', resizeHandler);
+    }
+  }
+
+  function deactivate() {
+    isActive = false;
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
+    closeZoomOverlay();
+    closeDetailPane();
+  }
+
+  function dispose() {
+    deactivate();
+    if (resizeHandler) { window.removeEventListener('resize', resizeHandler); resizeHandler = null; }
+    initialised = false;
+  }
+
+  return { activate, deactivate, dispose, refresh };
+})();

--- a/docs/reference-ui/koji.svg
+++ b/docs/reference-ui/koji.svg
@@ -1,0 +1,75 @@
+<svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="kojiStalk" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7e3da8"/>
+      <stop offset="50%" stop-color="#a45cd4"/>
+      <stop offset="100%" stop-color="#67298c"/>
+    </linearGradient>
+    <radialGradient id="kojiHead" cx="35%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#d0a3fc"/>
+      <stop offset="60%" stop-color="#9955cc"/>
+      <stop offset="100%" stop-color="#6e2d9c"/>
+    </radialGradient>
+    <radialGradient id="kojiSpore" cx="30%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#e6ccff"/>
+      <stop offset="50%" stop-color="#bb88ee"/>
+      <stop offset="100%" stop-color="#8a4bba"/>
+    </radialGradient>
+    <filter id="glowPurple" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+  </defs>
+  
+  <circle cx="120" cy="100" r="90" fill="#9955cc" opacity="0.05" filter="url(#glowPurple)"/>
+  
+  <g transform="translate(120, 200) rotate(5)">
+    <path d="M-12,50 C-8,-10 -15,-50 0,-90 C15,-50 8,-10 12,50 Z" fill="url(#kojiStalk)"/>
+    <circle cx="0" cy="-90" r="32" fill="url(#kojiHead)"/>
+    
+    <g transform="translate(0, -90)">
+      <circle cx="0" cy="0" r="38" fill="none" stroke="#8a4bba" stroke-width="4" stroke-dasharray="4 8" opacity="0.6"/>
+      
+      <g transform="rotate(0)">
+        <line x1="0" y1="-32" x2="0" y2="-48" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-52" r="8" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-68" r="7" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(45)">
+        <line x1="0" y1="-32" x2="0" y2="-50" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-54" r="8" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-70" r="6.5" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(90)">
+        <line x1="0" y1="-32" x2="0" y2="-52" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-56" r="8.5" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-72" r="7" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(135)">
+        <line x1="0" y1="-32" x2="0" y2="-48" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-52" r="8" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-66" r="6" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(180)">
+        <line x1="0" y1="-32" x2="0" y2="-50" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-54" r="8.5" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-70" r="7.5" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(225)">
+        <line x1="0" y1="-32" x2="0" y2="-48" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-52" r="8" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-68" r="6.5" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(270)">
+        <line x1="0" y1="-32" x2="0" y2="-52" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-56" r="9" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-73" r="7" fill="url(#kojiSpore)"/>
+      </g>
+      <g transform="rotate(315)">
+        <line x1="0" y1="-32" x2="0" y2="-48" stroke="#a45cd4" stroke-width="3"/>
+        <circle cx="0" cy="-52" r="8" fill="url(#kojiSpore)"/>
+        <circle cx="0" cy="-66" r="6" fill="url(#kojiSpore)"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/reference-ui/lab.svg
+++ b/docs/reference-ui/lab.svg
@@ -1,0 +1,38 @@
+<svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lactoBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#84d182"/>
+      <stop offset="100%" stop-color="#469e44"/>
+    </linearGradient>
+    <linearGradient id="lactoLight" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a3e3a1"/>
+      <stop offset="100%" stop-color="#5db85a"/>
+    </linearGradient>
+    <filter id="glowGreen" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+  </defs>
+  
+  <circle cx="120" cy="120" r="80" fill="#5db85a" opacity="0.05" filter="url(#glowGreen)"/>
+  
+  <g transform="translate(100, 40) rotate(-15)">
+    <rect x="-18" y="0" width="36" height="85" rx="18" fill="url(#lactoBase)"/>
+    <path d="M -12 10 Q -12 5 0 5 Q 12 5 12 10 L 12 75 Q 12 80 0 80 Q -12 80 -12 75 Z" fill="#ffffff" opacity="0.15"/>
+    
+    <g transform="translate(0, 92)">
+      <rect x="-18" y="0" width="36" height="80" rx="18" fill="url(#lactoBase)"/>
+      <path d="M -12 10 Q -12 5 0 5 Q 12 5 12 10 L 12 70 Q 12 75 0 75 Q -12 75 -12 70 Z" fill="#ffffff" opacity="0.15"/>
+    </g>
+    
+    <g transform="translate(0, 178)">
+      <rect x="-18" y="0" width="36" height="75" rx="18" fill="url(#lactoBase)"/>
+      <path d="M -12 10 Q -12 5 0 5 Q 12 5 12 10 L 12 65 Q 12 70 0 70 Q -12 70 -12 65 Z" fill="#ffffff" opacity="0.15"/>
+    </g>
+  </g>
+  
+  <g transform="translate(150, 110) rotate(20) scale(0.85)">
+    <rect x="-18" y="0" width="36" height="70" rx="18" fill="url(#lactoLight)"/>
+    <rect x="-18" y="75" width="36" height="60" rx="18" fill="url(#lactoLight)"/>
+  </g>
+</svg>

--- a/docs/reference-ui/letter.svg
+++ b/docs/reference-ui/letter.svg
@@ -1,0 +1,103 @@
+<svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Envelope gradients -->
+    <linearGradient id="envBack" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e8e3d5"/>
+      <stop offset="100%" stop-color="#dcd5c4"/>
+    </linearGradient>
+    <linearGradient id="envTopFlap" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#faf8f5"/>
+    </linearGradient>
+    <linearGradient id="envBottomFlap" x1="50%" y1="100%" x2="50%" y2="0%">
+      <stop offset="0%" stop-color="#f0ece1"/>
+      <stop offset="100%" stop-color="#e6dec3"/>
+    </linearGradient>
+    <linearGradient id="envSideLeft" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#faf8f5"/>
+      <stop offset="100%" stop-color="#f0ece1"/>
+    </linearGradient>
+    <linearGradient id="envSideRight" x1="100%" y1="50%" x2="0%" y2="50%">
+      <stop offset="0%" stop-color="#faf8f5"/>
+      <stop offset="100%" stop-color="#f0ece1"/>
+    </linearGradient>
+    
+    <!-- Wax seal gradients -->
+    <radialGradient id="waxMain" cx="35%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="50%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#965f00"/>
+    </radialGradient>
+    <radialGradient id="waxIndent" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#965f00" stop-opacity="0.6"/>
+      <stop offset="80%" stop-color="#d97706" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
+    </radialGradient>
+    
+    <!-- Filters -->
+    <filter id="glowAmber" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+    <filter id="flapShadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#4a3f35" flood-opacity="0.08"/>
+    </filter>
+    <filter id="waxShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="3" stdDeviation="2" flood-color="#965f00" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+  
+  <!-- Background glow -->
+  <circle cx="120" cy="120" r="80" fill="#d97706" opacity="0.06" filter="url(#glowAmber)"/>
+  
+  <!-- Envelope group -->
+  <g transform="rotate(-2 120 120)">
+    <!-- Back shadow -->
+    <rect x="32" y="74" width="176" height="106" rx="6" fill="#4a3f35" opacity="0.06" filter="blur(6px)"/>
+    
+    <!-- Envelope back -->
+    <rect x="30" y="70" width="180" height="110" rx="4" fill="url(#envBack)"/>
+    
+    <!-- Side flaps -->
+    <path d="M 30 70 L 105 125 L 30 180 Z" fill="url(#envSideLeft)"/>
+    <path d="M 210 70 L 135 125 L 210 180 Z" fill="url(#envSideRight)"/>
+    
+    <!-- Bottom flap -->
+    <path d="M 30 180 L 115 118 Q 120 115 125 118 L 210 180 Z" fill="url(#envBottomFlap)" filter="url(#flapShadow)"/>
+    <path d="M 32 178 L 115 118 Q 120 115 125 118 L 208 178" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+    
+    <!-- Top flap -->
+    <path d="M 30 70 L 115 132 Q 120 136 125 132 L 210 70 Z" fill="url(#envTopFlap)" filter="url(#flapShadow)"/>
+    <path d="M 32 72 L 115 132 Q 120 136 125 132 L 208 72" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" opacity="0.8"/>
+    
+    <!-- Wax seal -->
+    <g transform="translate(120, 134)" filter="url(#waxShadow)">
+      <!-- Wax droplets -->
+      <circle cx="-12" cy="8" r="4.5" fill="url(#waxMain)"/>
+      <circle cx="14" cy="-4" r="3.5" fill="url(#waxMain)"/>
+      <circle cx="6" cy="12" r="5" fill="url(#waxMain)"/>
+      
+      <!-- Main seal -->
+      <circle cx="0" cy="0" r="16" fill="url(#waxMain)"/>
+      <circle cx="0" cy="0" r="11" fill="url(#waxIndent)"/>
+      
+      <!-- Seal pattern (rice motif) -->
+      <g fill="#faf8f5" opacity="0.85">
+        <circle cx="0" cy="-3" r="2.5"/>
+        <circle cx="-4" cy="2" r="2"/>
+        <circle cx="4" cy="2" r="2"/>
+        <path d="M 0 -1 L -3 1 M 0 -1 L 3 1 M 0 -3 L 0 5" stroke="#faf8f5" stroke-width="1.2" stroke-linecap="round"/>
+      </g>
+      
+      <!-- Highlight -->
+      <path d="M -8 -8 A 12 12 0 0 1 8 -8" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" opacity="0.3" filter="blur(0.5px)"/>
+    </g>
+  </g>
+  
+  <!-- Decorative particles -->
+  <circle cx="45" cy="55" r="3" fill="#fbbf24" opacity="0.6"/>
+  <circle cx="195" cy="85" r="5" fill="#f0ece1" opacity="0.8"/>
+  <circle cx="175" cy="185" r="2.5" fill="#d97706" opacity="0.5"/>
+  <circle cx="55" cy="170" r="4" fill="#fbbf24" opacity="0.4"/>
+  <circle cx="140" cy="40" r="1.5" fill="#8b7355" opacity="0.3"/>
+</svg>

--- a/docs/reference-ui/oryzae-data.js
+++ b/docs/reference-ui/oryzae-data.js
@@ -1,0 +1,608 @@
+/**
+ * Oryzae Data Model
+ * Global data store for the Oryzae web app
+ * Phase 1: Standalone JavaScript data model
+ */
+
+const OryzaeData = {
+  // ============================================================================
+  // 1. QUESTIONS
+  // ============================================================================
+  questions: [
+    {
+      id: 'q1',
+      user_id: 'u1',
+      created_at: '2025-11-30T00:00:00Z',
+      updated_at: '2026-01-15T00:00:00Z',
+      is_archived: false,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    {
+      id: 'q2',
+      user_id: 'u1',
+      created_at: '2025-12-10T00:00:00Z',
+      updated_at: '2026-02-20T00:00:00Z',
+      is_archived: false,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    {
+      id: 'q3',
+      user_id: 'u1',
+      created_at: '2026-01-05T00:00:00Z',
+      updated_at: '2026-03-01T00:00:00Z',
+      is_archived: false,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: true
+    }
+  ],
+
+  // ============================================================================
+  // 2. QUESTION TRANSACTIONS
+  // ============================================================================
+  questionTransactions: [
+    // Q1: created by user, then updated by fermentation proposal (accepted), then updated by user
+    {
+      id: 'qt1',
+      question_id: 'q1',
+      string: '死者と生者はどのように共生し続けられるのか',
+      question_version: 1,
+      created_at: '2025-11-30T00:00:00Z',
+      updated_at: '2025-11-30T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    {
+      id: 'qt2',
+      question_id: 'q1',
+      string: '死者と生者はどのように共生し続けられるのか——夢と食卓の間で',
+      question_version: 2,
+      created_at: '2025-12-20T00:00:00Z',
+      updated_at: '2025-12-20T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: true
+    },
+    {
+      id: 'qt3',
+      question_id: 'q1',
+      string: '死者と生者はどのように共生し続けられるのか',
+      question_version: 3,
+      created_at: '2026-01-15T00:00:00Z',
+      updated_at: '2026-01-15T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    // Q2: created by user, then updated by user
+    {
+      id: 'qt4',
+      question_id: 'q2',
+      string: '問いはどのように生まれるのか？',
+      question_version: 1,
+      created_at: '2025-12-10T00:00:00Z',
+      updated_at: '2025-12-10T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    {
+      id: 'qt5',
+      question_id: 'q2',
+      string: '問いはどのように生まれ、育つのか？',
+      question_version: 2,
+      created_at: '2026-02-20T00:00:00Z',
+      updated_at: '2026-02-20T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    },
+    // Q3: proposed by oryzae, accepted by user, then updated by user
+    {
+      id: 'qt6',
+      question_id: 'q3',
+      string: '野生とは何か。',
+      question_version: 1,
+      created_at: '2026-01-05T00:00:00Z',
+      updated_at: '2026-01-05T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: true
+    },
+    {
+      id: 'qt7',
+      question_id: 'q3',
+      string: '野生とは何か。飼い馴らされた世界の外で',
+      question_version: 2,
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-01T00:00:00Z',
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    }
+  ],
+
+  // ============================================================================
+  // 3. FERMENTATION RESULTS
+  // ============================================================================
+  fermentationResults: [
+    {
+      id: 'fr1',
+      question_id: 'q1',
+      target_period: '2025-11-30〜2025-12-06',
+      created_at: '2025-12-07T00:00:00Z'
+    }
+  ],
+
+  // ============================================================================
+  // 4. ANALYSIS WORKSHEETS (6 concepts)
+  // ============================================================================
+  analysisWorksheets: [
+    {
+      id: 'aw1',
+      fermentation_result_id: 'fr1',
+      concept_name: '夢における一時的な邂逅と離別',
+      definition: '死者が夢の中で生者の世界に一時的に現れ、対話や交流を経た後に再び消えていくプロセス。生者は死者の存在を歓迎しつつ、その一時性を了解している。',
+      examples: '①「Yが普通な格好で来る。白と緑のワンピース。『おー、おつかれ』みたいに声をかけてやりとりする」（12/6）②「周りの人には見えていない、聞こえていない。周りの人たちを信頼して、いまYが来てると伝え、その声をみんなに伝える役を務める」（12/6）③「Yと会えて嬉しい。それが一時的であることが了解されている」（12/6）④「Yがしゅるしゅると小さくなり、最後は胎児にまで縮小して消えた」（12/6）',
+      theoretical_memo: '死者Yは夢の中で「普通な格好」で現れており、異界の存在ではなく日常の延長上にいるものとして描かれている。しかし他の生者には不可視であり、書き手だけが「媒介者」の役割を担う。最終的にYは胎児にまで退行して消えるが、これは死→生の逆行的イメージであり、死者が生の起源に回帰していく円環的な生死観を暗示する。対極例として、死者との遭遇を恐怖や不安として記述するものはこのデータには見られず、むしろ「嬉しい」という肯定的な感情が支配的であり、死者との共生が感情的に受容されていることを示す。'
+    },
+    {
+      id: 'aw2',
+      fermentation_result_id: 'fr1',
+      concept_name: 'ホロビオントの崩壊としての死',
+      definition: '死を個体の消滅としてではなく、無数の細胞や微生物からなる集合体（ホロビオント）の解体として捉え直す視座。個の死が共同体の破局として再定義される。',
+      examples: '①「無数の細胞や微生物の生存を預かる集合体を代表する責任を負うため？」（12/4）②「都市国家としての人の身体の死はホロビオントが崩壊するカタストロフであるから？」（12/4）③「猫と微生物の環世界を写しとる、という表現が生まれた」（12/6）④「機能環が結合するHさんのイメージを想起するが、それはかつて自分がオートポイエーシス論で考えていたシステム同士の構造的カップリングとそっくりであることに気づく」（12/6）',
+      theoretical_memo: '書き手は人新世の文脈から、死を個人的な事象から生態学的な事象へとスケール転換している。「都市国家」という政治的メタファーと「ホロビオント」という生態学的概念の重ね合わせは、死者が単なる不在ではなく、かつて共存していた無数の生命の解散として捉えられることを意味する。構造的カップリングへの言及は、死者と生者の関係を自律的システム同士の相互浸透として理論的に位置づけようとする試みである。'
+    },
+    {
+      id: 'aw3',
+      fermentation_result_id: 'fr1',
+      concept_name: '食と共異体の倫理',
+      definition: '食べる対象となる他の種を、自己とは異なるが同輩として認め（共異体）、食という行為を通じて生死の境界を問い直す倫理的態度。',
+      examples: '①「人が食べる対象の種を、自分とは異なるがある種の同輩として認め（共異体）」（11/30）②「食べたものが自分であったかもしれないという想像を働かせること」（11/30）③「全ての生命に来歴を認め（ビオスとして捉え）、かつ、自分の住む場所（ジオス）と接続することで魂の実感を得る」（11/30）',
+      theoretical_memo: '食という日常的な行為の中に、生者と死者（食べられた存在）の交換可能性が埋め込まれている。「食べたものが自分であったかもしれない」という想像力は、生者／死者の非対称性を揺さぶるものであり、共生の倫理的基盤を提供する。ビオス（来歴をもつ生命）とジオス（場所）の接続は、死者が土地や場所に根づく形で生者の世界に残り続ける可能性を示す。対極例として、食を単なる栄養摂取として記述する場面（妻の料理への感謝など）もあるが、そこでも食を通じた他者との関係性が重視されている。'
+    },
+    {
+      id: 'aw4',
+      fermentation_result_id: 'fr1',
+      concept_name: '分析的でない向き合い方への希求',
+      definition: '大事な存在（死者・生者を含む）に対して、言語的・分析的な方法ではなく、別の仕方で向き合う必要性を自覚すること。',
+      examples: '①「人は言葉から離れるために旅をする、という作中のセリフはすとんと腑に落ちる」（12/1）②「言葉によるジャーナリングに対する疑問が湧いてきた。忘却を促すことも大事なのではないか」（12/1）③「人間のこと、大事な存在たちに、分析的ではない仕方で向き合う時間がもっと必要なのではないか」（12/1）④「言わないことで表現できることがある」（12/1）',
+      theoretical_memo: '書き手は言語やジャーナリングという自身の主要な実践に対して根本的な疑問を呈している。「死者と生者の共生」という問いに対して、分析や記述という行為そのものが限界を持つことへの気づきがある。「忘却を促す」という発想は、記憶の保持＝死者との共生、という前提を覆すものであり、忘却もまた共生の一形態でありうることを示唆する。映画鑑賞という体験を通じてこの気づきが得られていることは、非分析的な認知様式の実例そのものでもある。'
+    },
+    {
+      id: 'aw5',
+      fermentation_result_id: 'fr1',
+      concept_name: '発酵的時間の中の変容',
+      definition: '思考や関係性が、微生物の発酵のように即座に結論へ至るのではなく、時間をかけて徐々に変質・熟成していくプロセスへの信頼。',
+      examples: '①「しばらくこの思いを発酵させよう」（12/5）②「ぬか床が家庭ごとで味が違うという連想をした。性格の異なる占い師が固定されるのではなく、ぬか床が徐々に人の影響を吸収するように、分析者AIもまた変化していくことは可能か」（12/3）③「ジャーナルの発酵とは何なのかについて突っ込んだ議論ができた」（12/3）④「冬は静かに過ごすと決めたおかげか、ゼミは落ち着いて過ごせた。完璧ではないが、ゆっくりと進めることが今はベストだと思って」（12/2）',
+      theoretical_memo: '発酵は、書き手にとって単なるメタファーではなく、実際のアプリケーション開発（ORYZAE）や研究実践と結びついた中核的概念である。ぬか床が使い手の微生物叢を吸収して固有の味になるように、死者との共生もまた、個々人の経験によって固有の形をとりうるという含意がある。「ゆっくりと進める」姿勢は、発酵的時間を生活実践のレベルで体現するものであり、概念4の「分析的でない向き合い方」とも通底する。'
+    },
+    {
+      id: 'aw6',
+      fermentation_result_id: 'fr1',
+      concept_name: '媒介者としての役割の引き受け',
+      definition: '他者には知覚できない存在（死者、見えにくい価値、土着のリアリティなど）を、可視化・翻訳して伝える役割を自覚的に引き受けること。',
+      examples: '①「周りの人たちを信頼して、いまYが来てると伝え、その声をみんなに伝える役を務める」（12/6）②「英語が世界言語であるところに、土着のリアリティを翻訳していく必要性がある。そうしないと、存在がなかったことにされてしまう」（11/30）③「Iさんの問いが面白く、一人に20分ほどかけて深掘ることをした。そしてそれぞれが問いのテキストをブラッシュアップする助産をしてみたら、うまく行った気がする」（12/4）',
+      theoretical_memo: '夢の中でYの声を他の生者に伝える行為と、土着のリアリティを翻訳する学術的営為、そして学生の問いを「助産」する教育実践が、「媒介者」という共通の構造で結ばれている。死者と生者の共生において、媒介者の存在は不可欠であり、書き手はその役割を学術的にも夢の中でも反復的に引き受けている。「存在がなかったことにされてしまう」という危機感は、死者の存在が忘却されることへの抵抗としても読める。'
+    }
+  ],
+
+  // ============================================================================
+  // 5. CATEGORY RELATIONS
+  // ============================================================================
+  categoryRelations: [
+    {
+      id: 'cat1',
+      fermentation_result_id: 'fr1',
+      category_name: '生死の境界の溶解',
+      related_concepts: ['aw1', 'aw2', 'aw3'],
+      storyline: 'このカテゴリーは、死者と生者の間にある境界線が、様々な次元において溶解・再編成される現象を捉える。\n\n概念1（夢における一時的な邂逅と離別）は、経験的・個人的な次元で生死の境界が一時的に消失する場面を示す。\n\n概念2（ホロビオントの崩壊としての死）は、理論的・生態学的な次元で死の意味を個体から集合体へとスケール転換する。\n\n概念3（食と共異体の倫理）は、日常的・倫理的な次元で、食を通じた生死の交換可能性を浮かび上がらせる。'
+    },
+    {
+      id: 'cat2',
+      fermentation_result_id: 'fr1',
+      category_name: '共生の方法論の探索',
+      related_concepts: ['aw4', 'aw5', 'aw6'],
+      storyline: 'このカテゴリーは、生死の境界が溶解した先で、死者と生者がいかにして共に在り続けるかの方法論を模索するプロセスを捉える。\n\n概念4（分析的でない向き合い方への希求）は、既存の方法（言語、分析）の限界を認識し、別の方法を求める出発点を示す。\n\n概念5（発酵的時間の中の変容）は、即座の理解ではなく、時間をかけた熟成という方法論を提示する。\n\n概念6（媒介者としての役割の引き受け）は、不可視の存在を翻訳・可視化するという実践的な方法を示す。'
+    }
+  ],
+
+  // ============================================================================
+  // 6. EXTRACTED SNIPPETS
+  // ============================================================================
+  extractedSnippets: [
+    {
+      id: 'snip1',
+      fermentation_result_id: 'fr1',
+      snippet_type: 'new_perspective',
+      original_text: '「都市国家としての人の身体の死はホロビオントが崩壊するカタストロフであるから？」',
+      source_date: '12/4',
+      selection_reason: '死を個体の消滅ではなく、共生する無数の生命の集合体が解散する「破局」として捉え直す視座は、死者と生者の共生を「すでにつねに共生していた存在の離散」として再定義する新しい角度を開く。'
+    },
+    {
+      id: 'snip2',
+      fermentation_result_id: 'fr1',
+      snippet_type: 'deepen',
+      original_text: '「周りの人たちを信頼して、いまYが来てると伝え、その声をみんなに伝える役を務める」',
+      source_date: '12/6',
+      selection_reason: '死者との対話という主題そのものは新しくないが、「他者に見えない死者の声を翻訳して伝える」という媒介の具体的実践が描かれている点で、問いの核心に迫る経験の深まりが見て取れる。'
+    },
+    {
+      id: 'snip3',
+      fermentation_result_id: 'fr1',
+      snippet_type: 'core',
+      original_text: '「人間のこと、大事な存在たちに、分析的ではない仕方で向き合う時間がもっと必要なのではないか」',
+      source_date: '12/1',
+      selection_reason: '死者と生者の共生を問うこと自体が分析的営為であるというパラドクスに気づき、共生を「問う」のではなく「生きる」方向へと転回する契機を示す。問いの方法論そのものを問い返す、メタレベルの核心的洞察。'
+    }
+  ],
+
+  // ============================================================================
+  // 7. LETTERS
+  // ============================================================================
+  letters: [
+    {
+      id: 'letter1',
+      fermentation_result_id: 'fr1',
+      body_text: 'あなたの一週間は、見えないものと見えるものの境目を、手探りで歩き続ける旅のようでした。\n\n夢のなかでYは訪れ、あなたはその声を周囲に届ける通訳者となりました。けれどYは最後、まだ生まれる前の姿にまで遡って消えてゆきました。消えることは失われることではなかったはずです——それはむしろ、ひとつの命が種子にまで還ってゆく光景に似ています。あなたが読んだ本のなかで、身体は無数の住人たちが暮らす都市のようなものだと語られていました。その都市が瓦解するとき、散り散りになった住人たちはどこへ向かうのでしょう。もしかすると、土に、水に、別の誰かの身体に——そうして都市は形を変えながら、どこかで存続し続けているのかもしれません。\n\nあなたは食卓でもその予感に触れていました。口にしたものがかつて自分であったかもしれないという想像、その想像力そのものが、亡き者と生きる者をつなぐ細い糸になっていました。そして映画館の暗がりのなかで、あなたは言葉を手放すことの価値に気づきました。沈黙のなかにこそ宿る表現があること、忘れることのなかにも一種の忠実さがあること。\n\nぬか床に手を差し入れるとき、その人の常在菌がぬかに移り、ぬかの微生物がその人に移ります。あなたが毎日書く言葉もまた、そのような交換のなかにあるのではないでしょうか。書くことで問いが変わり、問いが変わることで書く自分も変わる。死者との共生は、おそらく解くべき謎ではなく、すでに営まれている醸造のなかにあるのです。\n\nあなたはいま、翻訳者であり、醸造者であり、助産師です。見えないものに声を与え、まだ熟していない問いを急がず、他者のなかに眠る言葉が生まれ出るのを手助けしています。次に筆を執るとき、解答を探す必要はありません。むしろ、あなたの手がぬか床に触れるように、問いそのものに触れてみてください。'
+    }
+  ],
+
+  // ============================================================================
+  // 8. KEYWORDS
+  // ============================================================================
+  keywords: [
+    {
+      id: 'kw1',
+      fermentation_result_id: 'fr1',
+      keyword: '都市の離散',
+      description: '死を「崩壊」ではなく、共に住まう者たちが各地へ旅立っていく「離散（ディアスポラ）」として想像してみること。'
+    },
+    {
+      id: 'kw2',
+      fermentation_result_id: 'fr1',
+      keyword: '沈黙の忠実さ',
+      description: '語らないこと・忘れることのなかにある、死者への別種の誠実さ。言葉にしないことで守られる関係。'
+    },
+    {
+      id: 'kw3',
+      fermentation_result_id: 'fr1',
+      keyword: '胎児への回帰',
+      description: '消えゆく者が生の起源に向かって縮小する夢のイメージ。死は終点ではなく、まだ名づけられていない始まりへの折り返し。'
+    },
+    {
+      id: 'kw4',
+      fermentation_result_id: 'fr1',
+      keyword: 'ぬか床の記憶',
+      description: '個人の問いが、繰り返し触れることで徐々に固有の味わいを帯びていくこと。手の常在菌のように、無自覚に受け渡されるもの。'
+    },
+    {
+      id: 'kw5',
+      fermentation_result_id: 'fr1',
+      keyword: '共異体の食卓',
+      description: '自分とは異なるが同輩である存在と、食べる／食べられるという非対称な関係を通じて、対等な親密さを結ぶ場所。'
+    }
+  ],
+
+  // ============================================================================
+  // 9. ENTRY-QUESTION LINKS (for associating questions with entries)
+  // ============================================================================
+  entryQuestionLinks: [],
+
+  // ============================================================================
+  // HELPER METHODS
+  // ============================================================================
+
+  /**
+   * Get the latest version string for a question
+   * @param {string} questionId
+   * @returns {string|null}
+   */
+  getQuestionString(questionId) {
+    const transactions = this.questionTransactions.filter(
+      qt => qt.question_id === questionId && qt.is_validated_by_user !== false
+    );
+    if (transactions.length === 0) return null;
+    const latest = transactions.reduce((prev, current) =>
+      current.question_version > prev.question_version ? current : prev
+    );
+    return latest.string;
+  },
+
+  /**
+   * Get the fermentation result for a question
+   * @param {string} questionId
+   * @returns {object|null}
+   */
+  getFermentationForQuestion(questionId) {
+    return this.fermentationResults.find(fr => fr.question_id === questionId) || null;
+  },
+
+  /**
+   * Get extracted snippets for a fermentation result
+   * @param {string} fermentationResultId
+   * @returns {array}
+   */
+  getSnippetsForFermentation(fermentationResultId) {
+    return this.extractedSnippets.filter(
+      snippet => snippet.fermentation_result_id === fermentationResultId
+    );
+  },
+
+  /**
+   * Get keywords for a fermentation result
+   * @param {string} fermentationResultId
+   * @returns {array}
+   */
+  getKeywordsForFermentation(fermentationResultId) {
+    return this.keywords.filter(
+      kw => kw.fermentation_result_id === fermentationResultId
+    );
+  },
+
+  /**
+   * Get letter for a fermentation result
+   * @param {string} fermentationResultId
+   * @returns {object|null}
+   */
+  getLetterForFermentation(fermentationResultId) {
+    return this.letters.find(letter => letter.fermentation_result_id === fermentationResultId) || null;
+  },
+
+  /**
+   * Get analysis worksheets for a fermentation result
+   * @param {string} fermentationResultId
+   * @returns {array}
+   */
+  getWorksheetsForFermentation(fermentationResultId) {
+    return this.analysisWorksheets.filter(
+      worksheet => worksheet.fermentation_result_id === fermentationResultId
+    );
+  },
+
+  /**
+   * Get category relations for a fermentation result
+   * @param {string} fermentationResultId
+   * @returns {array}
+   */
+  getCategoriesForFermentation(fermentationResultId) {
+    return this.categoryRelations.filter(
+      category => category.fermentation_result_id === fermentationResultId
+    );
+  },
+
+  /**
+   * Add a new question with a given string
+   * @param {string} questionString
+   * @returns {object} the new question object
+   */
+  /**
+   * Get only active (non-archived, validated) questions
+   * @returns {array}
+   */
+  getActiveQuestions() {
+    return this.questions.filter(q =>
+      !q.is_archived && q.is_validated_by_user !== false
+    );
+  },
+
+  /**
+   * Get all transactions for a question, sorted by version
+   * @param {string} questionId
+   * @returns {array}
+   */
+  getTransactionsForQuestion(questionId) {
+    return this.questionTransactions
+      .filter(qt => qt.question_id === questionId)
+      .sort((a, b) => a.question_version - b.question_version);
+  },
+
+  /**
+   * Get the latest validated transaction for a question
+   * @param {string} questionId
+   * @returns {object|null}
+   */
+  getLatestTransaction(questionId) {
+    const transactions = this.questionTransactions.filter(
+      qt => qt.question_id === questionId && qt.is_validated_by_user !== false
+    );
+    if (transactions.length === 0) return null;
+    return transactions.reduce((prev, current) =>
+      current.question_version > prev.question_version ? current : prev
+    );
+  },
+
+  addQuestion(questionString) {
+    const newId = 'q' + Date.now();
+    const now = new Date().toISOString();
+
+    const newQuestion = {
+      id: newId,
+      user_id: 'u1',
+      created_at: now,
+      updated_at: now,
+      is_archived: false,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    };
+
+    this.questions.push(newQuestion);
+
+    const transactionId = 'qt' + Date.now();
+    const newTransaction = {
+      id: transactionId,
+      question_id: newId,
+      string: questionString,
+      question_version: 1,
+      created_at: now,
+      updated_at: now,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    };
+
+    this.questionTransactions.push(newTransaction);
+    this.saveToStorage();
+
+    return newQuestion;
+  },
+
+  /**
+   * Update a question's text (creates a new transaction)
+   * @param {string} questionId
+   * @param {string} newString
+   * @returns {object} the new transaction
+   */
+  updateQuestion(questionId, newString) {
+    const question = this.questions.find(q => q.id === questionId);
+    if (!question) return null;
+
+    const now = new Date().toISOString();
+    question.updated_at = now;
+
+    const existingTransactions = this.questionTransactions.filter(
+      qt => qt.question_id === questionId
+    );
+    const maxVersion = existingTransactions.reduce(
+      (max, qt) => Math.max(max, qt.question_version), 0
+    );
+
+    const newTransaction = {
+      id: 'qt' + Date.now(),
+      question_id: questionId,
+      string: newString,
+      question_version: maxVersion + 1,
+      created_at: now,
+      updated_at: now,
+      is_validated_by_user: true,
+      is_proposed_by_oryzae: false
+    };
+
+    this.questionTransactions.push(newTransaction);
+    this.saveToStorage();
+    return newTransaction;
+  },
+
+  /**
+   * Archive a question
+   * @param {string} questionId
+   */
+  archiveQuestion(questionId) {
+    const question = this.questions.find(q => q.id === questionId);
+    if (!question) return;
+    question.is_archived = true;
+    question.updated_at = new Date().toISOString();
+    this.saveToStorage();
+  },
+
+  /**
+   * Unarchive (restore) a question
+   * @param {string} questionId
+   */
+  unarchiveQuestion(questionId) {
+    const question = this.questions.find(q => q.id === questionId);
+    if (!question) return;
+    question.is_archived = false;
+    question.updated_at = new Date().toISOString();
+    this.saveToStorage();
+  },
+
+  /**
+   * Link a question to an entry
+   * @param {string} entryId
+   * @param {string} questionId
+   */
+  linkQuestionToEntry(entryId, questionId) {
+    // Check if link already exists
+    const exists = this.entryQuestionLinks.some(
+      link => link.entry_id === entryId && link.question_id === questionId
+    );
+
+    if (!exists) {
+      this.entryQuestionLinks.push({
+        entry_id: entryId,
+        question_id: questionId
+      });
+      this.saveToStorage();
+    }
+  },
+
+  /**
+   * Unlink a question from an entry
+   * @param {string} entryId
+   * @param {string} questionId
+   */
+  unlinkQuestionFromEntry(entryId, questionId) {
+    this.entryQuestionLinks = this.entryQuestionLinks.filter(
+      link => !(link.entry_id === entryId && link.question_id === questionId)
+    );
+    this.saveToStorage();
+  },
+
+  /**
+   * Get all questions linked to an entry
+   * @param {string} entryId
+   * @returns {array}
+   */
+  getQuestionsForEntry(entryId) {
+    const linkedIds = this.entryQuestionLinks
+      .filter(link => link.entry_id === entryId)
+      .map(link => link.question_id);
+
+    return this.questions.filter(q => linkedIds.includes(q.id));
+  },
+
+  /**
+   * Get all questions with their current strings
+   * @returns {array}
+   */
+  getAllQuestions() {
+    return this.getActiveQuestions().map(question => ({
+      ...question,
+      current_string: this.getQuestionString(question.id)
+    }));
+  },
+
+  /**
+   * Get ALL questions including archived (for timeline)
+   * @returns {array}
+   */
+  getAllQuestionsIncludingArchived() {
+    return this.questions.map(question => ({
+      ...question,
+      current_string: this.getQuestionString(question.id)
+    }));
+  },
+
+  /**
+   * Save data to localStorage
+   */
+  saveToStorage() {
+    const data = {
+      questions: this.questions,
+      questionTransactions: this.questionTransactions,
+      entryQuestionLinks: this.entryQuestionLinks
+    };
+    localStorage.setItem('oryzae_data', JSON.stringify(data));
+  },
+
+  /**
+   * Load data from localStorage
+   */
+  loadFromStorage() {
+    const saved = localStorage.getItem('oryzae_data');
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        if (data.questions) this.questions = data.questions;
+        if (data.questionTransactions) this.questionTransactions = data.questionTransactions;
+        if (data.entryQuestionLinks) this.entryQuestionLinks = data.entryQuestionLinks;
+      } catch(e) {
+        console.warn('Failed to load saved data:', e);
+      }
+    }
+  }
+};
+
+// Load saved data on startup
+OryzaeData.loadFromStorage();
+
+// Export for use in modules if needed
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = OryzaeData;
+}

--- a/docs/reference-ui/yeast.svg
+++ b/docs/reference-ui/yeast.svg
@@ -1,0 +1,41 @@
+<svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="yeastMain" cx="35%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#fad175"/>
+      <stop offset="60%" stop-color="#e8a020"/>
+      <stop offset="100%" stop-color="#b5760b"/>
+    </radialGradient>
+    <radialGradient id="yeastBud" cx="30%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#ffe19c"/>
+      <stop offset="70%" stop-color="#e8a020"/>
+      <stop offset="100%" stop-color="#c98612"/>
+    </radialGradient>
+    <radialGradient id="vacuole" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.2"/>
+      <stop offset="80%" stop-color="#ffffff" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="glowAmber" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+  </defs>
+  
+  <circle cx="120" cy="120" r="85" fill="#e8a020" opacity="0.05" filter="url(#glowAmber)"/>
+  
+  <g transform="translate(110, 130) rotate(-10)">
+    <ellipse cx="0" cy="0" rx="55" ry="68" fill="url(#yeastMain)"/>
+    <circle cx="5" cy="5" r="30" fill="url(#vacuole)"/>
+    <circle cx="-20" cy="-15" r="10" fill="#ffffff" opacity="0.15"/>
+    
+    <g transform="translate(35, -55) rotate(20)">
+      <ellipse cx="0" cy="0" rx="28" ry="32" fill="url(#yeastBud)"/>
+      <circle cx="-5" cy="5" r="12" fill="url(#vacuole)"/>
+      <circle cx="15" cy="-22" r="10" fill="url(#yeastBud)"/>
+    </g>
+    
+    <g transform="translate(-45, 30)">
+      <circle cx="0" cy="0" r="16" fill="url(#yeastBud)"/>
+    </g>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pre-push": "pnpm lint && pnpm typecheck"
   },
   "lint-staged": {
-    "!(.claude/**)*.{js,ts,jsx,tsx,json}": "biome check --write"
+    "!(.claude/**)!(**/docs/**)*.{js,ts,jsx,tsx,json}": "biome check --write"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## 概要

デザイン比較用の reference UI アセット（HTML, JS, SVG）を git 管理に追加。
PR #51 で `.gitignore` から `docs/reference-ui/` を削除したが、ファイル自体のコミットが漏れていた。

## 変更内容

- `docs/reference-ui/` 配下のファイル 8個を追加
- `package.json` の lint-staged パターンに `docs/` 除外を追加（biome.json で既に除外済みだが lint-staged が拾ってしまうため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)