### PR TITLE
fix: strip formatting on paste in entry editor

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -328,6 +328,12 @@ export function EntryEditor({
             setContent(text);
             if (status === 'saved') setStatus('editing');
           }}
+          onPaste={(e) => {
+            e.preventDefault();
+            const text = e.clipboardData.getData('text/plain');
+            if (!text) return;
+            document.execCommand('insertText', false, text);
+          }}
           data-placeholder="今日のことを書いてみましょう..."
           className="min-h-full whitespace-pre-wrap bg-transparent px-6 py-6 leading-relaxed focus:outline-none empty:before:text-zinc-400 empty:before:content-[attr(data-placeholder)]"
           style={{


### PR DESCRIPTION
## Summary
- エディタにリッチテキストをペーストした際、HTMLスタイルが持ち込まれる問題を修正
- `onPaste` ハンドラで `e.preventDefault()` + `text/plain` のみ挿入

## Test plan
- [ ] Webページからテキストをコピーしてエディタにペーストし、スタイルが除去されること
- [ ] Word/Google Docsからのペーストでも同様にプレーンテキストのみ挿入されること
- [ ] 通常のテキスト入力に影響がないこと

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)