### PR TITLE
feat: add timestamps to fermentation-related tables

### DIFF
--- a/apps/server/src/contexts/fermentation/domain/models/analysis-worksheet.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/analysis-worksheet.ts
@@ -4,6 +4,7 @@ interface AnalysisWorksheetProps {
   worksheetMarkdown: string;
   resultDiagramMarkdown: string;
   createdAt: string;
+  updatedAt: string;
 }
 
 export class AnalysisWorksheet {
@@ -12,6 +13,7 @@ export class AnalysisWorksheet {
   readonly worksheetMarkdown: string;
   readonly resultDiagramMarkdown: string;
   readonly createdAt: string;
+  readonly updatedAt: string;
 
   private constructor(props: AnalysisWorksheetProps) {
     this.id = props.id;
@@ -19,6 +21,7 @@ export class AnalysisWorksheet {
     this.worksheetMarkdown = props.worksheetMarkdown;
     this.resultDiagramMarkdown = props.resultDiagramMarkdown;
     this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 
   static create(
@@ -33,6 +36,7 @@ export class AnalysisWorksheet {
       worksheetMarkdown,
       resultDiagramMarkdown,
       createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     });
   }
 
@@ -47,6 +51,7 @@ export class AnalysisWorksheet {
       worksheetMarkdown: this.worksheetMarkdown,
       resultDiagramMarkdown: this.resultDiagramMarkdown,
       createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
 }

--- a/apps/server/src/contexts/fermentation/domain/models/extracted-snippet.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/extracted-snippet.ts
@@ -11,6 +11,8 @@ interface ExtractedSnippetProps {
   originalText: string;
   sourceDate: string;
   selectionReason: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 const VALID_TYPES: SnippetType[] = ['new_perspective', 'deepen', 'core'];
@@ -22,6 +24,8 @@ export class ExtractedSnippet {
   readonly originalText: string;
   readonly sourceDate: string;
   readonly selectionReason: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
 
   private constructor(props: ExtractedSnippetProps) {
     this.id = props.id;
@@ -30,16 +34,21 @@ export class ExtractedSnippet {
     this.originalText = props.originalText;
     this.sourceDate = props.sourceDate;
     this.selectionReason = props.selectionReason;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 
   static create(
-    params: Omit<ExtractedSnippetProps, 'id'>,
+    params: Omit<ExtractedSnippetProps, 'id' | 'createdAt' | 'updatedAt'>,
     generateId: () => string,
   ): Result<ExtractedSnippet, SnippetError> {
     if (!VALID_TYPES.includes(params.snippetType)) {
       return err({ type: 'INVALID_SNIPPET_TYPE', message: `Invalid type: ${params.snippetType}` });
     }
-    return ok(new ExtractedSnippet({ id: generateId(), ...params }));
+    const now = new Date().toISOString();
+    return ok(
+      new ExtractedSnippet({ id: generateId(), ...params, createdAt: now, updatedAt: now }),
+    );
   }
 
   static fromProps(props: ExtractedSnippetProps): ExtractedSnippet {
@@ -54,6 +63,8 @@ export class ExtractedSnippet {
       originalText: this.originalText,
       sourceDate: this.sourceDate,
       selectionReason: this.selectionReason,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
 }

--- a/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
@@ -12,6 +12,7 @@ export interface FermentationResultProps {
   targetPeriod: string;
   status: FermentationStatus;
   createdAt: string;
+  updatedAt: string;
 }
 
 interface CreateParams {
@@ -31,6 +32,7 @@ export class FermentationResult {
   readonly targetPeriod: string;
   readonly status: FermentationStatus;
   readonly createdAt: string;
+  readonly updatedAt: string;
 
   private constructor(props: FermentationResultProps) {
     this.id = props.id;
@@ -40,6 +42,7 @@ export class FermentationResult {
     this.targetPeriod = props.targetPeriod;
     this.status = props.status;
     this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 
   static create(
@@ -58,6 +61,7 @@ export class FermentationResult {
         targetPeriod: params.targetPeriod,
         status: 'pending',
         createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       }),
     );
   }
@@ -82,6 +86,7 @@ export class FermentationResult {
       targetPeriod: this.targetPeriod,
       status: this.status,
       createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
 }

--- a/apps/server/src/contexts/fermentation/domain/models/keyword.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/keyword.ts
@@ -3,6 +3,8 @@ interface KeywordProps {
   fermentationResultId: string;
   keyword: string;
   description: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export class Keyword {
@@ -10,12 +12,16 @@ export class Keyword {
   readonly fermentationResultId: string;
   readonly keyword: string;
   readonly description: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
 
   private constructor(props: KeywordProps) {
     this.id = props.id;
     this.fermentationResultId = props.fermentationResultId;
     this.keyword = props.keyword;
     this.description = props.description;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 
   static create(
@@ -24,7 +30,15 @@ export class Keyword {
     description: string,
     generateId: () => string,
   ): Keyword {
-    return new Keyword({ id: generateId(), fermentationResultId, keyword, description });
+    const now = new Date().toISOString();
+    return new Keyword({
+      id: generateId(),
+      fermentationResultId,
+      keyword,
+      description,
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   static fromProps(props: KeywordProps): Keyword {
@@ -37,6 +51,8 @@ export class Keyword {
       fermentationResultId: this.fermentationResultId,
       keyword: this.keyword,
       description: this.description,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
 }

--- a/apps/server/src/contexts/fermentation/domain/models/letter.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/letter.ts
@@ -2,21 +2,34 @@ interface LetterProps {
   id: string;
   fermentationResultId: string;
   bodyText: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export class Letter {
   readonly id: string;
   readonly fermentationResultId: string;
   readonly bodyText: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
 
   private constructor(props: LetterProps) {
     this.id = props.id;
     this.fermentationResultId = props.fermentationResultId;
     this.bodyText = props.bodyText;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 
   static create(fermentationResultId: string, bodyText: string, generateId: () => string): Letter {
-    return new Letter({ id: generateId(), fermentationResultId, bodyText });
+    const now = new Date().toISOString();
+    return new Letter({
+      id: generateId(),
+      fermentationResultId,
+      bodyText,
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   static fromProps(props: LetterProps): Letter {
@@ -28,6 +41,8 @@ export class Letter {
       id: this.id,
       fermentationResultId: this.fermentationResultId,
       bodyText: this.bodyText,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
     };
   }
 }

--- a/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
@@ -22,6 +22,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       target_period: props.targetPeriod,
       status: props.status,
       created_at: props.createdAt,
+      updated_at: props.updatedAt,
     });
     if (error) throw new Error(`Failed to save fermentation result: ${error.message}`);
   }
@@ -30,7 +31,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
     const props = result.toProps();
     const { error } = await this.supabase
       .from('fermentation_results')
-      .update({ status: props.status })
+      .update({ status: props.status, updated_at: new Date().toISOString() })
       .eq('id', props.id);
     if (error) throw new Error(`Failed to update fermentation result: ${error.message}`);
   }
@@ -50,6 +51,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       targetPeriod: data.target_period,
       status: data.status,
       createdAt: data.created_at,
+      updatedAt: data.updated_at,
     });
   }
 
@@ -75,6 +77,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
           worksheetMarkdown: worksheetRes.data.worksheet_markdown,
           resultDiagramMarkdown: worksheetRes.data.result_diagram_markdown,
           createdAt: worksheetRes.data.created_at,
+          updatedAt: worksheetRes.data.updated_at,
         })
       : null;
 
@@ -86,6 +89,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         originalText: row.original_text,
         sourceDate: row.source_date,
         selectionReason: row.selection_reason,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
       }),
     );
 
@@ -94,6 +99,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
           id: letterRes.data.id,
           fermentationResultId: letterRes.data.fermentation_result_id,
           bodyText: letterRes.data.body_text,
+          createdAt: letterRes.data.created_at,
+          updatedAt: letterRes.data.updated_at,
         })
       : null;
 
@@ -103,6 +110,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         fermentationResultId: row.fermentation_result_id,
         keyword: row.keyword,
         description: row.description,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
       }),
     );
 
@@ -125,6 +134,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         targetPeriod: row.target_period,
         status: row.status as 'pending' | 'processing' | 'completed' | 'failed',
         createdAt: row.created_at,
+        updatedAt: row.updated_at,
       }),
     );
   }
@@ -137,6 +147,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       worksheet_markdown: props.worksheetMarkdown,
       result_diagram_markdown: props.resultDiagramMarkdown,
       created_at: props.createdAt,
+      updated_at: props.updatedAt,
     });
     if (error) throw new Error(`Failed to save worksheet: ${error.message}`);
   }
