### PR TITLE
fix: use generateObject for reliable LLM structured output

### DIFF
--- a/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
@@ -1,9 +1,36 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText } from 'ai';
+import { generateObject } from 'ai';
+import { z } from 'zod';
 import type {
   FermentationOutput,
   LlmAnalysisGateway,
 } from '../../domain/gateways/llm-analysis.gateway.js';
+
+const fermentationSchema = z.object({
+  worksheetMarkdown: z
+    .string()
+    .describe('M-GTA分析ワークシート（Markdown形式）。概念名・定義・具体例・理論的メモを含む'),
+  resultDiagramMarkdown: z.string().describe('結果図とストーリーライン（Markdown形式）'),
+  snippets: z
+    .array(
+      z.object({
+        type: z.enum(['new_perspective', 'deepen', 'core']).describe('切片の種類'),
+        text: z.string().describe('原文からの引用テキスト'),
+        sourceDate: z.string().describe('出典日付'),
+        reason: z.string().describe('この切片を選んだ理由'),
+      }),
+    )
+    .describe('日記から抽出した3つの切片'),
+  letterBody: z.string().describe('500字程度の詩的な手紙。要約ではなく言い換えで書く'),
+  keywords: z
+    .array(
+      z.object({
+        keyword: z.string().describe('短い詩的キーワード'),
+        description: z.string().describe('キーワードの説明'),
+      }),
+    )
+    .describe('3〜5個の詩的キーワード'),
+});
 
 function buildPrompt(params: {
   question: string;
@@ -11,8 +38,7 @@ function buildPrompt(params: {
   targetPeriod: string;
 }): string {
   return `あなたは Oryzae の発酵分析エンジンです。
-ユーザーの日記エントリを、修正版グラウンデッド・セオリー・アプローチ（M-GTA）で分析し、
-3つのステップで処理してください。
+ユーザーの日記エントリを、修正版グラウンデッド・セオリー・アプローチ（M-GTA）で分析してください。
 
 ## 入力情報
 
@@ -24,88 +50,22 @@ function buildPrompt(params: {
 ${params.entryContent}
 ---
 
-## 出力形式
-
-以下の JSON 形式で結果を返してください。JSON のみを出力し、他のテキストは含めないでください。
-
-\`\`\`json
-{
-  "worksheetMarkdown": "### 分析ワークシート\\n\\n#### 概念1：[概念名]\\n\\n| 項目 | 内容 |\\n|------|------|\\n| **概念名** | ... |\\n| **定義** | ... |\\n| **具体例（ヴァリエーション）** | ... |\\n| **理論的メモ** | ... |\\n\\n(概念を必要な数だけ生成)\\n\\n---\\n\\n### 概念間の関係とカテゴリー\\n\\n#### カテゴリーA：[名前]\\n\\n[説明]\\n\\n#### カテゴリーB：[名前]\\n\\n[説明]",
-  "resultDiagramMarkdown": "### 結果図\\n\\n\`\`\`\\n[ASCII図]\\n\`\`\`\\n\\n**ストーリーライン:** [概要テキスト]",
-  "snippets": [
-    {
-      "type": "new_perspective",
-      "text": "原文からの引用",
-      "sourceDate": "日付",
-      "reason": "この切片を選んだ理由"
-    },
-    {
-      "type": "deepen",
-      "text": "原文からの引用",
-      "sourceDate": "日付",
-      "reason": "この切片を選んだ理由"
-    },
-    {
-      "type": "core",
-      "text": "原文からの引用",
-      "sourceDate": "日付",
-      "reason": "この切片を選んだ理由"
-    }
-  ],
-  "letterBody": "500字程度の詩的な手紙。要約ではなく、言い換え・別の角度からの光を当てる。ジャーナリングを続けたくなるようなインスピレーションを与える。",
-  "keywords": [
-    {
-      "keyword": "短い詩的キーワード",
-      "description": "キーワードの説明。問いに固着しない、より広い視座を喚起するもの。"
-    }
-  ]
-}
-\`\`\`
-
-## 分析の指針
+## 分析の3ステップ
 
 ### ステップ1「コウジカビ」：日記の分解
-- M-GTAに基づき、問いに関連する概念を抽出
+- M-GTAに基づき、問いに関連する概念を2〜3個抽出
 - 各概念に定義・具体例・理論的メモを付与
 - 概念間の関係をカテゴリーにまとめ、ストーリーラインを記述
-- 切片を3種類（新視点・深化・核心）抽出
+- 切片を3種類（new_perspective=新視点・deepen=深化・core=核心）抽出
 
-### ステップ2「乳酸菌」：プロセスの整理
-- 分析ワークシートを元に、500字程度の手紙を生成
+### ステップ2「乳酸菌」：手紙の生成
+- 分析を元に、500字程度の詩的な手紙を生成
 - 要約ではなく、言い換え・パラフレーズで書く
 - ジャーナリングを続けたくなるインスピレーションを与える
 
 ### ステップ3「酵母」：キーワードの生成
-- 3〜5個のキーワード/フレーズを生成
-- 問いに固着しない、より広い視座を喚起するもの
-- 詩的で、日常の言葉で表現されたもの`;
-}
-
-function parseOutput(text: string): FermentationOutput {
-  // Extract JSON from possible markdown code block
-  let jsonStr = text;
-  const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
-  if (codeBlockMatch) {
-    jsonStr = codeBlockMatch[1];
-  }
-
-  const parsed = JSON.parse(jsonStr.trim()) as FermentationOutput;
-
-  // Validate structure
-  if (!parsed.worksheetMarkdown || !parsed.resultDiagramMarkdown) {
-    throw new Error('Missing worksheet or diagram markdown');
-  }
-  if (!Array.isArray(parsed.snippets) || parsed.snippets.length === 0) {
-    throw new Error('Missing snippets');
-  }
-  if (!parsed.letterBody) {
-    throw new Error('Missing letter body');
-  }
-  if (!Array.isArray(parsed.keywords) || parsed.keywords.length === 0) {
-    throw new Error('Missing keywords');
-  }
-
-  return parsed;
+- 3〜5個の詩的キーワード/フレーズを生成
+- 問いに固着しない、より広い視座を喚起するもの`;
 }
 
 export class VercelAiAnalysisGateway implements LlmAnalysisGateway {
@@ -114,12 +74,13 @@ export class VercelAiAnalysisGateway implements LlmAnalysisGateway {
     entryContent: string;
     targetPeriod: string;
   }): Promise<FermentationOutput> {
-    const { text } = await generateText({
+    const { object } = await generateObject({
       model: anthropic('claude-sonnet-4-20250514'),
       prompt: buildPrompt(params),
-      maxOutputTokens: 8000,
+      schema: fermentationSchema,
+      maxOutputTokens: 16000,
     });
 
-    return parseOutput(text);
+    return object;
   }
 }


### PR DESCRIPTION
## Summary

- `generateText` + JSONプロンプトでは、Claude が長いJSON文字列（Markdownテーブルのエスケープ等）を途中で完了と判断し、不完全なJSONが返るバグがあった
- Vercel AI SDK の `generateObject` + Zod schema に切り替えることで、tool use 経由の structured output を強制し、確実に完全なJSONが返るようになった
- プロンプトも簡素化（出力形式の指定を Zod schema の `.describe()` に移動）

## 変更内容

- `vercel-ai-analysis.gateway.ts`: `generateText` → `generateObject` に変更
- Zod schema で出力構造を定義（`fermentationSchema`）
- `parseOutput()` 関数を削除（不要になったため）

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass（既存 warning のみ）
- [x] `pnpm knip` — pass
- [x] E2Eテスト: エントリ保存 → 自動発酵トリガー → Claude 分析 → DB保存（completed） → Jar ビュー表示を確認済み
- [x] Supabase で全5テーブル（fermentation_results, keywords, extracted_snippets, letters, analysis_worksheets）にデータが正しく保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)