### PR TITLE
feat: redesign Jar view to match reference UI

### DIFF
--- a/apps/client/src/app/(protected)/jar/page.tsx
+++ b/apps/client/src/app/(protected)/jar/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { JarView } from '@/features/fermentation/components/jar-view';
+import { useQuestions } from '@/features/questions/hooks/use-questions';
 
 interface QuestionData {
   id: string;
@@ -11,20 +12,47 @@ interface QuestionData {
 
 export default function JarPage() {
   const { api, loading: authLoading } = useAuth();
+  const { createQuestion, editQuestion, archiveQuestion } = useQuestions(api, authLoading);
   const [questions, setQuestions] = useState<QuestionData[]>([]);
 
+  const fetchActiveQuestions = useCallback(async () => {
+    if (!api) return;
+    const res = await api.fetch('/api/v1/questions');
+    if (res.ok) {
+      setQuestions(await res.json());
+    }
+  }, [api]);
+
   useEffect(() => {
-    if (authLoading || !api) return;
-    api.fetch('/api/v1/questions').then(async (res) => {
-      if (res.ok) {
-        setQuestions(await res.json());
-      }
-    });
-  }, [api, authLoading]);
+    if (authLoading) return;
+    fetchActiveQuestions();
+  }, [authLoading, fetchActiveQuestions]);
+
+  async function handleAddQuestion(text: string) {
+    await createQuestion(text);
+    await fetchActiveQuestions();
+  }
+
+  async function handleEditQuestion(id: string, text: string) {
+    await editQuestion(id, text);
+    await fetchActiveQuestions();
+  }
+
+  async function handleArchiveQuestion(id: string) {
+    await archiveQuestion(id);
+    await fetchActiveQuestions();
+  }
 
   return (
-    <div className="-mx-4 -my-6 h-[calc(100vh-0px)]">
-      <JarView api={api} authLoading={authLoading} questions={questions} />
+    <div className="absolute inset-0">
+      <JarView
+        api={api}
+        authLoading={authLoading}
+        questions={questions}
+        onAddQuestion={handleAddQuestion}
+        onEditQuestion={handleEditQuestion}
+        onArchiveQuestion={handleArchiveQuestion}
+      />
     </div>
   );
 }

--- a/apps/client/src/app/(protected)/layout.tsx
+++ b/apps/client/src/app/(protected)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { PageFooter } from '@/components/ui/page-footer';
 import { Sidebar } from '@/features/auth/components/sidebar';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import {
@@ -17,10 +18,11 @@ function ProtectedContent({ children }: { children: React.ReactNode }) {
 
   return (
     <main
-      className="flex-1 overflow-auto transition-[margin-left] duration-200 ease-linear"
+      className="flex flex-1 flex-col overflow-hidden transition-[margin-left] duration-200 ease-linear"
       style={{ '--sidebar-width': `${sidebarWidth}px` } as React.CSSProperties}
     >
-      <div className="mx-auto w-full max-w-4xl px-4 py-6">{children}</div>
+      <div className="relative flex-1 overflow-auto">{children}</div>
+      <PageFooter />
     </main>
   );
 }

--- a/apps/client/src/components/ui/page-footer.tsx
+++ b/apps/client/src/components/ui/page-footer.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+interface FooterEntry {
+  match: (pathname: string) => boolean;
+  label: string;
+}
+
+const FOOTER_ENTRIES: FooterEntry[] = [
+  { match: (p) => p === '/jar', label: 'FERMENTING' },
+  { match: (p) => p === '/entries/new' || p.startsWith('/entries/'), label: 'EDITOR' },
+  { match: (p) => p === '/entries', label: 'LIST' },
+  { match: (p) => p === '/questions', label: '問い一覧' },
+];
+
+function resolveLabel(pathname: string): string {
+  for (const entry of FOOTER_ENTRIES) {
+    if (entry.match(pathname)) return entry.label;
+  }
+  return 'ORYZAE';
+}
+
+/**
+ * Global footer (UI_SPEC.md §3).
+ * - Height: 36px
+ * - Status display only — no clickable actions
+ * - Label is derived from the current pathname
+ */
+export function PageFooter() {
+  const pathname = usePathname();
+  const label = resolveLabel(pathname);
+
+  return (
+    <footer
+      className="flex h-9 shrink-0 items-center justify-between border-t border-[var(--border-subtle)] bg-[var(--footer-bg)] px-4 text-xs text-[var(--date-color)]"
+      style={{ fontFamily: 'Inter, "Noto Sans JP", sans-serif' }}
+    >
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--date-color)] opacity-30" />
+        <span className="tracking-[0.15em]">{label}</span>
+      </div>
+
+      {/* Center: progress bar (decorative) */}
+      <div className="flex justify-center">
+        <div className="h-0.5 w-16 overflow-hidden rounded-full bg-[var(--item-border)]">
+          <div className="h-full w-0 rounded-full bg-[var(--accent)]" />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="tracking-[0.15em]">{label}</span>
+      </div>
+    </footer>
+  );
+}

--- a/apps/client/src/features/fermentation/components/jar-view.tsx
+++ b/apps/client/src/features/fermentation/components/jar-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { DetailPane } from '@/features/fermentation/components/detail-pane';
 import { QuestionCircle } from '@/features/fermentation/components/question-circle';
 import { useFermentationForQuestion } from '@/features/fermentation/hooks/use-fermentation-results';
@@ -15,13 +15,69 @@ interface JarViewProps {
   api: ApiClient | null;
   authLoading: boolean;
   questions: QuestionData[];
+  onAddQuestion?: (text: string) => Promise<void>;
+  onEditQuestion?: (id: string, text: string) => Promise<void>;
+  onArchiveQuestion?: (id: string) => Promise<void>;
 }
 
 const CIRCLE_POSITIONS = [
-  { top: '10%', right: '5%' },
-  { bottom: '15%', right: '10%' },
-  { top: '30%', left: '5%' },
+  { top: '22%', left: '80%' }, // top-right
+  { top: '72%', left: '72%' }, // bottom center-right
+  { top: '46%', left: '14%' }, // center-left
 ];