@@ -152,6 +163,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         original_text: p.originalText,
         source_date: p.sourceDate,
         selection_reason: p.selectionReason,
+        created_at: p.createdAt,
+        updated_at: p.updatedAt,
       };
     });
     const { error } = await this.supabase.from('extracted_snippets').insert(rows);
@@ -164,6 +177,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       id: props.id,
       fermentation_result_id: props.fermentationResultId,
       body_text: props.bodyText,
+      created_at: props.createdAt,
+      updated_at: props.updatedAt,
     });
     if (error) throw new Error(`Failed to save letter: ${error.message}`);
   }
@@ -177,6 +192,8 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         fermentation_result_id: p.fermentationResultId,
         keyword: p.keyword,
         description: p.description,
+        created_at: p.createdAt,
+        updated_at: p.updatedAt,
       };
     });
     const { error } = await this.supabase.from('keywords').insert(rows);

--- a/supabase/migrations/00004_add_timestamps_to_fermentation_tables.sql
+++ b/supabase/migrations/00004_add_timestamps_to_fermentation_tables.sql
@@ -1,0 +1,51 @@
+-- Add updated_at to fermentation_results (already has created_at)
+alter table fermentation_results
+  add column updated_at timestamptz not null default now();
+
+-- Add updated_at to analysis_worksheets (already has created_at)
+alter table analysis_worksheets
+  add column updated_at timestamptz not null default now();
+
+-- Add created_at and updated_at to extracted_snippets
+alter table extracted_snippets
+  add column created_at timestamptz not null default now(),
+  add column updated_at timestamptz not null default now();
+
+-- Add created_at and updated_at to letters
+alter table letters
+  add column created_at timestamptz not null default now(),
+  add column updated_at timestamptz not null default now();
+
+-- Add created_at and updated_at to keywords
+alter table keywords
+  add column created_at timestamptz not null default now(),
+  add column updated_at timestamptz not null default now();
+
+-- Auto-update updated_at on row modification
+create or replace function update_updated_at_column()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_fermentation_results_updated_at
+  before update on fermentation_results
+  for each row execute function update_updated_at_column();
+
+create trigger trg_analysis_worksheets_updated_at
+  before update on analysis_worksheets
+  for each row execute function update_updated_at_column();
+
+create trigger trg_extracted_snippets_updated_at
+  before update on extracted_snippets
+  for each row execute function update_updated_at_column();
+
+create trigger trg_letters_updated_at
+  before update on letters
+  for each row execute function update_updated_at_column();
+
+create trigger trg_keywords_updated_at
+  before update on keywords
+  for each row execute function update_updated_at_column();


### PR DESCRIPTION
## Summary
- `extracted_snippets`, `letters`, `keywords` に `created_at`/`updated_at` カラムを追加
- `fermentation_results`, `analysis_worksheets` に不足していた `updated_at` カラムを追加
- 全テーブルに `updated_at` 自動更新トリガーを設定
- ドメインモデルとリポジトリのマッピングを更新

Closes #63

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — 既存の warning のみ（新規なし）
- [x] `pnpm test` — 全91+19テスト通過
- [x] `pnpm dep-cruise` — 違反なし
- [x] `pnpm knip` — 新規デッドコードなし
- [x] Supabase にマイグレーション適用後、発酵分析を実行し、全テーブルに `created_at`/`updated_at` が正しく記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)