### PR TITLE
feat: auto-trigger fermentation on entry save

### DIFF
--- a/apps/client/src/app/(protected)/entries/[id]/page.tsx
+++ b/apps/client/src/app/(protected)/entries/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   useActiveQuestions,
   useEntryQuestions,
 } from '@/features/entry-questions/hooks/use-entry-questions';
+import { useTriggerFermentation } from '@/features/fermentation/hooks/use-trigger-fermentation';
 
 export default function EntryDetailPage() {
   const params = useParams<{ id: string }>();
@@ -15,11 +16,12 @@ export default function EntryDetailPage() {
   const { entry, loading: entryLoading } = useEntry(params.id, api, authLoading);
   const activeQuestions = useActiveQuestions(api, authLoading);
   const { linkedQuestions, linkQuestion, unlinkQuestion } = useEntryQuestions(api, params.id);
+  const triggerFermentation = useTriggerFermentation(api);
 
   if (entryLoading || authLoading) {
     return (
       <div className="flex min-h-full items-center justify-center">
-        <p className="text-sm text-zinc-500">読み込み中...</p>
+        <p className="text-sm text-[var(--date-color)]">読み込み中...</p>
       </div>
     );
   }
@@ -27,7 +29,7 @@ export default function EntryDetailPage() {
   if (!entry) {
     return (
       <div className="flex min-h-full items-center justify-center">
-        <p className="text-sm text-zinc-500">エントリが見つかりません</p>
+        <p className="text-sm text-[var(--date-color)]">エントリが見つかりません</p>
       </div>
     );
   }
@@ -42,6 +44,7 @@ export default function EntryDetailPage() {
       initialLinkedIds={linkedQuestions.map((q) => q.id)}
       onLinkQuestion={async (_entryId, questionId) => linkQuestion(questionId)}
       onUnlinkQuestion={async (_entryId, questionId) => unlinkQuestion(questionId)}
+      onSaveComplete={triggerFermentation}
     />
   );
 }

--- a/apps/client/src/app/(protected)/entries/new/page.tsx
+++ b/apps/client/src/app/(protected)/entries/new/page.tsx
@@ -3,10 +3,12 @@
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { EntryEditor } from '@/features/entries/components/entry-editor';
 import { useActiveQuestions } from '@/features/entry-questions/hooks/use-entry-questions';
+import { useTriggerFermentation } from '@/features/fermentation/hooks/use-trigger-fermentation';
 
 export default function NewEntryPage() {
   const { api, auth, loading } = useAuth();
   const activeQuestions = useActiveQuestions(api, loading);
+  const triggerFermentation = useTriggerFermentation(api);
 
   async function handleLinkQuestion(entryId: string, questionId: string) {
     if (!api) return;
@@ -21,6 +23,7 @@ export default function NewEntryPage() {
       auth={auth}
       activeQuestions={activeQuestions}
       onLinkQuestion={handleLinkQuestion}
+      onSaveComplete={triggerFermentation}
     />
   );
 }

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -37,6 +37,7 @@ interface EntryEditorProps {
   initialLinkedIds?: string[];
   onLinkQuestion?: (entryId: string, questionId: string) => Promise<void>;
   onUnlinkQuestion?: (entryId: string, questionId: string) => Promise<void>;
+  onSaveComplete?: (entryId: string, content: string) => void;
 }
 
 function formatDate(date: Date): string {
@@ -59,6 +60,7 @@ export function EntryEditor({
   initialLinkedIds = [],
   onLinkQuestion,
   onUnlinkQuestion,
+  onSaveComplete,
 }: EntryEditorProps) {
   const [content, setContent] = useState(initialContent);
   const [settings, setSettings] = useState<EditorSettings>(DEFAULT_SETTINGS);
@@ -122,11 +124,13 @@ export function EntryEditor({
         }
       }
       setTimeout(() => setStatus('editing'), 2000);
+      // Fire-and-forget: trigger fermentation analysis
+      onSaveComplete?.(savedId, content);
       if (!entryId) {
         router.push(`/entries/${savedId}`);
       }
     }
-  }, [content, entryId, save, linkedIds, onLinkQuestion, router]);
+  }, [content, entryId, save, linkedIds, onLinkQuestion, router, onSaveComplete]);
 
   const handleLink = useCallback(
     async (questionId: string) => {

--- a/apps/client/src/features/fermentation/hooks/use-trigger-fermentation.ts
+++ b/apps/client/src/features/fermentation/hooks/use-trigger-fermentation.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { ApiClient } from '@/lib/api';
+
+/**
+ * エントリ保存後に fire-and-forget でフェルメンテーション API を呼ぶ。
+ * アクティブな問い全てに対して分析をトリガーする。
+ */
+export function useTriggerFermentation(api: ApiClient | null) {
+  const trigger = useCallback(
+    async (entryId: string, entryContent: string) => {
+      if (!api) return;
+
+      try {
+        // 1. ユーザーのアクティブな問いを取得
+        const questionsRes = await api.fetch('/api/v1/questions');
+        if (!questionsRes.ok) return;
+
+        const questions = (await questionsRes.json()) as {
+          id: string;
+          currentText: string | null;
+        }[];
+
+        // 2. 各問いに対して分析をトリガー（並行実行）
+        await Promise.allSettled(
+          questions.map((q) =>
+            api.fetch('/api/v1/fermentations', {
+              method: 'POST',
+              body: JSON.stringify({
+                entryId,
+                questionId: q.id,
+                questionText: q.currentText ?? '',
+                entryContent,
+              }),
+            }),
+          ),
+        );
+      } catch {
+        // fire-and-forget: エラーは静かに無視
+      }
+    },
+    [api],
+  );
+
+  return trigger;
+}

--- a/apps/server/src/contexts/fermentation/application/usecases/trigger-fermentation-for-entry.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/trigger-fermentation-for-entry.usecase.ts
@@ -1,0 +1,45 @@
+import type { FermentationRepositoryGateway } from '../../domain/gateways/fermentation-repository.gateway.js';
+import type { LlmAnalysisGateway } from '../../domain/gateways/llm-analysis.gateway.js';
+import { RunFermentationUsecase } from './run-fermentation.usecase.js';
+
+/**
+ * エントリ保存時に、ユーザーのアクティブな問い全てに対して発酵分析を実行する。
+ * fire-and-forget で呼ばれるため、エラーはログに記録するだけ。
+ */
+export class TriggerFermentationForEntryUsecase {
+  constructor(
+    private fermentationRepo: FermentationRepositoryGateway,
+    private llmGateway: LlmAnalysisGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    entryId: string;
+    entryContent: string;
+    activeQuestions: { id: string; currentText: string }[];
+  }): Promise<void> {
+    const runUsecase = new RunFermentationUsecase(
+      this.fermentationRepo,
+      this.llmGateway,
+      this.generateId,
+    );
+
+    for (const question of params.activeQuestions) {
+      try {
+        await runUsecase.execute({
+          userId: params.userId,
+          questionId: question.id,
+          questionText: question.currentText,
+          entryId: params.entryId,
+          entryContent: params.entryContent,
+        });
+      } catch (error) {
+        console.error(
+          `[Fermentation] Failed for question ${question.id}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Auto-trigger fermentation analysis when entries are saved
- Client fires POST /api/v1/fermentations for each active question
- Feature isolation maintained via onSaveComplete callback prop
- TriggerFermentationForEntryUsecase for server-side batch

## Test plan
- [x] All quality checks pass
- [x] dep-cruise: no violations (feature isolation maintained)
- [ ] Save entry → fermentation results appear in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)