+
+/* Text particles floating inside the jar */
+const TEXT_PARTICLE_WORDS = ['発酵', '記憶', '静寂', '光', '闇', '朝', '麹', '息'];
+const FILLER_WORDS = [
+  '米',
+  '水',
+  '土壌',
+  '醸す',
+  '問い',
+  '時間',
+  '沈殿',
+  '風',
+  '季節',
+  '菌',
+  '熱',
+  '繁殖',
+  '心',
+  '秋',
+  '瀬',
+];
+const ALL_WORDS = [...TEXT_PARTICLE_WORDS, ...FILLER_WORDS];
+const FLOAT_CLASSES = ['j2-float-1', 'j2-float-2', 'j2-float-3'];
+const BLUR_LEVELS = [0.6, 0.8, 1.2, 1.8, 2.2, 2.5, 3.5, 4];
+const FONT_SIZES = [11, 12, 14, 16, 18, 22, 26];
+
+/* Microbe positions inside the jar */
+const JAR_MICROBES: Array<{
+  type: 'koji' | 'yeast' | 'lab';
+  top: string;
+  left: string;
+  size: number;
+  anim: string;
+  opacity: number;
+}> = [
+  { type: 'koji', top: '32%', left: '55%', size: 32, anim: 'j2-float-2', opacity: 0.5 },
+  { type: 'yeast', top: '52%', left: '22%', size: 24, anim: 'j2-float-3', opacity: 0.45 },
+  { type: 'lab', top: '75%', left: '60%', size: 36, anim: 'j2-float-1', opacity: 0.4 },
+  { type: 'koji', top: '15%', left: '68%', size: 28, anim: 'j2-float-2', opacity: 0.5 },
+  { type: 'yeast', top: '45%', left: '78%', size: 24, anim: 'j2-float-1', opacity: 0.55 },
+  { type: 'lab', top: '65%', left: '35%', size: 32, anim: 'j2-float-3', opacity: 0.4 },
+];
+
+/* Microbe SVG templates matching the reference design */
+const MICROBE_SVGS = {
+  koji: '<svg viewBox="0 0 28 28"><g fill="none"><path d="M14,24 C10,20 8,14 12,8 C14,6 16,6 18,8 C22,12 22,18 18,22" stroke="#A3B8A8" stroke-width="2" stroke-linecap="round" opacity="0.65"/><ellipse cx="14" cy="6" rx="3.5" ry="5" fill="#A3B8A8" opacity="0.35"/><ellipse cx="9" cy="10" rx="2" ry="3" fill="#8EA89C" opacity="0.45"/><ellipse cx="19" cy="14" rx="1.5" ry="2.5" fill="#8EA89C" opacity="0.3"/></g></svg>',
+  yeast:
+    '<svg viewBox="0 0 24 36"><g fill="#D9B48F" opacity="0.55"><rect x="8" y="4" width="8" height="20" rx="4" fill="#D9B48F" opacity="0.6"/><rect x="6" y="2" width="5" height="14" rx="2.5" fill="#E2C28E" opacity="0.7"/><rect x="14" y="8" width="4" height="12" rx="2" fill="#D9B48F" opacity="0.45"/><rect x="10" y="20" width="4" height="10" rx="2" fill="#E2C28E" opacity="0.5"/></g></svg>',
+  lab: '<svg viewBox="0 0 32 20"><g fill="none"><path d="M6,14 Q12,6 18,12 Q26,18 30,10" stroke="#A3B8A8" stroke-width="2.5" stroke-linecap="round" opacity="0.6"/><circle cx="6" cy="14" r="3" fill="#A3B8A8" opacity="0.4"/><circle cx="18" cy="12" r="2.5" fill="#8EA89C" opacity="0.35"/><circle cx="30" cy="10" r="2" fill="#A3B8A8" opacity="0.3"/></g></svg>',
+};
+
+/* Jar bottle SVG path (reference design) */
+const JAR_PATH =
+  'M190,100 C190,60 290,60 290,100 C290,130 270,140 270,170 C270,270 410,330 410,480 C410,580 70,580 70,480 C70,330 210,270 210,170 C210,140 190,130 190,100 Z';
 
 function QuestionCircleWithData({
   question,
@@ -33,7 +89,7 @@ function QuestionCircleWithData({
 }: {
   question: QuestionData;
   api: ApiClient | null;
-  position: React.CSSProperties;
+  position: { top: string; left: string };
   zoomedId: string | null;
   onZoom: (id: string | null) => void;
   onElementClick: (
@@ -51,34 +107,58 @@ function QuestionCircleWithData({
       className={`transition-opacity duration-500 ${isHidden ? 'pointer-events-none opacity-0' : 'opacity-100'}`}
     >
       <QuestionCircle
+        questionId={question.id}
         questionText={question.currentText ?? ''}
         detail={detail}
         zoomed={isZoomed}
         onClick={() => onZoom(question.id)}
         onElementClick={(type, data) => onElementClick(question.currentText ?? '', type, data)}
-        style={isZoomed ? {} : position}
+        style={
+          isZoomed
+            ? {}
+            : {
+                top: position.top,
+                left: position.left,
+              }
+        }
       />
     </div>
   );
 }
 
-export function JarView({ api, authLoading, questions }: JarViewProps) {
+export function JarView({
+  api,
+  authLoading,
+  questions,
+  onAddQuestion,
+  onEditQuestion,
+  onArchiveQuestion,
+}: JarViewProps) {
   const [zoomedId, setZoomedId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailType, setDetailType] = useState<'keyword' | 'snippet' | 'letter' | null>(null);
   const [detailData, setDetailData] = useState<Record<string, string> | null>(null);
   const [detailQuestion, setDetailQuestion] = useState('');
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [newQuestionText, setNewQuestionText] = useState('');
+  const addInputRef = useRef<HTMLTextAreaElement>(null);
+  const [editingQuestion, setEditingQuestion] = useState<QuestionData | null>(null);
+  const [editText, setEditText] = useState('');
+  const editInputRef = useRef<HTMLTextAreaElement>(null);
 
-  function handleElementClick(
-    questionText: string,
-    type: 'keyword' | 'snippet' | 'letter',
-    data: Record<string, string>,
-  ) {
-    setDetailQuestion(questionText);
-    setDetailType(type);
-    setDetailData(data);
-    setDetailOpen(true);
-  }
+  const handleElementClick = useCallback(
+    (
+      questionText: string,
+      type: 'keyword' | 'snippet' | 'letter',
+      data: Record<string, string>,
+    ) => {
+      setDetailQuestion(questionText);
+      setDetailType(type);
+      setDetailData(data);
+      setDetailOpen(true);
+    },
+    [],
+  );
 
   function closeZoom() {
     setDetailOpen(false);
@@ -94,141 +174,465 @@ export function JarView({ api, authLoading, questions }: JarViewProps) {
   }
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
-      {/* Float animation keyframes */}
+    <div className="relative h-full w-full overflow-hidden bg-[var(--bg)]">
+      {/* Keyframes */}
       <style>{`
-        @keyframes float {
-          0%, 100% { transform: translateY(0px) rotate(var(--base-rotate, 0deg)); }
-          50% { transform: translateY(-6px) rotate(calc(var(--base-rotate, 0deg) + 1deg)); }
+        @keyframes j2-float-1 {
+          0%, 100% { transform: translateY(0) translateX(0); }
+          33% { transform: translateY(-10px) translateX(5px); }
+          66% { transform: translateY(5px) translateX(-5px); }
+        }
+        @keyframes j2-float-2 {
+          0%, 100% { transform: translateY(0) translateX(0); }
+          33% { transform: translateY(5px) translateX(-8px); }
+          66% { transform: translateY(-8px) translateX(3px); }
+        }
+        @keyframes j2-float-3 {
+          0%, 100% { transform: translateY(0) translateX(0); }
+          33% { transform: translateY(-6px) translateX(-4px); }
+          66% { transform: translateY(8px) translateX(6px); }
+        }
+        .j2-float-1 { animation: j2-float-1 8s ease-in-out infinite; }
+        .j2-float-2 { animation: j2-float-2 12s ease-in-out infinite; }
+        .j2-float-3 { animation: j2-float-3 10s ease-in-out infinite 2s; }
+
+        @keyframes j2-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.6; }
+        }
+        @keyframes j2-flow {
+          0% { stroke-dashoffset: 1000; }
+          100% { stroke-dashoffset: 0; }
+        }
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
         }
       `}</style>
+
+      {/* Background grid pattern */}
+      <div
+        className="pointer-events-none absolute inset-0 z-0"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(140,133,126,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(140,133,126,0.04) 1px, transparent 1px)',
+          backgroundSize: '40px 40px',
+          backgroundPosition: 'center center',
+        }}
+      />
+      {/* Background radial */}
+      <div
+        className="pointer-events-none absolute inset-0 z-0"
+        style={{
+          background:
+            'radial-gradient(circle at 50% 40%, rgba(255,255,255,0.7) 0%, transparent 70%)',
+        }}
+      />
 
       {/* Zoom backdrop */}
       {zoomedId && (
         <button
           type="button"
           onClick={closeZoom}
-          className="absolute inset-0 z-[45] bg-[rgba(250,248,244,0.75)]"
+          className="absolute inset-0 z-[4] bg-[rgba(0,0,0,0.3)]"
           aria-label="ズームを閉じる"
         />
       )}
 
-      {/* Central jar illustration — larger, matching reference */}
-      <div className="absolute top-1/2 left-1/2 z-[2] -translate-x-1/2 -translate-y-[55%]">
-        <svg
-          aria-hidden="true"
-          width="380"
-          height="520"
-          viewBox="0 0 200 280"
-          fill="none"
-          opacity="0.25"
-        >
-          {/* Lid */}
-          <rect x="70" y="8" width="60" height="14" rx="4" fill="#c9a96e" opacity="0.4" />
-          {/* Neck */}
-          <path d="M75 22 L75 48 Q75 58 65 63" stroke="#c9a96e" strokeWidth="1" fill="none" />
-          <path d="M125 22 L125 48 Q125 58 135 63" stroke="#c9a96e" strokeWidth="1" fill="none" />
-          {/* Body */}
-          <path
-            d="M55 63 Q38 100 38 160 Q38 252 100 268 Q162 252 162 160 Q162 100 145 63"
-            stroke="#c9a96e"
-            strokeWidth="1.5"
-            fill="rgba(200,180,140,0.04)"
-          />
-          {/* Liquid */}
-          <path d="M48 140 Q48 252 100 264 Q152 252 152 140" fill="rgba(90,184,90,0.06)" />
-          {/* Floating text with animation class */}
-          <text x="75" y="155" fontSize="9" fill="#999" opacity="0.5">
-            発酵
-          </text>
-          <text x="105" y="180" fontSize="7" fill="#999" opacity="0.4">
-            記憶
-          </text>
-          <text x="85" y="210" fontSize="8" fill="#999" opacity="0.35">
-            問い
-          </text>
-          <text x="95" y="240" fontSize="6" fill="#999" opacity="0.25">
-            時間
-          </text>
-          <text x="110" y="160" fontSize="5" fill="#999" opacity="0.2">
-            沈黙
-          </text>
-          <text x="70" y="195" fontSize="6" fill="#999" opacity="0.3">
-            変容
-          </text>
-        </svg>
-      </div>
-
-      {/* Connection lines — quadratic bezier curves */}
+      {/* Connection lines — using percentage-based SVG */}
       <svg
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 z-[1]"
-        viewBox="0 0 100 100"
+        className="pointer-events-none absolute inset-0 z-[1] h-full w-full"
+        viewBox="0 0 1000 500"
         preserveAspectRatio="none"
-        style={{ opacity: zoomedId ? 0 : 1, transition: 'opacity 0.5s' }}
+        style={{ opacity: zoomedId ? 0 : 1, transition: 'opacity 0.5s ease' }}
       >
         {questions.slice(0, 3).map((q, i) => {
           const pos = CIRCLE_POSITIONS[i];
-          const endX = pos.right ? 82 : pos.left ? 18 : 50;
-          const endY = pos.top ? 25 : pos.bottom ? 78 : 50;
-          const cpX = (50 + endX) / 2 + (i === 0 ? 10 : i === 1 ? 5 : -10);
-          const cpY = (45 + endY) / 2 + (i === 0 ? -10 : i === 1 ? 10 : 0);
+          const endX = (Number.parseFloat(pos.left) / 100) * 1000;
+          const endY = (Number.parseFloat(pos.top) / 100) * 500;
+          const jarX = 500;
+          const jarY = 210;
+          const cpX = (jarX + endX) / 2 + (i === 0 ? 50 : i === 1 ? 25 : -50);
+          const cpY = (jarY + endY) / 2 + (i === 0 ? -30 : i === 1 ? 30 : 0);
           return (
-            <path
-              key={q.id}
-              d={`M 50 45 Q ${cpX} ${cpY} ${endX} ${endY}`}
-              stroke="#d97706"
-              strokeWidth="0.3"
-              strokeDasharray="1.5 1.5"
-              opacity="0.25"
-              fill="none"
-            />
+            <g key={q.id}>
+              {/* Glow layer */}
+              <path
+                d={`M ${jarX} ${jarY} Q ${cpX} ${cpY} ${endX} ${endY}`}
+                stroke="rgba(142,168,156,0.08)"
+                strokeWidth="4"
+                fill="none"
+                filter="url(#lineBlur)"
+              />
+              {/* Dashed line */}
+              <path
+                d={`M ${jarX} ${jarY} Q ${cpX} ${cpY} ${endX} ${endY}`}
+                stroke="rgba(142,168,156,0.25)"
+                strokeWidth="1"
+                strokeDasharray="6 4"
+                fill="none"
+                style={{ animation: 'j2-flow 60s linear infinite' }}
+              />
+            </g>
           );
         })}
+        <defs>
+          <filter id="lineBlur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="2" />
+          </filter>
+        </defs>
       </svg>
 
-      {/* Question circles */}
-      {questions.slice(0, 3).map((q, i) => (
-        <QuestionCircleWithData
-          key={q.id}
-          question={q}
-          api={api}
-          position={CIRCLE_POSITIONS[i]}
-          zoomedId={zoomedId}
-          onZoom={setZoomedId}
-          onElementClick={handleElementClick}
+      {/* Central jar illustration — matching reference design */}
+      <div
+        className="pointer-events-none absolute z-[2]"
+        style={{
+          left: '50%',
+          top: '45%',
+          transform: 'translate(-50%, -55%)',
+          width: '420px',
+          height: '520px',
+        }}
+      >
+        {/* Jar glow */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: 'rgba(226,194,142,0.1)',
+            borderRadius: '200px',
+            filter: 'blur(80px)',
+            animation: 'j2-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite',
+          }}
         />
-      ))}
+
+        {/* Jar SVG */}
+        <svg
+          aria-hidden="true"
+          className="h-full w-full"
+          viewBox="0 0 480 600"
+          fill="none"
+          style={{ filter: 'drop-shadow(0 20px 40px rgba(140,133,126,0.15))' }}
+        >
+          {/* Glass body */}
+          <path
+            d={JAR_PATH}
+            fill="rgba(253,251,247,0.2)"
+            stroke="rgba(255,255,255,0.8)"
+            strokeWidth="1.5"
+          />
+          {/* Fermentation liquid */}
+          <path
+            d="M78,450 C78,350 180,310 200,240 C220,240 270,310 402,450 C410,580 70,580 78,450 Z"
+            fill="url(#j2-fermentGradient)"
+            opacity="0.6"
+            filter="url(#blurLiquid)"
+          />
+          {/* Highlight stroke (left) */}
+          <path
+            d="M100,460 C100,340 220,270 220,180"
+            stroke="url(#j2-highlightGradient)"
+            strokeWidth="4"
+            strokeLinecap="round"
+            filter="url(#blurHighlight)"
+            opacity="0.7"
+          />
+          {/* Glass reflection (right) */}
+          <path
+            d="M380,480 C380,380 260,280 260,190"
+            stroke="rgba(255,255,255,0.4)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            filter="url(#blurReflection)"
+          />
+          {/* Rim highlight */}
+          <path
+            d="M210,100 Q 240,110 270,100"
+            stroke="rgba(255,255,255,0.9)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            filter="url(#blurReflection)"
+          />
+          {/* Interior flowing curves */}
+          <g stroke="rgba(226,194,142,0.4)" strokeWidth="0.75" fill="none" opacity="0.8">
+            <path d="M240,280 Q 280,350 250,420 T 320,520" className="j2-float-1" />
+            <path d="M320,320 Q 290,380 340,440 T 260,540" className="j2-float-2" />
+            <path d="M200,220 Q 240,290 180,350 T 210,480" className="j2-float-3" />
+            <path d="M160,360 Q 140,420 200,460 T 140,530" className="j2-float-1" />
+            <path d="M260,200 Q 270,250 240,290" />
+          </g>
+          <defs>
+            <linearGradient id="j2-fermentGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="rgba(226,194,142,0.1)" />
+              <stop offset="50%" stopColor="rgba(142,168,156,0.2)" />
+              <stop offset="100%" stopColor="rgba(226,194,142,0.4)" />
+            </linearGradient>
+            <linearGradient id="j2-highlightGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stopColor="rgba(255,255,255,0.8)" />
+              <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+            </linearGradient>
+            <filter id="blurLiquid">
+              <feGaussianBlur in="SourceGraphic" stdDeviation="6" />
+            </filter>
+            <filter id="blurHighlight">
+              <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
+            </filter>
+            <filter id="blurReflection">
+              <feGaussianBlur in="SourceGraphic" stdDeviation="0.5" />
+            </filter>
+          </defs>
+        </svg>
+
+        {/* Text particles + microbes clipped inside jar */}
+        <div
+          className="pointer-events-auto absolute inset-0 overflow-hidden"
+          style={{
+            clipPath: `path('${JAR_PATH}')`,
+          }}
+        >
+          {ALL_WORDS.map((word, i) => {
+            const top = 18 + ((i * 37) % 65);
+            const left = 22 + ((i * 53) % 60);
+            const blur = BLUR_LEVELS[i % BLUR_LEVELS.length];
+            const fontSize = FONT_SIZES[i % FONT_SIZES.length];
+            const opacity = 0.3 + (i % 5) * 0.12;
+            return (
+              <span
+                key={word}
+                className={`${FLOAT_CLASSES[i % 3]} pointer-events-none select-none`}
+                style={{
+                  position: 'absolute',
+                  top: `${top}%`,
+                  left: `${left}%`,
+                  filter: `blur(${blur}px)`,
+                  fontSize: `${fontSize}px`,
+                  opacity,
+                  letterSpacing: '0.15em',
+                  fontFamily: "'Noto Serif JP', serif",
+                  color: 'var(--date-color)',
+                }}
+              >
+                {word}
+              </span>
+            );
+          })}
+          {JAR_MICROBES.map((m, i) => (
+            <div
+              key={`microbe-${m.type}-${m.top}-${m.left}`}
+              className={m.anim}
+              style={{
+                position: 'absolute',
+                top: m.top,
+                left: m.left,
+                width: `${m.size}px`,
+                height: `${m.size}px`,
+                opacity: m.opacity,
+                pointerEvents: 'none',
+              }}
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG
+              dangerouslySetInnerHTML={{ __html: MICROBE_SVGS[m.type] }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Question circles */}
+      {questions.slice(0, 3).map((q, i) => {
+        const pos = CIRCLE_POSITIONS[i];
+        return (
+          <QuestionCircleWithData
+            key={q.id}
+            question={q}
+            api={api}
+            position={{ top: pos.top, left: pos.left }}
+            zoomedId={zoomedId}
+            onZoom={setZoomedId}
+            onElementClick={handleElementClick}
+          />
+        );
+      })}
 
       {/* Question list (bottom center) */}
       {!zoomedId && (
-        <div className="absolute bottom-8 left-1/2 z-[10] flex -translate-x-1/2 flex-col items-center gap-1.5">
+        <div className="absolute bottom-12 left-1/2 z-[30] flex -translate-x-1/2 flex-col items-center gap-2.5">
+          <div
+            className="h-6 w-px"
+            style={{
+              background: 'linear-gradient(to top, rgba(140,133,126,0.3), transparent)',
+            }}
+          />
           <span
-            className="mb-2 text-[10px] font-medium uppercase tracking-[0.2em] text-[var(--date-color)]"
+            className="text-[10px] tracking-[0.3em] text-[var(--date-color)]"
             style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
           >
             現在の問い
           </span>
-          {questions.slice(0, 3).map((q) => (
+          <div className="flex flex-wrap justify-center gap-2.5">
+            {questions.slice(0, 3).map((q) => (
+              <button
+                key={q.id}
+                type="button"
+                onClick={() => {
+                  setEditingQuestion(q);
+                  setEditText(q.currentText ?? '');
+                  setTimeout(() => editInputRef.current?.focus(), 100);
+                }}
+                className="rounded-full px-4 py-1.5 text-[11px] font-medium tracking-[0.08em] transition-all hover:-translate-y-0.5"
+                style={{
+                  background: 'linear-gradient(135deg, var(--text), rgba(140,133,126,0.9))',
+                  color: 'var(--bg)',
+                  fontFamily: "'Noto Serif JP', serif",
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  backdropFilter: 'blur(8px)',
+                  boxShadow: '0 2px 8px rgba(74,69,65,0.15)',
+                }}
+              >
+                {q.currentText}
+              </button>
+            ))}
+          </div>
+          {questions.length < 3 && onAddQuestion && (
             <button
-              key={q.id}
               type="button"
-              onClick={() => setZoomedId(q.id)}
-              className="rounded-full border-[1.5px] border-[#8b2020] bg-[#8b2020] px-5 py-1.5 text-xs text-white transition-colors hover:bg-[#6b1515]"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
-            >
-              {q.currentText}
-            </button>
-          ))}
-          {questions.length < 3 && (
-            <button
-              type="button"
-              className="mt-1 rounded-full border border-[var(--accent)] px-4 py-1 text-[11px] text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-white"
+              onClick={() => {
+                setShowAddModal(true);
+                setTimeout(() => addInputRef.current?.focus(), 100);
+              }}
+              className="rounded-full border border-dashed border-[var(--date-color)] px-3 py-1 text-[10px] tracking-[0.1em] text-[var(--date-color)] transition-all hover:bg-[rgba(140,133,126,0.1)]"
               style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
             >
               ＋ 問いを追加する
             </button>
           )}
+        </div>
+      )}
+
+      {/* Edit question modal */}
+      {editingQuestion && (
+        <div
+          className="absolute inset-0 z-[100] flex items-center justify-center"
+          style={{ background: 'rgba(0,0,0,0.4)', animation: 'fadeIn 0.3s' }}
+        >
+          <div
+            role="dialog"
+            className="w-[380px] max-w-[90%] rounded-2xl bg-[var(--bg)] p-7 shadow-[0_20px_50px_rgba(0,0,0,0.15)]"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <h3
+              className="mb-4 text-sm text-[var(--text)]"
+              style={{ fontFamily: "'Noto Serif JP', serif" }}
+            >
+              問いを編集
+            </h3>
+            <textarea
+              ref={editInputRef}
+              value={editText}
+              onChange={(e) => setEditText(e.target.value)}
+              maxLength={64}
+              rows={3}
+              className="w-full resize-none rounded-lg border border-[var(--border-subtle)] bg-transparent p-3 text-[13px] text-[var(--text)] outline-none"
+              style={{ fontFamily: "'Noto Serif JP', serif" }}
+            />
+            <div className="mt-1 text-right text-[10px] text-[var(--date-color)]">
+              {editText.length}/64
+            </div>
+            <div className="mt-3 flex justify-end gap-2.5">
+              {onArchiveQuestion && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await onArchiveQuestion(editingQuestion.id);
+                    setEditingQuestion(null);
+                  }}
+                  className="mr-auto rounded-full border border-[#dc2626] bg-transparent px-5 py-2 text-[11px] text-[#dc2626] transition-all hover:bg-[#dc2626] hover:text-white"
+                  style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
+                >
+                  アーカイブ
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setEditingQuestion(null)}
+                className="rounded-full border border-[var(--border-subtle)] bg-transparent px-5 py-2 text-[11px] text-[var(--date-color)] transition-all hover:bg-[rgba(140,133,126,0.1)]"
+                style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
+              >
+                キャンセル
+              </button>
+              {onEditQuestion && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (!editText.trim()) return;
+                    await onEditQuestion(editingQuestion.id, editText.trim());
+                    setEditingQuestion(null);
+                  }}
+                  className="rounded-full bg-[var(--text)] px-5 py-2 text-[11px] text-[var(--bg)] transition-opacity hover:opacity-85"
+                  style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
+                >
+                  更新する
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Add question modal */}
+      {showAddModal && (
+        <div
+          className="absolute inset-0 z-[100] flex items-center justify-center"
+          style={{ background: 'rgba(0,0,0,0.4)', animation: 'fadeIn 0.3s' }}
+        >
+          <div
+            role="dialog"
+            className="w-[380px] max-w-[90%] rounded-2xl bg-[var(--bg)] p-7 shadow-[0_20px_50px_rgba(0,0,0,0.15)]"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <h3
+              className="mb-4 text-sm text-[var(--text)]"
+              style={{ fontFamily: "'Noto Serif JP', serif" }}
+            >
+              新しい問いを追加
+            </h3>
+            <textarea
+              ref={addInputRef}
+              value={newQuestionText}
+              onChange={(e) => setNewQuestionText(e.target.value)}
+              placeholder="あなたの問いを入力してください"
+              rows={3}
+              className="w-full resize-none rounded-lg border border-[var(--border-subtle)] bg-transparent p-3 text-[13px] text-[var(--text)] outline-none"
+              style={{ fontFamily: "'Noto Serif JP', serif" }}
+            />
+            <div className="mt-4 flex justify-end gap-2.5">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAddModal(false);
+                  setNewQuestionText('');
+                }}
+                className="rounded-full border border-[var(--border-subtle)] bg-transparent px-5 py-2 text-[11px] text-[var(--date-color)] transition-all hover:bg-[rgba(140,133,126,0.1)]"
+                style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  if (!newQuestionText.trim() || !onAddQuestion) return;
+                  await onAddQuestion(newQuestionText.trim());
+                  setNewQuestionText('');
+                  setShowAddModal(false);
+                }}
+                className="rounded-full bg-[var(--text)] px-5 py-2 text-[11px] text-[var(--bg)] transition-opacity hover:opacity-85"
+                style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
+              >
+                追加する
+              </button>
+            </div>
+          </div>
         </div>
       )}
 
@@ -240,20 +644,6 @@ export function JarView({ api, authLoading, questions }: JarViewProps) {
         type={detailType}
         data={detailData}
       />
-
-      {/* Footer */}
-      <div className="absolute bottom-0 left-0 right-0 flex items-center justify-between border-t border-[var(--border-subtle)] bg-[var(--bg)] px-4 py-1.5 text-xs text-[var(--date-color)]">
-        <div className="flex items-center gap-2">
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--date-color)] opacity-30" />
-          <span style={{ fontFamily: 'Inter, sans-serif' }}>FERMENTING</span>
-        </div>
-        <div className="flex justify-center">
-          <div className="h-0.5 w-16 overflow-hidden rounded-full bg-[rgba(0,0,0,0.06)]">
-            <div className="h-full w-0 rounded-full bg-[var(--accent)]" />
-          </div>
-        </div>
-        <span style={{ fontFamily: 'Inter, sans-serif' }}>FERMENTING</span>
-      </div>
     </div>
   );
 }

--- a/apps/client/src/features/fermentation/components/question-circle.tsx
+++ b/apps/client/src/features/fermentation/components/question-circle.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useMemo } from 'react';
 import type { FermentationDetail } from '@/features/fermentation/hooks/use-fermentation-results';
 
 interface QuestionCircleProps {
+  questionId: string;
   questionText: string;
   detail: FermentationDetail | null;
   zoomed: boolean;
@@ -11,71 +13,76 @@ interface QuestionCircleProps {
   style?: React.CSSProperties;
 }
 
-const KEYWORD_ROTATIONS = [-5, 8, -3, 6, -7];
+/* ── Microbe SVG templates (matching reference) ── */
+const MICROBE_SVGS = {
+  koji: '<svg viewBox="0 0 28 28"><g fill="none"><path d="M14,24 C10,20 8,14 12,8 C14,6 16,6 18,8 C22,12 22,18 18,22" stroke="#A3B8A8" stroke-width="2" stroke-linecap="round" opacity="0.65"/><ellipse cx="14" cy="6" rx="3.5" ry="5" fill="#A3B8A8" opacity="0.35"/><ellipse cx="9" cy="10" rx="2" ry="3" fill="#8EA89C" opacity="0.45"/><ellipse cx="19" cy="14" rx="1.5" ry="2.5" fill="#8EA89C" opacity="0.3"/></g></svg>',
+  yeast:
+    '<svg viewBox="0 0 24 36"><g fill="#D9B48F" opacity="0.55"><rect x="8" y="4" width="8" height="20" rx="4" fill="#D9B48F" opacity="0.6"/><rect x="6" y="2" width="5" height="14" rx="2.5" fill="#E2C28E" opacity="0.7"/><rect x="14" y="8" width="4" height="12" rx="2" fill="#D9B48F" opacity="0.45"/><rect x="10" y="20" width="4" height="10" rx="2" fill="#E2C28E" opacity="0.5"/></g></svg>',
+  lab: '<svg viewBox="0 0 32 20"><g fill="none"><path d="M6,14 Q12,6 18,12 Q26,18 30,10" stroke="#A3B8A8" stroke-width="2.5" stroke-linecap="round" opacity="0.6"/><circle cx="6" cy="14" r="3" fill="#A3B8A8" opacity="0.4"/><circle cx="18" cy="12" r="2.5" fill="#8EA89C" opacity="0.35"/><circle cx="30" cy="10" r="2" fill="#A3B8A8" opacity="0.3"/></g></svg>',
+};
+const MICROBE_TYPES: Array<'koji' | 'yeast' | 'lab'> = ['koji', 'yeast', 'lab'];
+
+/* ── Positions for content elements ── */
 const KEYWORD_POSITIONS = [
-  { top: '10%', left: '40%' },
-  { top: '22%', left: '72%' },
-  { top: '60%', left: '70%' },
-  { top: '58%', left: '14%' },
-  { top: '22%', left: '14%' },
+  { top: 20, left: 55 },
+  { top: 38, left: 18 },
+  { top: 55, left: 65 },
+  { top: 72, left: 28 },
+  { top: 45, left: 45 },
 ];
-const SNIPPET_ROTATIONS = [-12, 8, -5];
 const SNIPPET_POSITIONS = [
-  { top: '32%', left: '20%' },
-  { top: '36%', left: '50%' },
-  { top: '50%', left: '36%' },
+  { top: 30, left: 35 },
+  { top: 60, left: 15 },
+  { top: 50, left: 75 },
 ];
-const LETTER_POSITION = { top: '74%', left: '42%' };
+const LETTER_POSITION = { top: 72, left: 52 };
+const FLOAT_CLASSES = ['j2-float-1', 'j2-float-2', 'j2-float-3'];
 
-/* Microbe SVG icons */
-function YeastIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="14"
-      height="14"
-      viewBox="0 0 20 20"
-      className="absolute -top-1 -right-1"
-    >
-      <ellipse cx="10" cy="12" rx="6" ry="5" fill="#d4a050" opacity="0.8" />
-      <ellipse cx="14" cy="7" rx="3.5" ry="3" fill="#d4a050" opacity="0.6" />
-    </svg>
-  );
+/* ── Empty state microbe positions ── */
+const EMPTY_MICROBE_POSITIONS = [
+  { top: 30, left: 40, size: 28 },
+  { top: 50, left: 25, size: 24 },
+  { top: 60, left: 60, size: 32 },
+  { top: 25, left: 65, size: 24 },
+  { top: 70, left: 38, size: 28 },
+  { top: 40, left: 70, size: 20 },
+];
+
+/** Seeded random number generator (same as reference) */
+function seededRandom(seed: string): () => number {
+  let s = 0;
+  for (let i = 0; i < seed.length; i++) s = ((s << 5) - s + seed.charCodeAt(i)) | 0;
+  return function next(): number {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s & 0x7fffffff) / 2147483647;
+  };
 }
 
-function KojiIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="14"
-      height="14"
-      viewBox="0 0 20 20"
-      className="absolute -top-1 -right-1"
-    >
-      <line x1="10" y1="18" x2="10" y2="6" stroke="#8b5cf6" strokeWidth="1.5" opacity="0.7" />
-      <circle cx="7" cy="5" r="2" fill="#8b5cf6" opacity="0.6" />
-      <circle cx="13" cy="7" r="1.5" fill="#8b5cf6" opacity="0.5" />
-      <circle cx="10" cy="3" r="1.8" fill="#8b5cf6" opacity="0.7" />
-    </svg>
-  );
-}
-
-function LabIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      width="12"
-      height="12"
-      viewBox="0 0 16 16"
-      className="absolute -top-1 -left-1"
-    >
-      <ellipse cx="8" cy="8" rx="4" ry="3" fill="#059669" opacity="0.6" />
-      <ellipse cx="5" cy="6" rx="2.5" ry="2" fill="#059669" opacity="0.5" />
-    </svg>
-  );
+/** Generate mycelium SVG paths radiating from center */
+function generateMyceliumPaths(size: number, questionId: string): string {
+  const cx = size / 2;
+  const cy = size / 2;
+  const rng = seededRandom(`${questionId}_mycelium`);
+  const paths: string[] = [];
+  const count = 5;
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2 + 0.3;
+    const endR = size / 2 - 20;
+    const midR = endR * (0.35 + rng() * 0.3);
+    const midAngle = angle + (rng() - 0.5) * 0.6;
+    const mx = cx + Math.cos(midAngle) * midR;
+    const my = cy + Math.sin(midAngle) * midR;
+    const ex = cx + Math.cos(angle) * endR;
+    const ey = cy + Math.sin(angle) * endR;
+    paths.push(
+      `<path d="M${cx},${cy} C ${mx},${my} ${mx},${my} ${ex},${ey}" stroke-dasharray="4 4"/>`,
+    );
+  }
+  return paths.join('\n');
 }
 
 export function QuestionCircle({
+  questionId,
   questionText,
   detail,
   zoomed,
@@ -84,6 +91,9 @@ export function QuestionCircle({
   style,
 }: QuestionCircleProps) {
   const hasData = detail && detail.status === 'completed';
+  const size = 280;
+
+  const myceliumHtml = useMemo(() => generateMyceliumPaths(size, questionId), [questionId]);
 
   return (
     <div
@@ -97,169 +107,357 @@ export function QuestionCircle({
               if (e.key === 'Enter') onClick();
             }
       }
-      className={`absolute transition-all duration-[1200ms] ease-[cubic-bezier(0.19,1,0.22,1)] ${zoomed ? 'z-[55]' : 'z-[3] cursor-pointer'}`}
+      className={`absolute transition-all duration-[600ms] ${zoomed ? 'z-[55]' : 'z-[3] cursor-pointer'}`}
       style={{
         ...style,
-        width: zoomed ? 'min(50vw, 75vh, 500px)' : 'min(240px, 38vh)',
-        height: zoomed ? 'min(50vw, 75vh, 500px)' : 'min(240px, 38vh)',
-        ...(zoomed ? { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' } : {}),
+        width: zoomed ? 'min(50vw, 75vh, 500px)' : `${size}px`,
+        height: zoomed ? 'min(50vw, 75vh, 500px)' : `${size}px`,
+        transform: zoomed ? 'translate(-50%, -50%)' : 'translate(-50%, -50%)',
+        ...(zoomed ? { top: '50%', left: '50%' } : {}),
+        // @ts-expect-error: CSS custom property for element scaling
+        '--el-scale': zoomed ? '1.1' : '0.65',
       }}
     >
-      {/* Circle border */}
-      <svg aria-hidden="true" className="absolute inset-0 h-full w-full" viewBox="0 0 200 200">
-        <circle
-          cx="100"
-          cy="100"
-          r="90"
-          fill="none"
-          stroke="#d4a574"
-          strokeWidth="1.5"
-          opacity="0.6"
-        />
-        <circle
-          cx="100"
-          cy="100"
-          r="82"
-          fill="none"
-          stroke="#d4a574"
-          strokeWidth="0.5"
-          opacity="0.3"
-        />
-      </svg>
+      {/* Circle keyframes */}
+      <style>{`
+        @keyframes spin {
+          from { transform: translate(-50%, -50%) rotate(0deg); }
+          to { transform: translate(-50%, -50%) rotate(360deg); }
+        }
+      `}</style>
 
-      {/* Question text arc */}
-      <svg
-        aria-hidden="true"
-        className="absolute inset-[-20%] h-[140%] w-[140%]"
-        viewBox="0 0 280 280"
+      {/* Circle glow */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: '-10%',
+          borderRadius: '50%',
+          background: 'rgba(217,180,143,0.05)',
+          filter: 'blur(30px)',
+          animation: 'j2-pulse 4s cubic-bezier(0.4,0,0.6,1) infinite',
+        }}
+      />
+
+      {/* Rotating question text ring */}
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          width: '100%',
+          height: '100%',
+          animation: 'spin 120s linear infinite',
+          pointerEvents: 'none',
+        }}
       >
-        <defs>
+        <svg aria-hidden="true" viewBox={`0 0 ${size} ${size}`} className="h-full w-full">
           <path
-            id={`arc-${questionText.slice(0, 10)}`}
-            d="M 140 140 m -110 0 a 110 110 0 1 1 220 0 a 110 110 0 1 1 -220 0"
-            fill="none"
+            id={`ring-${questionId}`}
+            d={`M ${size / 2},${size / 2} m ${-(size / 2 - 12)},0 a ${size / 2 - 12},${size / 2 - 12} 0 1,1 ${size - 24},0 a ${size / 2 - 12},${size / 2 - 12} 0 1,1 ${-(size - 24)},0`}
+            fill="transparent"
           />
-        </defs>
-        <text
-          fill="#6b2c2c"
-          fontSize="13"
-          fontWeight="500"
-          letterSpacing="0.12em"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
-        >
-          <textPath href={`#arc-${questionText.slice(0, 10)}`} startOffset="5%">
-            {questionText}
-          </textPath>
-        </text>
-      </svg>
+          <text
+            style={{
+              fontFamily: "'Noto Serif JP', serif",
+              fontSize: '9px',
+              letterSpacing: '0.2em',
+              fill: '#7A3B3F',
+              opacity: 0.6,
+            }}
+          >
+            <textPath href={`#ring-${questionId}`} startOffset="0%">
+              {questionText} &bull;{' '}
+            </textPath>
+          </text>
+        </svg>
+      </div>
+
+      {/* Mycelium lines (counter-rotating) */}
+      <div
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          width: '100%',
+          height: '100%',
+          animation: 'spin 120s linear infinite reverse',
+          pointerEvents: 'none',
+        }}
+      >
+        <svg
+          viewBox={`0 0 ${size} ${size}`}
+          className="h-full w-full"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static generated SVG paths, no user input
+          dangerouslySetInnerHTML={{
+            __html: `<g stroke="rgba(226,194,142,0.6)" stroke-width="1.2" fill="none" stroke-linecap="round">${myceliumHtml}</g>`,
+          }}
+        />
+      </div>
 
       {/* Inner content */}
-      <div className="absolute inset-0 overflow-visible">
+      <div
+        className="absolute overflow-visible"
+        style={{
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '100%',
+          height: '100%',
+          borderRadius: '50%',
+          pointerEvents: zoomed ? 'auto' : 'none',
+        }}
+      >
         {hasData ? (
           <>
-            {/* Keywords with yeast icon */}
-            {detail.keywords.slice(0, 5).map((kw, i) => (
-              <div
-                key={kw.id}
-                onClick={(e) => {
-                  if (!zoomed) return;
-                  e.stopPropagation();
-                  onElementClick('keyword', { keyword: kw.keyword, description: kw.description });
-                }}
-                className={`absolute animate-[float_${3 + i * 0.5}s_ease-in-out_infinite] rounded-md bg-[#d4a574] px-2.5 py-1 text-[9px] font-medium text-white ${zoomed ? 'cursor-pointer transition-transform hover:scale-[1.15]' : ''}`}
-                style={{
-                  ...KEYWORD_POSITIONS[i],
-                  transform: `rotate(${KEYWORD_ROTATIONS[i]}deg)`,
-                  fontFamily: "'Noto Serif JP', serif",
-                  boxShadow: '0 4px 15px rgba(212,165,116,0.3)',
-                  animationDelay: `${i * 0.4}s`,
-                }}
-              >
-                <div className="relative">
-                  {kw.keyword}
-                  <YeastIcon />
+            {/* Keywords with attached microbe */}
+            {detail.keywords.slice(0, 5).map((kw, i) => {
+              const pos = KEYWORD_POSITIONS[i] ?? { top: 35 + i * 12, left: 20 + i * 15 };
+              const mType = MICROBE_TYPES[i % 3];
+              return (
+                <div
+                  key={kw.id}
+                  className={FLOAT_CLASSES[i % 3]}
+                  style={{
+                    position: 'absolute',
+                    top: `${pos.top}%`,
+                    left: `${pos.left}%`,
+                    transform: 'scale(var(--el-scale))',
+                    transition: 'transform 0.6s cubic-bezier(0.4, 0, 0.2, 1)',
+                  }}
+                >
+                  <div
+                    onClick={(e) => {
+                      if (!zoomed) return;
+                      e.stopPropagation();
+                      onElementClick('keyword', {
+                        keyword: kw.keyword,
+                        description: kw.description,
+                      });
+                    }}
+                    className={zoomed ? 'cursor-pointer' : ''}
+                    style={{
+                      position: 'relative',
+                      zIndex: 10,
+                      background: 'linear-gradient(135deg, #E8D1B5, #D9B48F)',
+                      color: 'var(--text)',
+                      fontFamily: "'Noto Serif JP', serif",
+                      fontSize: zoomed ? '13px' : '11px',
+                      letterSpacing: '0.15em',
+                      padding: zoomed ? '8px 20px' : '6px 16px',
+                      borderRadius: '999px',
+                      boxShadow: '0 4px 12px rgba(217,180,143,0.3)',
+                      border: '1px solid rgba(255,255,255,0.5)',
+                      whiteSpace: 'nowrap',
+                      transition: 'transform 0.5s',
+                    }}
+                  >
+                    {kw.keyword}
+                    <span
+                      className="pointer-events-none absolute -top-2.5 -right-3 block h-[18px] w-[18px] opacity-60"
+                      // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG
+                      dangerouslySetInnerHTML={{ __html: MICROBE_SVGS[mType] }}
+                    />
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
-            {/* Snippets with koji icon + rotation */}
-            {detail.snippets.slice(0, 3).map((s, i) => (
-              <div
-                key={s.id}
-                onClick={(e) => {
-                  if (!zoomed) return;
-                  e.stopPropagation();
-                  onElementClick('snippet', {
-                    originalText: s.originalText,
-                    sourceDate: s.sourceDate,
-                    selectionReason: s.selectionReason,
-                  });
-                }}
-                className={`absolute max-w-[140px] animate-[float_${3.5 + i * 0.6}s_ease-in-out_infinite] rounded-md border border-[rgba(139,115,85,0.15)] bg-white/80 px-2.5 py-2 text-[8px] leading-snug shadow-sm backdrop-blur-sm ${zoomed ? 'cursor-pointer transition-transform hover:scale-[1.15]' : ''}`}
-                style={{
-                  ...SNIPPET_POSITIONS[i],
-                  transform: `rotate(${SNIPPET_ROTATIONS[i]}deg)`,
-                  fontFamily: "'Noto Serif JP', serif",
-                  animationDelay: `${1 + i * 0.5}s`,
-                }}
-              >
-                <div className="relative">
-                  「{s.originalText.substring(0, 25)}...
-                  <KojiIcon />
+            {/* Snippets with attached microbe */}
+            {detail.snippets.slice(0, 3).map((s, i) => {
+              const pos = SNIPPET_POSITIONS[i] ?? { top: 40 + i * 18, left: 25 + i * 20 };
+              const mType = MICROBE_TYPES[(i + 1) % 3];
+              const displayText =
+                s.originalText.length > 60 ? `${s.originalText.substring(0, 60)}…` : s.originalText;
+              return (
+                <div
+                  key={s.id}
+                  className={FLOAT_CLASSES[(i + 1) % 3]}
+                  style={{
+                    position: 'absolute',
+                    top: `${pos.top}%`,
+                    left: `${pos.left}%`,
+                    transform: 'scale(var(--el-scale))',
+                    transition: 'transform 0.6s cubic-bezier(0.4, 0, 0.2, 1)',
+                  }}
+                >
+                  <div
+                    onClick={(e) => {
+                      if (!zoomed) return;
+                      e.stopPropagation();
+                      onElementClick('snippet', {
+                        originalText: s.originalText,
+                        sourceDate: s.sourceDate,
+                        selectionReason: s.selectionReason,
+                      });
+                    }}
+                    className={zoomed ? 'cursor-pointer' : ''}
+                    style={{
+                      position: 'relative',
+                      zIndex: 20,
+                      background: 'rgba(253,251,247,0.4)',
+                      backdropFilter: 'blur(12px)',
+                      WebkitBackdropFilter: 'blur(12px)',
+                      border: '1px solid rgba(255,255,255,0.6)',
+                      padding: '10px 12px',
+                      borderRadius: '12px',
+                      maxWidth: zoomed ? '200px' : '140px',
+                      boxShadow: '0 4px 16px rgba(140,133,126,0.08)',
+                      transition: 'all 0.3s',
+                    }}
+                  >
+                    <p
+                      style={{
+                        fontSize: zoomed ? '11px' : '9px',
+                        color: 'var(--text)',
+                        lineHeight: 1.6,
+                        fontFamily: "'Noto Sans JP', sans-serif",
+                        fontWeight: 500,
+                        opacity: 0.95,
+                        margin: 0,
+                      }}
+                    >
+                      「{displayText}
+                    </p>
+                    {/* Dot indicator */}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: '-6px',
+                        left: '24px',
+                        width: '6px',
+                        height: '6px',
+                        borderRadius: '50%',
+                        background: '#E2C28E',
+                        border: '1px solid white',
+                        boxShadow: '0 0 4px rgba(226,194,142,0.4)',
+                      }}
+                    />
+                    <span
+                      className="pointer-events-none absolute -bottom-2.5 -left-2 block h-[18px] w-[18px] opacity-60"
+                      // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG
+                      dangerouslySetInnerHTML={{ __html: MICROBE_SVGS[mType] }}
+                    />
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
-            {/* Letter with lab icon */}
+            {/* Letter with attached microbe */}
             {detail.letter && (
               <div
-                onClick={(e) => {
-                  if (!zoomed) return;
-                  e.stopPropagation();
-                  onElementClick('letter', { bodyText: detail.letter!.bodyText });
+                className="j2-float-2"
+                style={{
+                  position: 'absolute',
+                  top: `${LETTER_POSITION.top}%`,
+                  left: `${LETTER_POSITION.left}%`,
+                  transform: 'scale(var(--el-scale))',
+                  transition: 'transform 0.6s cubic-bezier(0.4, 0, 0.2, 1)',
                 }}
-                className={`absolute animate-[float_4s_ease-in-out_infinite] ${zoomed ? 'cursor-pointer transition-transform hover:scale-[1.15]' : ''}`}
-                style={{ ...LETTER_POSITION, transform: 'rotate(3deg)', animationDelay: '2s' }}
               >
-                <div className="relative">
-                  <LabIcon />
-                  <svg aria-hidden="true" width="56" height="46" viewBox="0 0 56 46" fill="none">
-                    <rect
-                      x="4"
-                      y="8"
-                      width="48"
-                      height="34"
-                      rx="3"
-                      fill="#faf5eb"
-                      stroke="#c9a96e"
-                      strokeWidth="1"
+                <div
+                  onClick={(e) => {
+                    if (!zoomed) return;
+                    e.stopPropagation();
+                    onElementClick('letter', { bodyText: detail.letter!.bodyText });
+                  }}
+                  className={zoomed ? 'cursor-pointer' : ''}
+                  style={{
+                    position: 'relative',
+                    zIndex: 20,
+                    width: '32px',
+                    height: '32px',
+                    borderRadius: '50%',
+                    background: 'linear-gradient(135deg, white, #FDFBF7)',
+                    boxShadow: '0 4px 12px rgba(140,133,126,0.15)',
+                    border: '1px solid rgba(140,133,126,0.2)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    transition: 'all 0.3s',
+                  }}
+                >
+                  <svg
+                    aria-hidden="true"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    style={{ color: '#7A3B3F' }}
+                  >
+                    <path
+                      d="M1 4L8 9L15 4"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
                     />
-                    <path d="M4 14l24 16 24-16" stroke="#c9a96e" strokeWidth="1" fill="none" />
-                    <circle cx="28" cy="34" r="5" fill="#d4758a" opacity="0.7" />
+                    <path
+                      d="M1 4V12H15V4"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M5 8L1 12"
+                      stroke="currentColor"
+                      strokeWidth="0.8"
+                      strokeLinecap="round"
+                      opacity="0.6"
+                    />
+                    <path
+                      d="M11 8L15 12"
+                      stroke="currentColor"
+                      strokeWidth="0.8"
+                      strokeLinecap="round"
+                      opacity="0.6"
+                    />
                   </svg>
+                  {/* Dot indicator */}
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: '-6px',
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      width: '6px',
+                      height: '6px',
+                      borderRadius: '50%',
+                      background: '#E2C28E',
+                      border: '1px solid white',
+                    }}
+                  />
+                  <span
+                    className="pointer-events-none absolute -top-2.5 -right-3 block h-[18px] w-[18px] opacity-60"
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG
+                    dangerouslySetInnerHTML={{ __html: MICROBE_SVGS.lab }}
+                  />
                 </div>
               </div>
             )}
           </>
         ) : (
-          /* Empty state: microbe placeholders */
-          <div className="flex h-full items-center justify-center">
-            <div className="flex gap-4 opacity-40">
-              <svg aria-hidden="true" width="24" height="24" viewBox="0 0 20 20">
-                <ellipse cx="10" cy="12" rx="6" ry="5" fill="#d4a050" />
-                <ellipse cx="14" cy="7" rx="3.5" ry="3" fill="#d4a050" opacity="0.6" />
-              </svg>
-              <svg aria-hidden="true" width="24" height="24" viewBox="0 0 20 20">
-                <line x1="10" y1="18" x2="10" y2="6" stroke="#8b5cf6" strokeWidth="1.5" />
-                <circle cx="7" cy="5" r="2" fill="#8b5cf6" />
-                <circle cx="13" cy="7" r="1.5" fill="#8b5cf6" opacity="0.7" />
-              </svg>
-              <svg aria-hidden="true" width="24" height="24" viewBox="0 0 16 16">
-                <ellipse cx="8" cy="8" rx="4" ry="3" fill="#059669" />
-                <ellipse cx="5" cy="6" rx="2.5" ry="2" fill="#059669" opacity="0.6" />
-              </svg>
-            </div>
-          </div>
+          /* Empty state: floating microbes */
+          EMPTY_MICROBE_POSITIONS.map((p, i) => {
+            const type = MICROBE_TYPES[i % 3];
+            return (
+              <div
+                key={`empty-${type}-${p.top}-${p.left}`}
+                className={`j2-float-${(i % 3) + 1}`}
+                style={{
+                  position: 'absolute',
+                  top: `${p.top}%`,
+                  left: `${p.left}%`,
+                  width: `${p.size}px`,
+                  height: `${p.size}px`,
+                  opacity: 0.45,
+                  pointerEvents: 'none',
+                }}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG
+                dangerouslySetInnerHTML={{ __html: MICROBE_SVGS[type] }}
+              />
+            );
+          })
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Jar画面をデザイン原案（jar-view2）に忠実に再実装。ガラス効果のSVGボトル、テキストパーティクル、微生物アイコン、回転テキストリング、菌糸ネットワークを移植
- jar2を廃止しjarに統合。サイドバーからjar2リンクを削除
- 問いの追加・編集・アーカイブモーダルをjar画面に実装
- グローバルフッター（PageFooter）を追加し、レイアウトを整理

## Test plan
- [ ] `/jar` でガラス効果の瓶が表示されること
- [ ] 瓶内にテキストパーティクルと微生物が浮遊していること
- [ ] 円形要素に回転テキストリングと菌糸ネットワークが表示されること
- [ ] 「＋ 問いを追加する」で問いが追加できること
- [ ] 下部の問いタグクリックで編集モーダル（更新・アーカイブ・キャンセル）が開くこと
- [ ] サイドバーにjar2リンクが表示されないこと
- [ ] フッターに左右とも現在のモードラベルが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)