### PR TITLE
fix: resolve fermentation trigger 404 by transpiling server from source

### DIFF
--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@oryzae/shared'],
+  transpilePackages: ['@oryzae/shared', '@oryzae/server'],
   turbopack: {},
 };
 


### PR DESCRIPTION
## Summary
- エントリー保存時に `POST /api/v1/fermentations` が 404 を返し、発酵分析が発火しない問題を修正
- 原因: Next.js が `@oryzae/server` の `dist/app.js`（古いビルド）を使用しており、fermentations ルートが含まれていなかった
- 修正: `next.config.ts` の `transpilePackages` に `@oryzae/server` を追加し、常にソースから直接トランスパイルするように変更。これにより `dist/` の手動ビルドが不要になる

## Test plan
- [ ] エントリーを新規保存し、サーバーログに `POST /api/v1/fermentations 201` が出ること
- [ ] 既存エントリーを更新保存しても同様に発酵がトリガーされること
- [ ] 他のAPIエンドポイント（entries, questions）が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)