### PR TITLE
feat: add Board view for spatial card arrangement

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "supabase/**"
+  - "apps/server/src/**/infrastructure/**"
+  - "apps/server/src/**/domain/models/**"
+---
+
+# データベースマイグレーションルール
+
+## 絶対ルール: マイグレーションファイルの生成
+
+DB スキーマを変更する場合（テーブル作成・カラム追加・インデックス・トリガー・RLS ポリシー等）、**必ず `supabase/migrations/` にマイグレーション SQL ファイルを生成すること**。
+
+### 手順
+
+1. **マイグレーションファイルを作成**: `supabase/migrations/NNNNN_<名前>.sql` に SQL を記述
+   - 連番は既存ファイルの最大番号 + 1（例: `00005_create_board.sql`）
+2. **Supabase MCP でリモート DB に適用**: `mcp__supabase__apply_migration` で本番/ステージング DB にも適用
+3. **マイグレーションファイルをコミット**: git にファイルを含めること
+
+### 禁止事項
+
+- **Supabase MCP だけで migration を実行してリポジトリにファイルを残さないこと** — これをやるとリポジトリが DB の実態と乖離し、他の開発者やCI/CDが再現できなくなる
+- **手動で Supabase Dashboard から DDL を実行すること** — 同様の理由
+
+### マイグレーションファイルの命名
+
+```
+supabase/migrations/NNNNN_<動詞>_<対象>.sql
+```
+
+例:
+- `00001_create_entries.sql`
+- `00004_add_timestamps_to_fermentation_tables.sql`
+- `00005_create_board.sql`
+
+### マイグレーションの内容に含めるもの
+
+- テーブル定義 (`CREATE TABLE`)
+- インデックス (`CREATE INDEX`)
+- RLS ポリシー (`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + `CREATE POLICY`)
+- トリガー・関数 (`CREATE FUNCTION` + `CREATE TRIGGER`)
+- 必要に応じてデータ移行

--- a/apps/client/e2e/board.spec.ts
+++ b/apps/client/e2e/board.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from './fixtures/auth';
+
+test.describe('ボード画面', () => {
+  test.beforeEach(async ({ authenticated, page }) => {
+    await page.goto('/board');
+    await page.waitForSelector('[role="application"]');
+  });
+
+  test('ボード画面が表示される', async ({ page }) => {
+    await expect(page.locator('text=Daily')).toBeVisible();
+    await expect(page.locator('button:has-text("Snippet")')).toBeVisible();
+  });
+
+  test('日付ナビゲーションで前日/翌日に切り替えできる', async ({ page }) => {
+    const dateText = page.locator('[class*="tracking"]').first();
+    const initialDate = await dateText.textContent();
+
+    await page.click('button:has-text("‹")');
+    await page.waitForTimeout(500);
+    const prevDate = await dateText.textContent();
+    expect(prevDate).not.toBe(initialDate);
+
+    await page.click('button:has-text("›")');
+    await page.waitForTimeout(500);
+    const nextDate = await dateText.textContent();
+    expect(nextDate).toBe(initialDate);
+  });
+
+  test('スニペットを作成できる', async ({ page }) => {
+    await page.click('button:has-text("Snippet")');
+    await expect(page.locator('text=New Snippet')).toBeVisible();
+
+    await page.fill('input[placeholder*="スニペット"]', 'E2Eテストスニペット');
+    await page.click('button:has-text("Add")');
+
+    await page.waitForTimeout(1000);
+    await expect(page.locator('text=E2Eテストスニペット')).toBeVisible();
+  });
+
+  test('エントリカードが表示される（当日エントリがある場合）', async ({ page }) => {
+    // まずエントリを作成
+    await page.goto('/entries/new');
+    const editor = page.locator('[contenteditable="true"]');
+    await editor.click();
+    await editor.pressSequentially('ボードE2Eテスト用エントリ');
+    await page.click('button:has-text("保存")');
+    await page.waitForTimeout(2000);
+
+    // ボードに移動してカードを確認
+    await page.goto('/board');
+    await page.waitForTimeout(2000);
+    await expect(page.locator('text=ボードE2Eテスト用エントリ')).toBeVisible();
+  });
+});

--- a/apps/client/e2e/board.spec.ts
+++ b/apps/client/e2e/board.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from './fixtures/auth';
 
 test.describe('ボード画面', () => {
-  test.beforeEach(async ({ authenticated, page }) => {
+  test.beforeEach(async ({ authenticated: _, page }) => {
     await page.goto('/board');
     await page.waitForSelector('[role="application"]');
   });

--- a/apps/client/src/app/(protected)/board/page.tsx
+++ b/apps/client/src/app/(protected)/board/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useAuth } from '@/features/auth/hooks/use-auth';
+import { BoardView } from '@/features/board/components/board-view';
+
+export default function BoardPage() {
+  const { api, loading: authLoading } = useAuth();
+
+  if (authLoading || !api) {
+    return (
+      <div
+        className="flex h-full items-center justify-center text-xs"
+        style={{ color: 'var(--date-color)' }}
+      >
+        Loading...
+      </div>
+    );
+  }
+
+  return <BoardView api={api} />;
+}

--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -75,29 +75,32 @@ body {
   bottom: auto;
 }
 
-/* Board card animations */
+/* Board card animations — uses scale() instead of transform to avoid
+   overriding the inline rotate() on cards */
 @keyframes popIn {
   0% {
-    transform: scale(0.8) translateY(20px);
+    scale: 0.8;
+    translate: 0 20px;
     opacity: 0;
   }
   100% {
-    transform: scale(1) translateY(0);
+    scale: 1;
+    translate: 0 0;
     opacity: 1;
   }
 }
 
 @keyframes itemRemove {
   0% {
+    scale: 1;
     opacity: 1;
-    transform: scale(1);
   }
   40% {
+    scale: 1.06;
     opacity: 0.6;
-    transform: scale(1.06);
   }
   100% {
+    scale: 0.7;
     opacity: 0;
-    transform: scale(0.7);
   }
 }

--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -77,12 +77,27 @@ body {
 
 /* Board card animations */
 @keyframes popIn {
-  0% { transform: scale(0.8) translateY(20px); opacity: 0; }
-  100% { transform: scale(1) translateY(0); opacity: 1; }
+  0% {
+    transform: scale(0.8) translateY(20px);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) translateY(0);
+    opacity: 1;
+  }
 }
 
 @keyframes itemRemove {
-  0%   { opacity: 1; transform: scale(1); }
-  40%  { opacity: 0.6; transform: scale(1.06); }
-  100% { opacity: 0; transform: scale(0.7); }
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  40% {
+    opacity: 0.6;
+    transform: scale(1.06);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.7);
+  }
 }

--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -8,6 +8,7 @@
   --border-subtle: rgba(0, 0, 0, 0.05);
   --toolbar-hover: rgba(0, 0, 0, 0.04);
   --date-color: #999;
+  --card-snippet: #fffbe0;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -19,6 +20,7 @@
     --border-subtle: rgba(255, 255, 255, 0.06);
     --toolbar-hover: rgba(255, 255, 255, 0.06);
     --date-color: #666;
+    --card-snippet: #3a3520;
   }
 }
 
@@ -71,4 +73,16 @@ body {
 [data-tooltip-pos="bottom"]::after {
   top: calc(100% + 6px);
   bottom: auto;
+}
+
+/* Board card animations */
+@keyframes popIn {
+  0% { transform: scale(0.8) translateY(20px); opacity: 0; }
+  100% { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+@keyframes itemRemove {
+  0%   { opacity: 1; transform: scale(1); }
+  40%  { opacity: 0.6; transform: scale(1.06); }
+  100% { opacity: 0; transform: scale(0.7); }
 }

--- a/apps/client/src/components/ui/page-footer.tsx
+++ b/apps/client/src/components/ui/page-footer.tsx
@@ -8,6 +8,7 @@ interface FooterEntry {
 }
 
 const FOOTER_ENTRIES: FooterEntry[] = [
+  { match: (p) => p === '/board', label: 'BOARD' },
   { match: (p) => p === '/jar', label: 'FERMENTING' },
   { match: (p) => p === '/entries/new' || p.startsWith('/entries/'), label: 'EDITOR' },
   { match: (p) => p === '/entries', label: 'LIST' },

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -14,6 +14,13 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   {
+    href: '/board',
+    label: 'Board',
+    match: '/board',
+    iconPath:
+      'M4 5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5ZM14 5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1V5ZM4 15a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-4ZM14 15a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-4a1 1 0 0 1-1-1v-4Z',
+  },
+  {
     href: '/jar',
     label: 'Jar',
     match: '/jar',

--- a/apps/client/src/features/board/components/board-card.tsx
+++ b/apps/client/src/features/board/components/board-card.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import type { BoardCardData } from '../hooks/use-board';
+import { EntryCardContent } from './entry-card-content';
+import { SnippetCardContent } from './snippet-card-content';
+
+interface BoardCardProps {
+  card: BoardCardData;
+  isSelected: boolean;
+  onPointerDown: (cardId: string, x: number, y: number) => void;
+  onRotateStart: (cardId: string, centerX: number, centerY: number) => void;
+  onResizeStart: (cardId: string, corner: 'se' | 'sw' | 'ne' | 'nw', x: number, y: number) => void;
+  onDelete: (cardId: string) => void;
+  onClick: (card: BoardCardData) => void;
+}
+
+function isEntryContent(
+  content: BoardCardData['content'],
+): content is { title: string; preview: string; createdAt: string } {
+  return 'title' in content;
+}
+
+function isSnippetContent(content: BoardCardData['content']): content is { text: string } {
+  return 'text' in content;
+}
+
+export function BoardCard({
+  card,
+  isSelected,
+  onPointerDown,
+  onRotateStart,
+  onResizeStart,
+  onDelete,
+  onClick,
+}: BoardCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.stopPropagation();
+      onPointerDown(card.id, e.clientX, e.clientY);
+    },
+    [card.id, onPointerDown],
+  );
+
+  const handleRotateDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.stopPropagation();
+      if (!cardRef.current) return;
+      const rect = cardRef.current.getBoundingClientRect();
+      onRotateStart(card.id, rect.left + rect.width / 2, rect.top + rect.height / 2);
+    },
+    [card.id, onRotateStart],
+  );
+
+  const handleResizeDown = useCallback(
+    (corner: 'se' | 'sw' | 'ne' | 'nw') => (e: React.PointerEvent) => {
+      e.stopPropagation();
+      onResizeStart(card.id, corner, e.clientX, e.clientY);
+    },
+    [card.id, onResizeStart],
+  );
+
+  return (
+    <div
+      ref={cardRef}
+      data-card-id={card.id}
+      className="board-card"
+      style={{
+        position: 'absolute',
+        left: card.x,
+        top: card.y,
+        width: card.width,
+        height: card.height,
+        transform: `rotate(${card.rotation}deg)`,
+        zIndex: card.zIndex,
+        cursor: 'grab',
+        borderRadius: 2,
+        backgroundColor: 'var(--bg)',
+        border: '1px solid var(--border-subtle)',
+        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -1px rgba(0,0,0,0.04)',
+        outline: isSelected ? '1.5px solid var(--accent)' : 'none',
+        outlineOffset: isSelected ? 4 : 0,
+        overflow: 'hidden',
+        userSelect: 'none',
+        touchAction: 'none',
+      }}
+      onPointerDown={handlePointerDown}
+    >
+      {/* Invisible click target */}
+      <button
+        type="button"
+        aria-label={card.cardType === 'entry' ? 'Open entry' : 'Edit snippet'}
+        className="absolute inset-0 z-[1] cursor-grab bg-transparent"
+        style={{ border: 'none', outline: 'none' }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick(card);
+        }}
+      />
+      {card.cardType === 'entry' && isEntryContent(card.content) && (
+        <EntryCardContent content={card.content} />
+      )}
+      {card.cardType === 'snippet' && isSnippetContent(card.content) && (
+        <SnippetCardContent content={card.content} />
+      )}
+
+      {/* Handles - visible only when selected */}
+      {isSelected && (
+        <>
+          {/* Delete button */}
+          <button
+            type="button"
+            aria-label="Delete card"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(card.id);
+            }}
+            className="absolute flex items-center justify-center rounded-full"
+            style={{
+              top: -8,
+              right: -8,
+              width: 22,
+              height: 22,
+              backgroundColor: 'var(--bg)',
+              border: '1.5px solid rgba(200,80,80,0.5)',
+              cursor: 'pointer',
+              zIndex: 10,
+            }}
+          >
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              stroke="rgba(200,80,80,0.7)"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
+              <line x1="2" y1="2" x2="8" y2="8" />
+              <line x1="8" y1="2" x2="2" y2="8" />
+            </svg>
+          </button>
+
+          {/* Rotate handle */}
+          <div
+            role="slider"
+            tabIndex={0}
+            aria-label="Rotate card"
+            aria-valuemin={-180}
+            aria-valuemax={180}
+            aria-valuenow={card.rotation}
+            onPointerDown={handleRotateDown}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="absolute left-1/2 flex items-center justify-center rounded-full"
+            style={{
+              bottom: -32,
+              transform: 'translateX(-50%)',
+              width: 24,
+              height: 24,
+              backgroundColor: 'var(--bg)',
+              border: '1.5px solid var(--accent)',
+              opacity: 0.8,
+              cursor: 'crosshair',
+              zIndex: 10,
+            }}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="var(--accent)"
+              strokeWidth="1.2"
+              aria-hidden="true"
+            >
+              <path d="M9 3a4.5 4.5 0 1 0 .5 4.5M9 1v3h-3" />
+            </svg>
+          </div>
+
+          {/* Resize handles */}
+          {(['se', 'sw', 'ne', 'nw'] as const).map((corner) => {
+            const style: React.CSSProperties = {
+              position: 'absolute',
+              width: 10,
+              height: 10,
+              backgroundColor: 'var(--bg)',
+              border: '1px solid var(--accent)',
+              zIndex: 10,
+            };
+            if (corner.includes('s')) style.bottom = -6;
+            if (corner.includes('n')) style.top = -6;
+            if (corner.includes('e')) style.right = -6;
+            if (corner.includes('w')) style.left = -6;
+            style.cursor = `${corner}-resize`;
+
+            return <div key={corner} onPointerDown={handleResizeDown(corner)} style={style} />;
+          })}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/board-card.tsx
+++ b/apps/client/src/features/board/components/board-card.tsx
@@ -77,14 +77,15 @@ export function BoardCard({
         zIndex: card.zIndex,
         cursor: 'grab',
         borderRadius: 2,
-        backgroundColor: 'var(--bg)',
+        backgroundColor: card.cardType === 'snippet' ? 'var(--card-snippet, #FFFBE0)' : 'var(--bg)',
         border: '1px solid var(--border-subtle)',
-        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -1px rgba(0,0,0,0.04)',
-        outline: isSelected ? '1.5px solid var(--accent)' : 'none',
+        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -2px rgba(0,0,0,0.03)',
+        outline: isSelected ? '1.5px solid rgba(74,158,142,0.5)' : 'none',
         outlineOffset: isSelected ? 4 : 0,
         overflow: 'hidden',
         userSelect: 'none',
         touchAction: 'none',
+        animation: 'popIn 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
       }}
       onPointerDown={handlePointerDown}
     >

--- a/apps/client/src/features/board/components/board-controls.tsx
+++ b/apps/client/src/features/board/components/board-controls.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+interface BoardControlsProps {
+  onAddSnippet: () => void;
+}
+
+export function BoardControls({ onAddSnippet }: BoardControlsProps) {
+  return (
+    <div
+      className="absolute right-6 top-5 z-10 flex items-center gap-2"
+      style={{ fontFamily: 'Inter, sans-serif' }}
+    >
+      <span
+        className="rounded px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider"
+        style={{
+          backgroundColor: 'var(--accent)',
+          color: '#fff',
+        }}
+      >
+        Daily
+      </span>
+      <button
+        type="button"
+        onClick={onAddSnippet}
+        className="flex items-center gap-1.5 rounded border px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider transition-colors hover:bg-[var(--toolbar-hover)]"
+        style={{
+          borderColor: 'var(--border-subtle)',
+          color: 'var(--date-color)',
+          fontFamily: 'Inter, sans-serif',
+        }}
+      >
+        ✦ Snippet
+      </button>
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/board-date-nav.tsx
+++ b/apps/client/src/features/board/components/board-date-nav.tsx
@@ -14,7 +14,10 @@ function formatDate(dateKey: string): string {
 function shiftDate(dateKey: string, offset: number): string {
   const d = new Date(`${dateKey}T00:00:00`);
   d.setDate(d.getDate() + offset);
-  return d.toISOString().split('T')[0];
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 export function BoardDateNav({ dateKey, onDateChange }: BoardDateNavProps) {

--- a/apps/client/src/features/board/components/board-date-nav.tsx
+++ b/apps/client/src/features/board/components/board-date-nav.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+interface BoardDateNavProps {
+  dateKey: string;
+  onDateChange: (dateKey: string) => void;
+}
+
+function formatDate(dateKey: string): string {
+  const d = new Date(`${dateKey}T00:00:00`);
+  const days = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'];
+  return `${dateKey.replace(/-/g, '.')} — ${days[d.getDay()]}`;
+}
+
+function shiftDate(dateKey: string, offset: number): string {
+  const d = new Date(`${dateKey}T00:00:00`);
+  d.setDate(d.getDate() + offset);
+  return d.toISOString().split('T')[0];
+}
+
+export function BoardDateNav({ dateKey, onDateChange }: BoardDateNavProps) {
+  return (
+    <div
+      className="absolute left-6 top-5 z-10 flex items-center gap-3"
+      style={{ fontFamily: 'Inter, sans-serif' }}
+    >
+      <button
+        type="button"
+        onClick={() => onDateChange(shiftDate(dateKey, -1))}
+        className="flex h-6 w-6 items-center justify-center rounded text-sm transition-colors"
+        style={{ color: 'var(--date-color)' }}
+      >
+        ‹
+      </button>
+      <span
+        className="text-[10px] font-medium uppercase tracking-wider"
+        style={{ color: 'var(--date-color)' }}
+      >
+        {formatDate(dateKey)}
+      </span>
+      <button
+        type="button"
+        onClick={() => onDateChange(shiftDate(dateKey, 1))}
+        className="flex h-6 w-6 items-center justify-center rounded text-sm transition-colors"
+        style={{ color: 'var(--date-color)' }}
+      >
+        ›
+      </button>
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/board-view.tsx
+++ b/apps/client/src/features/board/components/board-view.tsx
@@ -17,7 +17,11 @@ interface BoardViewProps {
 }
 
 function todayKey(): string {
-  return new Date().toISOString().split('T')[0];
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 export function BoardView({ api }: BoardViewProps) {

--- a/apps/client/src/features/board/components/board-view.tsx
+++ b/apps/client/src/features/board/components/board-view.tsx
@@ -66,9 +66,8 @@ export function BoardView({ api }: BoardViewProps) {
       if (didDrag()) return;
       if (card.cardType === 'entry') {
         router.push(`/entries/${card.refId}`);
-      } else if (card.cardType === 'snippet') {
-        const content = card.content as { text: string };
-        setSnippetDialog({ open: true, snippetId: card.refId, initialText: content.text });
+      } else if (card.cardType === 'snippet' && 'text' in card.content) {
+        setSnippetDialog({ open: true, snippetId: card.refId, initialText: card.content.text });
       }
     },
     [router, didDrag],
@@ -87,8 +86,10 @@ export function BoardView({ api }: BoardViewProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Delete' || e.key === 'Backspace') {
+        // @type-assertion-allowed: DOM KeyboardEvent target is always HTMLElement
         const tag = (e.target as HTMLElement).tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        // @type-assertion-allowed: DOM KeyboardEvent target is always HTMLElement
         if ((e.target as HTMLElement).isContentEditable) return;
         if (selectedId) {
           e.preventDefault();

--- a/apps/client/src/features/board/components/board-view.tsx
+++ b/apps/client/src/features/board/components/board-view.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import type { ApiClient } from '@/lib/api';
+import type { BoardCardData } from '../hooks/use-board';
+import { useBoard } from '../hooks/use-board';
+import { useBoardInteraction } from '../hooks/use-board-interaction';
+import { useBoardSave } from '../hooks/use-board-save';
+import { BoardCard } from './board-card';
+import { BoardControls } from './board-controls';
+import { BoardDateNav } from './board-date-nav';
+import { SnippetDialog } from './snippet-dialog';
+
+interface BoardViewProps {
+  api: ApiClient;
+}
+
+function todayKey(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function BoardView({ api }: BoardViewProps) {
+  const router = useRouter();
+  const [dateKey, setDateKey] = useState(todayKey);
+  const [snippetDialog, setSnippetDialog] = useState<{
+    open: boolean;
+    snippetId?: string;
+    initialText?: string;
+  }>({ open: false });
+
+  const { cards, setCards, loading, createSnippet, updateSnippet, deleteCard } = useBoard(
+    api,
+    dateKey,
+  );
+  const { savePositions } = useBoardSave(api);
+
+  const handleCardsChange = useCallback(
+    (newCards: BoardCardData[]) => {
+      setCards(newCards);
+    },
+    [setCards],
+  );
+
+  const handleInteractionEnd = useCallback(() => {
+    savePositions(cards);
+  }, [cards, savePositions]);
+
+  const {
+    selectedId,
+    startDrag,
+    startRotate,
+    startResize,
+    onPointerMove,
+    onPointerUp,
+    deselect,
+    didDrag,
+  } = useBoardInteraction(cards, handleCardsChange, handleInteractionEnd);
+
+  const handleCardClick = useCallback(
+    (card: BoardCardData) => {
+      if (didDrag()) return;
+      if (card.cardType === 'entry') {
+        router.push(`/entries/${card.refId}`);
+      } else if (card.cardType === 'snippet') {
+        const content = card.content as { text: string };
+        setSnippetDialog({ open: true, snippetId: card.refId, initialText: content.text });
+      }
+    },
+    [router, didDrag],
+  );
+
+  const handleDeleteCard = useCallback(
+    (cardId: string) => {
+      const card = cards.find((c) => c.id === cardId);
+      if (!card) return;
+      deleteCard(cardId, card.cardType, card.refId);
+    },
+    [cards, deleteCard],
+  );
+
+  // Keyboard handling for Delete/Backspace
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        if ((e.target as HTMLElement).isContentEditable) return;
+        if (selectedId) {
+          e.preventDefault();
+          handleDeleteCard(selectedId);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selectedId, handleDeleteCard]);
+
+  return (
+    <div
+      role="application"
+      aria-label="Board canvas"
+      className="relative h-full w-full overflow-auto"
+      style={{ backgroundColor: 'var(--bg)' }}
+      onPointerMove={(e) => onPointerMove(e.clientX, e.clientY)}
+      onPointerUp={onPointerUp}
+      onClick={deselect}
+      onKeyDown={() => {}}
+    >
+      {/* Grid background */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(0,0,0,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.03) 1px, transparent 1px)',
+          backgroundSize: '40px 40px',
+          opacity: 0.6,
+        }}
+      />
+
+      <BoardDateNav dateKey={dateKey} onDateChange={setDateKey} />
+      <BoardControls onAddSnippet={() => setSnippetDialog({ open: true })} />
+
+      {/* Canvas */}
+      <div className="relative min-h-full" style={{ minWidth: 1200, minHeight: 900 }}>
+        {loading && (
+          <div
+            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xs"
+            style={{ color: 'var(--date-color)' }}
+          >
+            Loading...
+          </div>
+        )}
+
+        {cards.map((card) => (
+          <BoardCard
+            key={card.id}
+            card={card}
+            isSelected={selectedId === card.id}
+            onPointerDown={startDrag}
+            onRotateStart={startRotate}
+            onResizeStart={startResize}
+            onDelete={handleDeleteCard}
+            onClick={handleCardClick}
+          />
+        ))}
+      </div>
+
+      {/* Snippet dialog */}
+      <SnippetDialog
+        open={snippetDialog.open}
+        initialText={snippetDialog.initialText}
+        onSubmit={(text) => {
+          if (snippetDialog.snippetId) {
+            updateSnippet(snippetDialog.snippetId, text);
+          } else {
+            createSnippet(text);
+          }
+        }}
+        onClose={() => setSnippetDialog({ open: false })}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/entry-card-content.tsx
+++ b/apps/client/src/features/board/components/entry-card-content.tsx
@@ -10,25 +10,32 @@ interface EntryCardContentProps {
   content: EntryContent;
 }
 
-export function EntryCardContent({ content }: EntryCardContentProps) {
-  const dateStr = new Date(content.createdAt).toLocaleDateString('ja-JP', {
-    month: 'short',
-    day: 'numeric',
-  });
+function formatEntryDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
 
+export function EntryCardContent({ content }: EntryCardContentProps) {
   return (
     <div className="flex h-full flex-col overflow-hidden p-6">
-      <div className="mb-2 flex items-center gap-2">
+      {/* Header with border separator */}
+      <div
+        className="mb-2 flex items-center justify-between pb-2"
+        style={{ borderBottom: '1px solid var(--border-subtle)' }}
+      >
         <span
-          className="inline-block h-2 w-2 rounded-full"
-          style={{ backgroundColor: 'var(--accent)' }}
-        />
-        <span
-          className="text-[10px] uppercase tracking-wider"
+          className="text-[9px] uppercase tracking-[0.2em]"
           style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
         >
-          {dateStr}
+          Entry {formatEntryDate(content.createdAt)}
         </span>
+        <span
+          className="inline-block h-1 w-1 rounded-full"
+          style={{ backgroundColor: 'var(--accent)' }}
+        />
       </div>
       {content.title && (
         <h3
@@ -38,11 +45,14 @@ export function EntryCardContent({ content }: EntryCardContentProps) {
           {content.title}
         </h3>
       )}
-      <p className="flex-1 text-xs leading-relaxed" style={{ color: 'var(--date-color)' }}>
+      <p
+        className="flex-1 leading-loose"
+        style={{ color: 'var(--date-color)', fontSize: 13, opacity: 0.85 }}
+      >
         {content.preview}
       </p>
       <div
-        className="pointer-events-none absolute bottom-0 left-0 right-0 h-16"
+        className="pointer-events-none absolute bottom-0 left-0 right-0 h-12"
         style={{
           background: 'linear-gradient(transparent, var(--card-bg, var(--bg)))',
         }}

--- a/apps/client/src/features/board/components/entry-card-content.tsx
+++ b/apps/client/src/features/board/components/entry-card-content.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+interface EntryContent {
+  title: string;
+  preview: string;
+  createdAt: string;
+}
+
+interface EntryCardContentProps {
+  content: EntryContent;
+}
+
+export function EntryCardContent({ content }: EntryCardContentProps) {
+  const dateStr = new Date(content.createdAt).toLocaleDateString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden p-6">
+      <div className="mb-2 flex items-center gap-2">
+        <span
+          className="inline-block h-2 w-2 rounded-full"
+          style={{ backgroundColor: 'var(--accent)' }}
+        />
+        <span
+          className="text-[10px] uppercase tracking-wider"
+          style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+        >
+          {dateStr}
+        </span>
+      </div>
+      {content.title && (
+        <h3
+          className="mb-2 line-clamp-2 text-sm font-medium leading-snug"
+          style={{ color: 'var(--fg)' }}
+        >
+          {content.title}
+        </h3>
+      )}
+      <p className="flex-1 text-xs leading-relaxed" style={{ color: 'var(--date-color)' }}>
+        {content.preview}
+      </p>
+      <div
+        className="pointer-events-none absolute bottom-0 left-0 right-0 h-16"
+        style={{
+          background: 'linear-gradient(transparent, var(--card-bg, var(--bg)))',
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/snippet-card-content.tsx
+++ b/apps/client/src/features/board/components/snippet-card-content.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+interface SnippetContent {
+  text: string;
+}
+
+interface SnippetCardContentProps {
+  content: SnippetContent;
+}
+
+export function SnippetCardContent({ content }: SnippetCardContentProps) {
+  return (
+    <div className="flex h-full flex-col p-6">
+      <div className="mb-2 flex items-center gap-2">
+        <span
+          className="inline-block h-2 w-2 rounded-full"
+          style={{ backgroundColor: '#E5D5A0' }}
+        />
+        <span
+          className="rounded-sm border px-1.5 py-0.5 text-[9px] uppercase tracking-wider"
+          style={{
+            borderColor: 'var(--accent)',
+            color: 'var(--accent)',
+            fontFamily: 'Inter, sans-serif',
+          }}
+        >
+          ✦ Snippet
+        </span>
+      </div>
+      <p className="flex-1 text-sm leading-relaxed" style={{ color: 'var(--fg)' }}>
+        {content.text}
+      </p>
+    </div>
+  );
+}

--- a/apps/client/src/features/board/components/snippet-card-content.tsx
+++ b/apps/client/src/features/board/components/snippet-card-content.tsx
@@ -13,13 +13,14 @@ export function SnippetCardContent({ content }: SnippetCardContentProps) {
     <div className="flex h-full flex-col p-6">
       <div className="mb-2 flex items-center gap-2">
         <span
-          className="inline-block h-2 w-2 rounded-full"
+          className="inline-block h-1 w-1 rounded-full"
           style={{ backgroundColor: '#E5D5A0' }}
         />
         <span
-          className="rounded-sm border px-1.5 py-0.5 text-[9px] uppercase tracking-wider"
+          className="rounded px-1.5 py-0.5 text-[9px] uppercase tracking-[0.2em]"
           style={{
-            borderColor: 'var(--accent)',
+            border: '1px solid rgba(74,158,142,0.3)',
+            backgroundColor: 'rgba(255,255,255,0.5)',
             color: 'var(--accent)',
             fontFamily: 'Inter, sans-serif',
           }}
@@ -27,7 +28,7 @@ export function SnippetCardContent({ content }: SnippetCardContentProps) {
           ✦ Snippet
         </span>
       </div>
-      <p className="flex-1 text-sm leading-relaxed" style={{ color: 'var(--fg)' }}>
+      <p className="flex-1 text-sm" style={{ color: 'var(--fg)', lineHeight: 1.8 }}>
         {content.text}
       </p>
     </div>

--- a/apps/client/src/features/board/components/snippet-dialog.tsx
+++ b/apps/client/src/features/board/components/snippet-dialog.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface SnippetDialogProps {
+  open: boolean;
+  initialText?: string;
+  onSubmit: (text: string) => void;
+  onClose: () => void;
+}
+
+export function SnippetDialog({ open, initialText = '', onSubmit, onClose }: SnippetDialogProps) {
+  const [text, setText] = useState(initialText);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setText(initialText);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open, initialText]);
+
+  if (!open) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (trimmed.length > 0 && trimmed.length <= 50) {
+      onSubmit(trimmed);
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Snippet dialog"
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="w-80 rounded-lg p-6 shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', border: '1px solid var(--border-subtle)' }}
+      >
+        <h3
+          className="mb-4 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--accent)', fontFamily: 'Inter, sans-serif' }}
+        >
+          {initialText ? 'Edit Snippet' : '✦ New Snippet'}
+        </h3>
+        <input
+          ref={inputRef}
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          maxLength={50}
+          placeholder="スニペットを入力..."
+          className="mb-3 w-full rounded border px-3 py-2 text-sm outline-none"
+          style={{
+            backgroundColor: 'var(--bg)',
+            borderColor: 'var(--border-subtle)',
+            color: 'var(--fg)',
+          }}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-[10px]" style={{ color: 'var(--date-color)' }}>
+            {text.length}/50
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded px-3 py-1 text-xs"
+              style={{ color: 'var(--date-color)' }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={text.trim().length === 0}
+              className="rounded px-3 py-1 text-xs text-white disabled:opacity-40"
+              style={{ backgroundColor: 'var(--accent)' }}
+            >
+              {initialText ? 'Update' : 'Add'}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/client/src/features/board/hooks/use-board-interaction.ts
+++ b/apps/client/src/features/board/hooks/use-board-interaction.ts
@@ -1,0 +1,187 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import type { BoardCardData } from './use-board';
+
+type InteractionType = 'drag' | 'rotate' | 'resize';
+type ResizeCorner = 'se' | 'sw' | 'ne' | 'nw';
+
+interface DragState {
+  type: 'drag';
+  cardId: string;
+  startX: number;
+  startY: number;
+  cardStartX: number;
+  cardStartY: number;
+}
+
+interface RotateState {
+  type: 'rotate';
+  cardId: string;
+  centerX: number;
+  centerY: number;
+}
+
+interface ResizeState {
+  type: 'resize';
+  cardId: string;
+  corner: ResizeCorner;
+  startX: number;
+  startY: number;
+  cardStartX: number;
+  cardStartY: number;
+  cardStartW: number;
+  cardStartH: number;
+}
+
+type InteractionState = DragState | RotateState | ResizeState | null;
+
+const MIN_SIZE = 120;
+const DRAG_THRESHOLD = 4;
+
+export function useBoardInteraction(
+  cards: BoardCardData[],
+  onCardsChange: (cards: BoardCardData[]) => void,
+  onInteractionEnd: () => void,
+) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const stateRef = useRef<InteractionState>(null);
+  const didDragRef = useRef(false);
+  const zCounterRef = useRef(cards.length > 0 ? Math.max(...cards.map((c) => c.zIndex)) + 1 : 100);
+
+  const updateCard = useCallback(
+    (cardId: string, update: Partial<BoardCardData>) => {
+      onCardsChange(cards.map((c) => (c.id === cardId ? { ...c, ...update } : c)));
+    },
+    [cards, onCardsChange],
+  );
+
+  const startDrag = useCallback(
+    (cardId: string, pointerX: number, pointerY: number) => {
+      const card = cards.find((c) => c.id === cardId);
+      if (!card) return;
+
+      setSelectedId(cardId);
+      didDragRef.current = false;
+      stateRef.current = {
+        type: 'drag',
+        cardId,
+        startX: pointerX,
+        startY: pointerY,
+        cardStartX: card.x,
+        cardStartY: card.y,
+      };
+    },
+    [cards],
+  );
+
+  const startRotate = useCallback((cardId: string, centerX: number, centerY: number) => {
+    stateRef.current = { type: 'rotate', cardId, centerX, centerY };
+  }, []);
+
+  const startResize = useCallback(
+    (cardId: string, corner: ResizeCorner, pointerX: number, pointerY: number) => {
+      const card = cards.find((c) => c.id === cardId);
+      if (!card) return;
+
+      stateRef.current = {
+        type: 'resize',
+        cardId,
+        corner,
+        startX: pointerX,
+        startY: pointerY,
+        cardStartX: card.x,
+        cardStartY: card.y,
+        cardStartW: card.width,
+        cardStartH: card.height,
+      };
+    },
+    [cards],
+  );
+
+  const onPointerMove = useCallback(
+    (pointerX: number, pointerY: number) => {
+      const state = stateRef.current;
+      if (!state) return;
+
+      if (state.type === 'drag') {
+        const dx = pointerX - state.startX;
+        const dy = pointerY - state.startY;
+        if (!didDragRef.current && Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return;
+        didDragRef.current = true;
+        updateCard(state.cardId, {
+          x: state.cardStartX + dx,
+          y: state.cardStartY + dy,
+        });
+      } else if (state.type === 'rotate') {
+        const angle =
+          Math.atan2(pointerY - state.centerY, pointerX - state.centerX) * (180 / Math.PI);
+        const rounded = Math.round(angle * 10) / 10;
+        updateCard(state.cardId, { rotation: rounded });
+      } else if (state.type === 'resize') {
+        const dx = pointerX - state.startX;
+        const dy = pointerY - state.startY;
+        let newW = state.cardStartW;
+        let newH = state.cardStartH;
+        let newX = state.cardStartX;
+        let newY = state.cardStartY;
+
+        if (state.corner === 'se') {
+          newW = Math.max(MIN_SIZE, state.cardStartW + dx);
+          newH = Math.max(MIN_SIZE, state.cardStartH + dy);
+        } else if (state.corner === 'sw') {
+          newW = Math.max(MIN_SIZE, state.cardStartW - dx);
+          newH = Math.max(MIN_SIZE, state.cardStartH + dy);
+          newX = state.cardStartX + (state.cardStartW - newW);
+        } else if (state.corner === 'ne') {
+          newW = Math.max(MIN_SIZE, state.cardStartW + dx);
+          newH = Math.max(MIN_SIZE, state.cardStartH - dy);
+          newY = state.cardStartY + (state.cardStartH - newH);
+        } else if (state.corner === 'nw') {
+          newW = Math.max(MIN_SIZE, state.cardStartW - dx);
+          newH = Math.max(MIN_SIZE, state.cardStartH - dy);
+          newX = state.cardStartX + (state.cardStartW - newW);
+          newY = state.cardStartY + (state.cardStartH - newH);
+        }
+
+        updateCard(state.cardId, { x: newX, y: newY, width: newW, height: newH });
+      }
+    },
+    [updateCard],
+  );
+
+  const onPointerUp = useCallback(() => {
+    const state = stateRef.current;
+    if (state) {
+      if (state.type === 'drag') {
+        zCounterRef.current += 1;
+        updateCard(state.cardId, { zIndex: zCounterRef.current });
+      }
+      onInteractionEnd();
+    }
+    stateRef.current = null;
+  }, [updateCard, onInteractionEnd]);
+
+  const deselect = useCallback(() => {
+    setSelectedId(null);
+  }, []);
+
+  const getInteractionType = (): InteractionType | null => {
+    return stateRef.current?.type ?? null;
+  };
+
+  const didDrag = () => didDragRef.current;
+
+  return {
+    selectedId,
+    setSelectedId,
+    startDrag,
+    startRotate,
+    startResize,
+    onPointerMove,
+    onPointerUp,
+    deselect,
+    getInteractionType,
+    didDrag,
+  };
+}

--- a/apps/client/src/features/board/hooks/use-board-save.ts
+++ b/apps/client/src/features/board/hooks/use-board-save.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import type { ApiClient } from '@/lib/api';
+import type { BoardCardData } from './use-board';
+
+export function useBoardSave(api: ApiClient | null) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const savePositions = useCallback(
+    (cards: BoardCardData[]) => {
+      if (!api) return;
+
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      timerRef.current = setTimeout(async () => {
+        await api.fetch('/api/v1/board/cards', {
+          method: 'PUT',
+          body: JSON.stringify({
+            cards: cards.map((c) => ({
+              id: c.id,
+              x: c.x,
+              y: c.y,
+              rotation: c.rotation,
+              width: c.width,
+              height: c.height,
+              zIndex: c.zIndex,
+            })),
+          }),
+        });
+      }, 500);
+    },
+    [api],
+  );
+
+  return { savePositions };
+}

--- a/apps/client/src/features/board/hooks/use-board.ts
+++ b/apps/client/src/features/board/hooks/use-board.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { ApiClient } from '@/lib/api';
+
+interface EntryContent {
+  title: string;
+  preview: string;
+  createdAt: string;
+}
+
+interface SnippetContent {
+  text: string;
+}
+
+export interface BoardCardData {
+  id: string;
+  cardType: 'entry' | 'snippet';
+  refId: string;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  content: EntryContent | SnippetContent;
+}
+
+interface BoardData {
+  dateKey: string;
+  viewType: string;
+  cards: BoardCardData[];
+}
+
+export function useBoard(api: ApiClient | null, dateKey: string) {
+  const [cards, setCards] = useState<BoardCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchBoard = useCallback(async () => {
+    if (!api) return;
+    setLoading(true);
+    const res = await api.fetch(`/api/v1/board?dateKey=${dateKey}`);
+    if (res.ok) {
+      const data: BoardData = await res.json();
+      setCards(data.cards);
+    }
+    setLoading(false);
+  }, [api, dateKey]);
+
+  useEffect(() => {
+    fetchBoard();
+  }, [fetchBoard]);
+
+  const createSnippet = useCallback(
+    async (text: string) => {
+      if (!api) return;
+      const res = await api.fetch('/api/v1/board/snippets', {
+        method: 'POST',
+        body: JSON.stringify({ text, dateKey }),
+      });
+      if (res.ok) {
+        await fetchBoard();
+      }
+    },
+    [api, dateKey, fetchBoard],
+  );
+
+  const updateSnippet = useCallback(
+    async (snippetId: string, text: string) => {
+      if (!api) return;
+      const res = await api.fetch(`/api/v1/board/snippets/${snippetId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ text }),
+      });
+      if (res.ok) {
+        setCards((prev) =>
+          prev.map((c) =>
+            c.refId === snippetId && c.cardType === 'snippet' ? { ...c, content: { text } } : c,
+          ),
+        );
+      }
+    },
+    [api],
+  );
+
+  const deleteCard = useCallback(
+    async (cardId: string, cardType: string, refId: string) => {
+      if (!api) return;
+      if (cardType === 'snippet') {
+        await api.fetch(`/api/v1/board/snippets/${refId}`, { method: 'DELETE' });
+      } else {
+        await api.fetch(`/api/v1/board/cards/${cardId}`, { method: 'DELETE' });
+      }
+      setCards((prev) => prev.filter((c) => c.id !== cardId));
+    },
+    [api],
+  );
+
+  return {
+    cards,
+    setCards,
+    loading,
+    refresh: fetchBoard,
+    createSnippet,
+    updateSnippet,
+    deleteCard,
+  };
+}

--- a/apps/client/test/features/board/hooks/use-board-save.test.ts
+++ b/apps/client/test/features/board/hooks/use-board-save.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BoardCardData } from '@/features/board/hooks/use-board';
+import { useBoardSave } from '@/features/board/hooks/use-board-save';
+import type { ApiClient } from '@/lib/api';
+
+function createMockApi(fetchImpl: ReturnType<typeof vi.fn>): ApiClient {
+  return { baseUrl: '', headers: {}, fetch: fetchImpl };
+}
+
+describe('useBoardSave', () => {
+  let apiFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiFetch = vi.fn().mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('500ms のデバウンス後に保存する', async () => {
+    const api = createMockApi(apiFetch);
+    const { result } = renderHook(() => useBoardSave(api));
+
+    const cards: BoardCardData[] = [
+      {
+        id: 'c-1',
+        cardType: 'entry',
+        refId: 'e-1',
+        x: 100,
+        y: 200,
+        rotation: 0,
+        width: 340,
+        height: 280,
+        zIndex: 0,
+        content: { title: '', preview: '', createdAt: '' },
+      },
+    ];
+
+    act(() => {
+      result.current.savePositions(cards);
+    });
+
+    expect(apiFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/v1/board/cards',
+      expect.objectContaining({
+        method: 'PUT',
+      }),
+    );
+  });
+
+  it('連続呼び出しでは最後のみ実行する', async () => {
+    const api = createMockApi(apiFetch);
+    const { result } = renderHook(() => useBoardSave(api));
+
+    const cards1: BoardCardData[] = [
+      {
+        id: 'c-1',
+        cardType: 'entry',
+        refId: 'e-1',
+        x: 100,
+        y: 200,
+        rotation: 0,
+        width: 340,
+        height: 280,
+        zIndex: 0,
+        content: { title: '', preview: '', createdAt: '' },
+      },
+    ];
+    const cards2: BoardCardData[] = [
+      {
+        id: 'c-1',
+        cardType: 'entry',
+        refId: 'e-1',
+        x: 200,
+        y: 300,
+        rotation: 5,
+        width: 340,
+        height: 280,
+        zIndex: 1,
+        content: { title: '', preview: '', createdAt: '' },
+      },
+    ];
+
+    act(() => {
+      result.current.savePositions(cards1);
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.savePositions(cards2);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/test/features/board/hooks/use-board.test.ts
+++ b/apps/client/test/features/board/hooks/use-board.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBoard } from '@/features/board/hooks/use-board';
+import type { ApiClient } from '@/lib/api';
+
+function createMockApi(fetchImpl: ReturnType<typeof vi.fn>): ApiClient {
+  return { baseUrl: '', headers: {}, fetch: fetchImpl };
+}
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body), status: ok ? 200 : 400 } as Response;
+}
+
+describe('useBoard', () => {
+  let apiFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiFetch = vi.fn();
+  });
+
+  it('dateKey でボードデータを取得する', async () => {
+    const boardData = {
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      cards: [
+        {
+          id: 'c-1',
+          cardType: 'entry',
+          refId: 'e-1',
+          x: 100,
+          y: 200,
+          rotation: 0,
+          width: 340,
+          height: 280,
+          zIndex: 0,
+          content: { title: 'Test', preview: 'Preview', createdAt: '2026-04-11T00:00:00Z' },
+        },
+      ],
+    };
+    apiFetch.mockResolvedValueOnce(mockResponse(true, boardData));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useBoard(api, '2026-04-11'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.cards).toHaveLength(1);
+    expect(result.current.cards[0].id).toBe('c-1');
+    expect(apiFetch).toHaveBeenCalledWith('/api/v1/board?dateKey=2026-04-11');
+  });
+
+  it('api が null の場合はフェッチしない', () => {
+    renderHook(() => useBoard(null, '2026-04-11'));
+    // no error thrown
+  });
+
+  it('API エラー時は cards が空のまま', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(false, {}));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useBoard(api, '2026-04-11'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.cards).toEqual([]);
+  });
+
+  it('dateKey 変更で再フェッチする', async () => {
+    const data1 = { dateKey: '2026-04-11', viewType: 'daily', cards: [] };
+    const data2 = {
+      dateKey: '2026-04-12',
+      viewType: 'daily',
+      cards: [
+        {
+          id: 'c-2',
+          cardType: 'entry',
+          refId: 'e-2',
+          x: 50,
+          y: 50,
+          rotation: 0,
+          width: 340,
+          height: 280,
+          zIndex: 0,
+          content: { title: 'T', preview: 'P', createdAt: '2026-04-12T00:00:00Z' },
+        },
+      ],
+    };
+    apiFetch.mockResolvedValueOnce(mockResponse(true, data1));
+    const api = createMockApi(apiFetch);
+
+    const { result, rerender } = renderHook(({ dateKey }) => useBoard(api, dateKey), {
+      initialProps: { dateKey: '2026-04-11' },
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.cards).toEqual([]);
+
+    apiFetch.mockResolvedValueOnce(mockResponse(true, data2));
+    rerender({ dateKey: '2026-04-12' });
+
+    await waitFor(() => expect(result.current.cards).toHaveLength(1));
+    expect(result.current.cards[0].id).toBe('c-2');
+  });
+});

--- a/apps/server/.dependency-cruiser.cjs
+++ b/apps/server/.dependency-cruiser.cjs
@@ -94,6 +94,52 @@ module.exports = {
       to: { path: '^src/contexts/question/presentation' },
     },
 
+    // === Board context isolation ===
+    {
+      name: 'board-context-isolation',
+      comment:
+        'board context may import entry domain (gateway IFs for cross-context reads)',
+      severity: 'error',
+      from: { path: '^src/contexts/board/(domain|application|infrastructure)' },
+      to: {
+        path: '^src/contexts/',
+        pathNot: ['^src/contexts/board', '^src/contexts/shared', '^src/contexts/entry/domain'],
+      },
+    },
+
+    // === DDD layer rules for board ===
+    {
+      name: 'board-domain-isolation',
+      comment: 'board domain must not depend on other layers',
+      severity: 'error',
+      from: { path: '^src/contexts/board/domain' },
+      to: { path: '^src/contexts/board/(application|infrastructure|presentation)' },
+    },
+    {
+      name: 'board-application-no-infra',
+      severity: 'error',
+      from: { path: '^src/contexts/board/application' },
+      to: { path: '^src/contexts/board/infrastructure' },
+    },
+    {
+      name: 'board-application-no-presentation',
+      severity: 'error',
+      from: { path: '^src/contexts/board/application' },
+      to: { path: '^src/contexts/board/presentation' },
+    },
+    {
+      name: 'board-infra-no-application',
+      severity: 'error',
+      from: { path: '^src/contexts/board/infrastructure' },
+      to: { path: '^src/contexts/board/application' },
+    },
+    {
+      name: 'board-infra-no-presentation',
+      severity: 'error',
+      from: { path: '^src/contexts/board/infrastructure' },
+      to: { path: '^src/contexts/board/presentation' },
+    },
+
     // === Shared domain isolation ===
     {
       name: 'shared-domain-isolation',

--- a/apps/server/.dependency-cruiser.cjs
+++ b/apps/server/.dependency-cruiser.cjs
@@ -97,8 +97,7 @@ module.exports = {
     // === Board context isolation ===
     {
       name: 'board-context-isolation',
-      comment:
-        'board context may import entry domain (gateway IFs for cross-context reads)',
+      comment: 'board context may import entry domain (gateway IFs for cross-context reads)',
       severity: 'error',
       from: { path: '^src/contexts/board/(domain|application|infrastructure)' },
       to: {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { board } from './contexts/board/presentation/routes/board.js';
 import { entries } from './contexts/entry/presentation/routes/entries.js';
 import { fermentations } from './contexts/fermentation/presentation/routes/fermentations.js';
 import { entryQuestions } from './contexts/question/presentation/routes/entry-questions.js';
@@ -12,6 +13,7 @@ const app = new Hono()
   .get('/health', (c) => c.json({ status: 'ok' }))
   .route('/api/v1/auth', authRoutes)
   .use('/api/v1/*', authMiddleware)
+  .route('/api/v1/board', board)
   .route('/api/v1/entries', entries)
   .route('/api/v1/questions', questions)
   .route('/api/v1/entries/:entryId/questions', entryQuestions)

--- a/apps/server/src/contexts/board/application/errors/board.errors.ts
+++ b/apps/server/src/contexts/board/application/errors/board.errors.ts
@@ -1,0 +1,14 @@
+import {
+  NotFoundError,
+  ValidationError,
+} from '../../../shared/application/errors/application.errors.js';
+
+export class BoardSnippetNotFoundError extends NotFoundError {
+  constructor(id: string) {
+    super(`Board snippet not found: ${id}`);
+  }
+}
+
+export class BoardCardValidationError extends ValidationError {}
+
+export class BoardSnippetValidationError extends ValidationError {}

--- a/apps/server/src/contexts/board/application/usecases/create-board-snippet.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/create-board-snippet.usecase.ts
@@ -1,0 +1,84 @@
+import type { BoardCardRepositoryGateway } from '../../domain/gateways/board-card-repository.gateway.js';
+import type { BoardSnippetRepositoryGateway } from '../../domain/gateways/board-snippet-repository.gateway.js';
+import { BoardCard } from '../../domain/models/board-card.js';
+import { BoardSnippet } from '../../domain/models/board-snippet.js';
+import { BoardCardValidationError, BoardSnippetValidationError } from '../errors/board.errors.js';
+
+interface CreateBoardSnippetInput {
+  text: string;
+  dateKey: string;
+}
+
+interface CreateBoardSnippetResponse {
+  snippetId: string;
+  cardId: string;
+  text: string;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+}
+
+const DEFAULT_WIDTH = 260;
+const DEFAULT_HEIGHT = 150;
+
+export class CreateBoardSnippetUsecase {
+  constructor(
+    private boardSnippetRepo: BoardSnippetRepositoryGateway,
+    private boardCardRepo: BoardCardRepositoryGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(
+    userId: string,
+    input: CreateBoardSnippetInput,
+  ): Promise<CreateBoardSnippetResponse> {
+    const snippetResult = BoardSnippet.create({ userId, text: input.text }, this.generateId);
+    if (!snippetResult.success) {
+      throw new BoardSnippetValidationError(snippetResult.error.message);
+    }
+    const snippet = snippetResult.value;
+
+    const x = Math.floor(Math.random() * 741) + 60;
+    const y = Math.floor(Math.random() * 541) + 60;
+    const rotation = Math.round((Math.random() * 10 - 5) * 10) / 10;
+
+    const cardResult = BoardCard.create(
+      {
+        userId,
+        cardType: 'snippet',
+        refId: snippet.id,
+        dateKey: input.dateKey,
+        viewType: 'daily',
+        x,
+        y,
+        rotation,
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT,
+        zIndex: 0,
+      },
+      this.generateId,
+    );
+    if (!cardResult.success) {
+      throw new BoardCardValidationError(cardResult.error.message);
+    }
+    const card = cardResult.value;
+
+    await this.boardSnippetRepo.save(snippet);
+    await this.boardCardRepo.saveMany([card]);
+
+    return {
+      snippetId: snippet.id,
+      cardId: card.id,
+      text: snippet.text,
+      x: card.x,
+      y: card.y,
+      rotation: card.rotation,
+      width: card.width,
+      height: card.height,
+      zIndex: card.zIndex,
+    };
+  }
+}

--- a/apps/server/src/contexts/board/application/usecases/delete-board-snippet.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/delete-board-snippet.usecase.ts
@@ -1,0 +1,14 @@
+import type { BoardCardRepositoryGateway } from '../../domain/gateways/board-card-repository.gateway.js';
+import type { BoardSnippetRepositoryGateway } from '../../domain/gateways/board-snippet-repository.gateway.js';
+
+export class DeleteBoardSnippetUsecase {
+  constructor(
+    private boardSnippetRepo: BoardSnippetRepositoryGateway,
+    private boardCardRepo: BoardCardRepositoryGateway,
+  ) {}
+
+  async execute(snippetId: string, userId: string): Promise<void> {
+    await this.boardCardRepo.deleteByRefId(snippetId, userId);
+    await this.boardSnippetRepo.delete(snippetId);
+  }
+}

--- a/apps/server/src/contexts/board/application/usecases/delete-card.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/delete-card.usecase.ts
@@ -1,0 +1,9 @@
+import type { BoardCardRepositoryGateway } from '../../domain/gateways/board-card-repository.gateway.js';
+
+export class DeleteCardUsecase {
+  constructor(private boardCardRepo: BoardCardRepositoryGateway) {}
+
+  async execute(cardId: string, userId: string): Promise<void> {
+    await this.boardCardRepo.delete(cardId, userId);
+  }
+}

--- a/apps/server/src/contexts/board/application/usecases/load-board.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/load-board.usecase.ts
@@ -106,16 +106,16 @@ export class LoadBoardUsecase {
     const entryRefIds = cards.filter((c) => c.cardType === 'entry').map((c) => c.refId);
     const snippetRefIds = cards.filter((c) => c.cardType === 'snippet').map((c) => c.refId);
 
-    // Fetch entry content
+    // Fetch entry content (batch)
     const entryMap = new Map<string, EntryContent>();
-    for (const refId of entryRefIds) {
-      const entry = await this.entryRepo.findById(refId);
-      if (entry) {
+    if (entryRefIds.length > 0) {
+      const entries = await this.entryRepo.findByIds(entryRefIds);
+      for (const entry of entries) {
         const content = entry.content;
-        const lines = content.split('\n').filter((l) => l.trim().length > 0);
-        entryMap.set(refId, {
-          title: lines[0]?.substring(0, 100) ?? '',
-          preview: content.substring(0, 100),
+        const firstLine = content.split('\n').find((l) => l.trim().length > 0);
+        entryMap.set(entry.id, {
+          title: firstLine?.substring(0, 100) ?? '',
+          preview: content.substring(0, 200),
           createdAt: entry.createdAt,
         });
       }

--- a/apps/server/src/contexts/board/application/usecases/load-board.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/load-board.usecase.ts
@@ -1,0 +1,158 @@
+import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway.js';
+import type { BoardCardRepositoryGateway } from '../../domain/gateways/board-card-repository.gateway.js';
+import type { BoardSnippetRepositoryGateway } from '../../domain/gateways/board-snippet-repository.gateway.js';
+import { BoardCard } from '../../domain/models/board-card.js';
+
+interface EntryContent {
+  title: string;
+  preview: string;
+  createdAt: string;
+}
+
+interface SnippetContent {
+  text: string;
+}
+
+interface CardResponse {
+  id: string;
+  cardType: 'entry' | 'snippet';
+  refId: string;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  content: EntryContent | SnippetContent;
+}
+
+interface LoadBoardResponse {
+  dateKey: string;
+  viewType: string;
+  cards: CardResponse[];
+}
+
+const DEFAULT_ENTRY_WIDTH = 340;
+const DEFAULT_ENTRY_HEIGHT = 280;
+
+function randomBetween(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export class LoadBoardUsecase {
+  constructor(
+    private boardCardRepo: BoardCardRepositoryGateway,
+    private boardSnippetRepo: BoardSnippetRepositoryGateway,
+    private entryRepo: EntryRepositoryGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(userId: string, dateKey: string): Promise<LoadBoardResponse> {
+    const viewType = 'daily';
+
+    // 1. Load existing cards
+    const existingCards = await this.boardCardRepo.findByDateAndView(userId, dateKey, viewType);
+
+    // 2. Auto-populate entries that don't have cards yet
+    const existingEntryRefIds = await this.boardCardRepo.findRefIdsByDateAndView(
+      userId,
+      dateKey,
+      viewType,
+      'entry',
+    );
+    const existingRefIdSet = new Set(existingEntryRefIds);
+
+    const entries = await this.entryRepo.listByUserIdAndDate(userId, dateKey);
+    const newCards: BoardCard[] = [];
+
+    for (const entry of entries) {
+      if (existingRefIdSet.has(entry.id)) continue;
+
+      const result = BoardCard.create(
+        {
+          userId,
+          cardType: 'entry',
+          refId: entry.id,
+          dateKey,
+          viewType,
+          x: randomBetween(60, 800),
+          y: randomBetween(60, 600),
+          rotation: Math.round((Math.random() * 10 - 5) * 10) / 10,
+          width: DEFAULT_ENTRY_WIDTH,
+          height: DEFAULT_ENTRY_HEIGHT,
+          zIndex: existingCards.length + newCards.length,
+        },
+        this.generateId,
+      );
+      if (result.success) {
+        newCards.push(result.value);
+      }
+    }
+
+    if (newCards.length > 0) {
+      await this.boardCardRepo.saveMany(newCards);
+    }
+
+    const allCards = [...existingCards, ...newCards];
+
+    // 3. Hydrate content
+    const cardResponses = await this.hydrateCards(allCards);
+
+    return { dateKey, viewType, cards: cardResponses };
+  }
+
+  private async hydrateCards(cards: BoardCard[]): Promise<CardResponse[]> {
+    // Collect refIds by type
+    const entryRefIds = cards.filter((c) => c.cardType === 'entry').map((c) => c.refId);
+    const snippetRefIds = cards.filter((c) => c.cardType === 'snippet').map((c) => c.refId);
+
+    // Fetch entry content
+    const entryMap = new Map<string, EntryContent>();
+    for (const refId of entryRefIds) {
+      const entry = await this.entryRepo.findById(refId);
+      if (entry) {
+        const content = entry.content;
+        const lines = content.split('\n').filter((l) => l.trim().length > 0);
+        entryMap.set(refId, {
+          title: lines[0]?.substring(0, 100) ?? '',
+          preview: content.substring(0, 100),
+          createdAt: entry.createdAt,
+        });
+      }
+    }
+
+    // Fetch snippet content
+    const snippetMap = new Map<string, SnippetContent>();
+    if (snippetRefIds.length > 0) {
+      const snippets = await this.boardSnippetRepo.findByIds(snippetRefIds);
+      for (const snippet of snippets) {
+        snippetMap.set(snippet.id, { text: snippet.text });
+      }
+    }
+
+    return cards
+      .map((card) => {
+        let content: EntryContent | SnippetContent | undefined;
+        if (card.cardType === 'entry') {
+          content = entryMap.get(card.refId);
+        } else if (card.cardType === 'snippet') {
+          content = snippetMap.get(card.refId);
+        }
+        if (!content) return null;
+
+        return {
+          id: card.id,
+          cardType: card.cardType,
+          refId: card.refId,
+          x: card.x,
+          y: card.y,
+          rotation: card.rotation,
+          width: card.width,
+          height: card.height,
+          zIndex: card.zIndex,
+          content,
+        };
+      })
+      .filter((c): c is CardResponse => c !== null);
+  }
+}

--- a/apps/server/src/contexts/board/application/usecases/save-card-positions.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/save-card-positions.usecase.ts
@@ -1,0 +1,20 @@
+import type {
+  BoardCardRepositoryGateway,
+  CardPositionUpdate,
+} from '../../domain/gateways/board-card-repository.gateway.js';
+import { BoardCardValidationError } from '../errors/board.errors.js';
+
+const MIN_SIZE = 120;
+
+export class SaveCardPositionsUsecase {
+  constructor(private boardCardRepo: BoardCardRepositoryGateway) {}
+
+  async execute(cards: CardPositionUpdate[]): Promise<void> {
+    for (const card of cards) {
+      if (card.width < MIN_SIZE || card.height < MIN_SIZE) {
+        throw new BoardCardValidationError(`Card dimensions must be at least ${MIN_SIZE}px`);
+      }
+    }
+    await this.boardCardRepo.updatePositions(cards);
+  }
+}

--- a/apps/server/src/contexts/board/application/usecases/update-board-snippet.usecase.ts
+++ b/apps/server/src/contexts/board/application/usecases/update-board-snippet.usecase.ts
@@ -1,0 +1,20 @@
+import type { BoardSnippetRepositoryGateway } from '../../domain/gateways/board-snippet-repository.gateway.js';
+import { BoardSnippetNotFoundError, BoardSnippetValidationError } from '../errors/board.errors.js';
+
+export class UpdateBoardSnippetUsecase {
+  constructor(private boardSnippetRepo: BoardSnippetRepositoryGateway) {}
+
+  async execute(snippetId: string, text: string): Promise<void> {
+    const snippet = await this.boardSnippetRepo.findById(snippetId);
+    if (!snippet) {
+      throw new BoardSnippetNotFoundError(snippetId);
+    }
+
+    const result = snippet.withText(text);
+    if (!result.success) {
+      throw new BoardSnippetValidationError(result.error.message);
+    }
+
+    await this.boardSnippetRepo.update(result.value);
+  }
+}

--- a/apps/server/src/contexts/board/domain/gateways/board-card-repository.gateway.ts
+++ b/apps/server/src/contexts/board/domain/gateways/board-card-repository.gateway.ts
@@ -1,0 +1,25 @@
+import type { BoardCard } from '../models/board-card.js';
+
+export interface CardPositionUpdate {
+  id: string;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+}
+
+export interface BoardCardRepositoryGateway {
+  findByDateAndView(userId: string, dateKey: string, viewType: string): Promise<BoardCard[]>;
+  findRefIdsByDateAndView(
+    userId: string,
+    dateKey: string,
+    viewType: string,
+    cardType: string,
+  ): Promise<string[]>;
+  saveMany(cards: BoardCard[]): Promise<void>;
+  updatePositions(cards: CardPositionUpdate[]): Promise<void>;
+  delete(id: string, userId: string): Promise<void>;
+  deleteByRefId(refId: string, userId: string): Promise<void>;
+}

--- a/apps/server/src/contexts/board/domain/gateways/board-snippet-repository.gateway.ts
+++ b/apps/server/src/contexts/board/domain/gateways/board-snippet-repository.gateway.ts
@@ -1,0 +1,9 @@
+import type { BoardSnippet } from '../models/board-snippet.js';
+
+export interface BoardSnippetRepositoryGateway {
+  findById(id: string): Promise<BoardSnippet | null>;
+  findByIds(ids: string[]): Promise<BoardSnippet[]>;
+  save(snippet: BoardSnippet): Promise<void>;
+  update(snippet: BoardSnippet): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/apps/server/src/contexts/board/domain/models/board-card.ts
+++ b/apps/server/src/contexts/board/domain/models/board-card.ts
@@ -7,6 +7,14 @@ const MIN_SIZE = 120;
 type CardType = (typeof VALID_CARD_TYPES)[number];
 type ViewType = (typeof VALID_VIEW_TYPES)[number];
 
+function isCardType(value: string): value is CardType {
+  return value === 'entry' || value === 'snippet';
+}
+
+function isViewType(value: string): value is ViewType {
+  return value === 'daily' || value === 'weekly';
+}
+
 type BoardCardError =
   | { type: 'INVALID_CARD_TYPE'; message: string }
   | { type: 'INVALID_VIEW_TYPE'; message: string }
@@ -81,13 +89,14 @@ export class BoardCard {
     params: CreateBoardCardParams,
     generateId: () => string,
   ): Result<BoardCard, BoardCardError> {
-    if (!VALID_CARD_TYPES.includes(params.cardType as CardType)) {
+    const { cardType, viewType } = params;
+    if (!isCardType(cardType)) {
       return err({
         type: 'INVALID_CARD_TYPE',
         message: `Card type must be one of: ${VALID_CARD_TYPES.join(', ')}`,
       });
     }
-    if (!VALID_VIEW_TYPES.includes(params.viewType as ViewType)) {
+    if (!isViewType(viewType)) {
       return err({
         type: 'INVALID_VIEW_TYPE',
         message: `View type must be one of: ${VALID_VIEW_TYPES.join(', ')}`,
@@ -104,10 +113,10 @@ export class BoardCard {
       new BoardCard({
         id: generateId(),
         userId: params.userId,
-        cardType: params.cardType as CardType,
+        cardType,
         refId: params.refId,
         dateKey: params.dateKey,
-        viewType: params.viewType as ViewType,
+        viewType,
         x: params.x,
         y: params.y,
         rotation: params.rotation,

--- a/apps/server/src/contexts/board/domain/models/board-card.ts
+++ b/apps/server/src/contexts/board/domain/models/board-card.ts
@@ -1,0 +1,187 @@
+import { err, ok, type Result } from '../../../shared/domain/types/result.js';
+
+const VALID_CARD_TYPES = ['entry', 'snippet'] as const;
+const VALID_VIEW_TYPES = ['daily', 'weekly'] as const;
+const MIN_SIZE = 120;
+
+type CardType = (typeof VALID_CARD_TYPES)[number];
+type ViewType = (typeof VALID_VIEW_TYPES)[number];
+
+type BoardCardError =
+  | { type: 'INVALID_CARD_TYPE'; message: string }
+  | { type: 'INVALID_VIEW_TYPE'; message: string }
+  | { type: 'INVALID_DIMENSIONS'; message: string }
+  | { type: 'MISSING_REF_ID'; message: string };
+
+interface BoardCardProps {
+  id: string;
+  userId: string;
+  cardType: CardType;
+  refId: string;
+  dateKey: string;
+  viewType: ViewType;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateBoardCardParams {
+  userId: string;
+  cardType: string;
+  refId: string;
+  dateKey: string;
+  viewType: string;
+  x: number;
+  y: number;
+  rotation: number;
+  width: number;
+  height: number;
+  zIndex: number;
+}
+
+export class BoardCard {
+  readonly id: string;
+  readonly userId: string;
+  readonly cardType: CardType;
+  readonly refId: string;
+  readonly dateKey: string;
+  readonly viewType: ViewType;
+  readonly x: number;
+  readonly y: number;
+  readonly rotation: number;
+  readonly width: number;
+  readonly height: number;
+  readonly zIndex: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  private constructor(props: BoardCardProps) {
+    this.id = props.id;
+    this.userId = props.userId;
+    this.cardType = props.cardType;
+    this.refId = props.refId;
+    this.dateKey = props.dateKey;
+    this.viewType = props.viewType;
+    this.x = props.x;
+    this.y = props.y;
+    this.rotation = props.rotation;
+    this.width = props.width;
+    this.height = props.height;
+    this.zIndex = props.zIndex;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static create(
+    params: CreateBoardCardParams,
+    generateId: () => string,
+  ): Result<BoardCard, BoardCardError> {
+    if (!VALID_CARD_TYPES.includes(params.cardType as CardType)) {
+      return err({
+        type: 'INVALID_CARD_TYPE',
+        message: `Card type must be one of: ${VALID_CARD_TYPES.join(', ')}`,
+      });
+    }
+    if (!VALID_VIEW_TYPES.includes(params.viewType as ViewType)) {
+      return err({
+        type: 'INVALID_VIEW_TYPE',
+        message: `View type must be one of: ${VALID_VIEW_TYPES.join(', ')}`,
+      });
+    }
+    if (!params.refId || params.refId.trim().length === 0) {
+      return err({ type: 'MISSING_REF_ID', message: 'refId must not be empty' });
+    }
+    const dimError = BoardCard.validateDimensions(params.width, params.height);
+    if (dimError) return err(dimError);
+
+    const now = new Date().toISOString();
+    return ok(
+      new BoardCard({
+        id: generateId(),
+        userId: params.userId,
+        cardType: params.cardType as CardType,
+        refId: params.refId,
+        dateKey: params.dateKey,
+        viewType: params.viewType as ViewType,
+        x: params.x,
+        y: params.y,
+        rotation: params.rotation,
+        width: params.width,
+        height: params.height,
+        zIndex: params.zIndex,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  static fromProps(props: BoardCardProps): BoardCard {
+    return new BoardCard(props);
+  }
+
+  withPosition(x: number, y: number, rotation: number): BoardCard {
+    return new BoardCard({
+      ...this.toProps(),
+      x,
+      y,
+      rotation,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  withDimensions(width: number, height: number): Result<BoardCard, BoardCardError> {
+    const dimError = BoardCard.validateDimensions(width, height);
+    if (dimError) return err(dimError);
+
+    return ok(
+      new BoardCard({
+        ...this.toProps(),
+        width,
+        height,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  }
+
+  withZIndex(zIndex: number): BoardCard {
+    return new BoardCard({
+      ...this.toProps(),
+      zIndex,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  toProps(): BoardCardProps {
+    return {
+      id: this.id,
+      userId: this.userId,
+      cardType: this.cardType,
+      refId: this.refId,
+      dateKey: this.dateKey,
+      viewType: this.viewType,
+      x: this.x,
+      y: this.y,
+      rotation: this.rotation,
+      width: this.width,
+      height: this.height,
+      zIndex: this.zIndex,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  private static validateDimensions(width: number, height: number): BoardCardError | null {
+    if (width < MIN_SIZE || height < MIN_SIZE) {
+      return {
+        type: 'INVALID_DIMENSIONS',
+        message: `Width and height must be at least ${MIN_SIZE}px`,
+      };
+    }
+    return null;
+  }
+}

--- a/apps/server/src/contexts/board/domain/models/board-snippet.ts
+++ b/apps/server/src/contexts/board/domain/models/board-snippet.ts
@@ -1,0 +1,95 @@
+import { err, ok, type Result } from '../../../shared/domain/types/result.js';
+
+const MAX_TEXT_LENGTH = 50;
+
+type BoardSnippetError =
+  | { type: 'EMPTY_TEXT'; message: string }
+  | { type: 'TEXT_TOO_LONG'; message: string };
+
+interface BoardSnippetProps {
+  id: string;
+  userId: string;
+  text: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateBoardSnippetParams {
+  userId: string;
+  text: string;
+}
+
+export class BoardSnippet {
+  readonly id: string;
+  readonly userId: string;
+  readonly text: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  private constructor(props: BoardSnippetProps) {
+    this.id = props.id;
+    this.userId = props.userId;
+    this.text = props.text;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static create(
+    params: CreateBoardSnippetParams,
+    generateId: () => string,
+  ): Result<BoardSnippet, BoardSnippetError> {
+    const textError = BoardSnippet.validateText(params.text);
+    if (textError) return err(textError);
+
+    const now = new Date().toISOString();
+    return ok(
+      new BoardSnippet({
+        id: generateId(),
+        userId: params.userId,
+        text: params.text,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
+  static fromProps(props: BoardSnippetProps): BoardSnippet {
+    return new BoardSnippet(props);
+  }
+
+  withText(text: string): Result<BoardSnippet, BoardSnippetError> {
+    const textError = BoardSnippet.validateText(text);
+    if (textError) return err(textError);
+
+    return ok(
+      new BoardSnippet({
+        ...this.toProps(),
+        text,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  }
+
+  toProps(): BoardSnippetProps {
+    return {
+      id: this.id,
+      userId: this.userId,
+      text: this.text,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  private static validateText(text: string): BoardSnippetError | null {
+    if (text.trim().length === 0) {
+      return { type: 'EMPTY_TEXT', message: 'Snippet text must not be empty' };
+    }
+    if (text.length > MAX_TEXT_LENGTH) {
+      return {
+        type: 'TEXT_TOO_LONG',
+        message: `Snippet text must not exceed ${MAX_TEXT_LENGTH} characters`,
+      };
+    }
+    return null;
+  }
+}

--- a/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-card.repository.ts
+++ b/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-card.repository.ts
@@ -36,6 +36,7 @@ export class SupabaseBoardCardRepository implements BoardCardRepositoryGateway {
       .eq('card_type', cardType);
 
     if (error) throw error;
+    // @type-assertion-allowed: Supabase row data is untyped Record<string, unknown>
     return (data ?? []).map((row: Record<string, unknown>) => row.ref_id as string);
   }
 
@@ -112,6 +113,7 @@ export class SupabaseBoardCardRepository implements BoardCardRepositoryGateway {
     if (error) throw error;
   }
 
+  // @type-assertion-allowed: Supabase row data is untyped Record<string, unknown>
   private toDomain(row: Record<string, unknown>): BoardCard {
     return BoardCard.fromProps({
       id: row.id as string,

--- a/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-card.repository.ts
+++ b/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-card.repository.ts
@@ -1,0 +1,133 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  BoardCardRepositoryGateway,
+  CardPositionUpdate,
+} from '../../domain/gateways/board-card-repository.gateway.js';
+import { BoardCard } from '../../domain/models/board-card.js';
+
+export class SupabaseBoardCardRepository implements BoardCardRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findByDateAndView(userId: string, dateKey: string, viewType: string): Promise<BoardCard[]> {
+    const { data, error } = await this.supabase
+      .from('board_cards')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('date_key', dateKey)
+      .eq('view_type', viewType)
+      .order('z_index', { ascending: true });
+
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
+  }
+
+  async findRefIdsByDateAndView(
+    userId: string,
+    dateKey: string,
+    viewType: string,
+    cardType: string,
+  ): Promise<string[]> {
+    const { data, error } = await this.supabase
+      .from('board_cards')
+      .select('ref_id')
+      .eq('user_id', userId)
+      .eq('date_key', dateKey)
+      .eq('view_type', viewType)
+      .eq('card_type', cardType);
+
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => row.ref_id as string);
+  }
+
+  async saveMany(cards: BoardCard[]): Promise<void> {
+    if (cards.length === 0) return;
+
+    const rows = cards.map((card) => {
+      const props = card.toProps();
+      return {
+        id: props.id,
+        user_id: props.userId,
+        card_type: props.cardType,
+        ref_id: props.refId,
+        date_key: props.dateKey,
+        view_type: props.viewType,
+        x: props.x,
+        y: props.y,
+        rotation: props.rotation,
+        width: props.width,
+        height: props.height,
+        z_index: props.zIndex,
+        created_at: props.createdAt,
+        updated_at: props.updatedAt,
+      };
+    });
+
+    const { error } = await this.supabase.from('board_cards').upsert(rows, {
+      onConflict: 'user_id,ref_id,date_key,view_type',
+      ignoreDuplicates: true,
+    });
+    if (error) throw error;
+  }
+
+  async updatePositions(cards: CardPositionUpdate[]): Promise<void> {
+    if (cards.length === 0) return;
+
+    const now = new Date().toISOString();
+    const promises = cards.map((card) =>
+      this.supabase
+        .from('board_cards')
+        .update({
+          x: card.x,
+          y: card.y,
+          rotation: card.rotation,
+          width: card.width,
+          height: card.height,
+          z_index: card.zIndex,
+          updated_at: now,
+        })
+        .eq('id', card.id),
+    );
+
+    const results = await Promise.all(promises);
+    for (const result of results) {
+      if (result.error) throw result.error;
+    }
+  }
+
+  async delete(id: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('board_cards')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId);
+    if (error) throw error;
+  }
+
+  async deleteByRefId(refId: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('board_cards')
+      .delete()
+      .eq('ref_id', refId)
+      .eq('user_id', userId);
+    if (error) throw error;
+  }
+
+  private toDomain(row: Record<string, unknown>): BoardCard {
+    return BoardCard.fromProps({
+      id: row.id as string,
+      userId: row.user_id as string,
+      cardType: row.card_type as 'entry' | 'snippet',
+      refId: row.ref_id as string,
+      dateKey: row.date_key as string,
+      viewType: row.view_type as 'daily' | 'weekly',
+      x: row.x as number,
+      y: row.y as number,
+      rotation: row.rotation as number,
+      width: row.width as number,
+      height: row.height as number,
+      zIndex: row.z_index as number,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    });
+  }
+}

--- a/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-snippet.repository.ts
+++ b/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-snippet.repository.ts
@@ -1,0 +1,66 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { BoardSnippetRepositoryGateway } from '../../domain/gateways/board-snippet-repository.gateway.js';
+import { BoardSnippet } from '../../domain/models/board-snippet.js';
+
+export class SupabaseBoardSnippetRepository implements BoardSnippetRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findById(id: string): Promise<BoardSnippet | null> {
+    const { data, error } = await this.supabase
+      .from('board_snippets')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) return null;
+    return this.toDomain(data);
+  }
+
+  async findByIds(ids: string[]): Promise<BoardSnippet[]> {
+    if (ids.length === 0) return [];
+
+    const { data, error } = await this.supabase.from('board_snippets').select('*').in('id', ids);
+
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
+  }
+
+  async save(snippet: BoardSnippet): Promise<void> {
+    const props = snippet.toProps();
+    const { error } = await this.supabase.from('board_snippets').insert({
+      id: props.id,
+      user_id: props.userId,
+      text: props.text,
+      created_at: props.createdAt,
+      updated_at: props.updatedAt,
+    });
+    if (error) throw error;
+  }
+
+  async update(snippet: BoardSnippet): Promise<void> {
+    const props = snippet.toProps();
+    const { error } = await this.supabase
+      .from('board_snippets')
+      .update({
+        text: props.text,
+        updated_at: props.updatedAt,
+      })
+      .eq('id', props.id);
+    if (error) throw error;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.supabase.from('board_snippets').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  private toDomain(row: Record<string, unknown>): BoardSnippet {
+    return BoardSnippet.fromProps({
+      id: row.id as string,
+      userId: row.user_id as string,
+      text: row.text as string,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    });
+  }
+}

--- a/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-snippet.repository.ts
+++ b/apps/server/src/contexts/board/infrastructure/repositories/supabase-board-snippet.repository.ts
@@ -54,6 +54,7 @@ export class SupabaseBoardSnippetRepository implements BoardSnippetRepositoryGat
     if (error) throw error;
   }
 
+  // @type-assertion-allowed: Supabase row data is untyped Record<string, unknown>
   private toDomain(row: Record<string, unknown>): BoardSnippet {
     return BoardSnippet.fromProps({
       id: row.id as string,

--- a/apps/server/src/contexts/board/presentation/routes/board.ts
+++ b/apps/server/src/contexts/board/presentation/routes/board.ts
@@ -1,0 +1,96 @@
+import {
+  boardCardUpdateSchema,
+  boardQuerySchema,
+  boardSnippetCreateSchema,
+  boardSnippetUpdateSchema,
+} from '@oryzae/shared';
+import { Hono } from 'hono';
+import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
+import { CreateBoardSnippetUsecase } from '../../application/usecases/create-board-snippet.usecase.js';
+import { DeleteBoardSnippetUsecase } from '../../application/usecases/delete-board-snippet.usecase.js';
+import { DeleteCardUsecase } from '../../application/usecases/delete-card.usecase.js';
+import { LoadBoardUsecase } from '../../application/usecases/load-board.usecase.js';
+import { SaveCardPositionsUsecase } from '../../application/usecases/save-card-positions.usecase.js';
+import { UpdateBoardSnippetUsecase } from '../../application/usecases/update-board-snippet.usecase.js';
+import { SupabaseBoardCardRepository } from '../../infrastructure/repositories/supabase-board-card.repository.js';
+import { SupabaseBoardSnippetRepository } from '../../infrastructure/repositories/supabase-board-snippet.repository.js';
+
+type Env = {
+  Variables: {
+    userId: string;
+    supabase: import('@supabase/supabase-js').SupabaseClient;
+  };
+};
+
+const generateId = () => crypto.randomUUID();
+
+export const board = new Hono<Env>()
+  // GET /api/v1/board?dateKey=YYYY-MM-DD
+  .get('/', async (c) => {
+    const { dateKey } = boardQuerySchema.parse({
+      dateKey: c.req.query('dateKey'),
+    });
+    const supabase = c.get('supabase');
+    const boardCardRepo = new SupabaseBoardCardRepository(supabase);
+    const boardSnippetRepo = new SupabaseBoardSnippetRepository(supabase);
+    const entryRepo = new SupabaseEntryRepository(supabase);
+    const usecase = new LoadBoardUsecase(boardCardRepo, boardSnippetRepo, entryRepo, generateId);
+
+    const result = await usecase.execute(c.get('userId'), dateKey);
+    return c.json(result);
+  })
+
+  // PUT /api/v1/board/cards
+  .put('/cards', async (c) => {
+    const body = boardCardUpdateSchema.parse(await c.req.json());
+    const supabase = c.get('supabase');
+    const boardCardRepo = new SupabaseBoardCardRepository(supabase);
+    const usecase = new SaveCardPositionsUsecase(boardCardRepo);
+
+    await usecase.execute(body.cards);
+    return c.json({ ok: true });
+  })
+
+  // DELETE /api/v1/board/cards/:id
+  .delete('/cards/:id', async (c) => {
+    const supabase = c.get('supabase');
+    const boardCardRepo = new SupabaseBoardCardRepository(supabase);
+    const usecase = new DeleteCardUsecase(boardCardRepo);
+
+    await usecase.execute(c.req.param('id'), c.get('userId'));
+    return c.json({ ok: true });
+  })
+
+  // POST /api/v1/board/snippets
+  .post('/snippets', async (c) => {
+    const body = boardSnippetCreateSchema.parse(await c.req.json());
+    const supabase = c.get('supabase');
+    const boardSnippetRepo = new SupabaseBoardSnippetRepository(supabase);
+    const boardCardRepo = new SupabaseBoardCardRepository(supabase);
+    const usecase = new CreateBoardSnippetUsecase(boardSnippetRepo, boardCardRepo, generateId);
+
+    const result = await usecase.execute(c.get('userId'), body);
+    return c.json(result, 201);
+  })
+
+  // PUT /api/v1/board/snippets/:id
+  .put('/snippets/:id', async (c) => {
+    const body = boardSnippetUpdateSchema.parse(await c.req.json());
+    const supabase = c.get('supabase');
+    const boardSnippetRepo = new SupabaseBoardSnippetRepository(supabase);
+    const usecase = new UpdateBoardSnippetUsecase(boardSnippetRepo);
+
+    await usecase.execute(c.req.param('id'), body.text);
+    return c.json({ ok: true });
+  })
+
+  // DELETE /api/v1/board/snippets/:id
+  .delete('/snippets/:id', async (c) => {
+    const supabase = c.get('supabase');
+    const boardSnippetRepo = new SupabaseBoardSnippetRepository(supabase);
+    const boardCardRepo = new SupabaseBoardCardRepository(supabase);
+    const usecase = new DeleteBoardSnippetUsecase(boardSnippetRepo, boardCardRepo);
+
+    await usecase.execute(c.req.param('id'), c.get('userId'));
+    return c.json({ ok: true });
+  });

--- a/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
@@ -2,6 +2,7 @@ import type { Entry } from '../models/entry.js';
 
 export interface EntryRepositoryGateway {
   findById(id: string): Promise<Entry | null>;
+  findByIds(ids: string[]): Promise<Entry[]>;
   listByUserId(userId: string, cursor?: string, limit?: number): Promise<Entry[]>;
   listByUserIdAndDate(userId: string, dateKey: string): Promise<Entry[]>;
   save(entry: Entry): Promise<void>;

--- a/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
@@ -3,6 +3,7 @@ import type { Entry } from '../models/entry.js';
 export interface EntryRepositoryGateway {
   findById(id: string): Promise<Entry | null>;
   listByUserId(userId: string, cursor?: string, limit?: number): Promise<Entry[]>;
+  listByUserIdAndDate(userId: string, dateKey: string): Promise<Entry[]>;
   save(entry: Entry): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -29,6 +29,24 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
     return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
+  async listByUserIdAndDate(userId: string, dateKey: string): Promise<Entry[]> {
+    const startOfDay = `${dateKey}T00:00:00.000Z`;
+    const nextDay = new Date(`${dateKey}T00:00:00.000Z`);
+    nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+    const endOfDay = nextDay.toISOString();
+
+    const { data, error } = await this.supabase
+      .from('entries')
+      .select('*')
+      .eq('user_id', userId)
+      .gte('created_at', startOfDay)
+      .lt('created_at', endOfDay)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
+  }
+
   async save(entry: Entry): Promise<void> {
     const props = entry.toProps();
     const { error } = await this.supabase.from('entries').upsert({

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -12,6 +12,13 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
     return this.toDomain(data);
   }
 
+  async findByIds(ids: string[]): Promise<Entry[]> {
+    if (ids.length === 0) return [];
+    const { data, error } = await this.supabase.from('entries').select('*').in('id', ids);
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
+  }
+
   async listByUserId(userId: string, cursor?: string, limit = 20): Promise<Entry[]> {
     let query = this.supabase
       .from('entries')

--- a/apps/server/test/contexts/board/application/usecases/create-board-snippet.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/create-board-snippet.usecase.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardSnippetValidationError } from '@/contexts/board/application/errors/board.errors';
+import { CreateBoardSnippetUsecase } from '@/contexts/board/application/usecases/create-board-snippet.usecase';
+import type { BoardCardRepositoryGateway } from '@/contexts/board/domain/gateways/board-card-repository.gateway';
+import type { BoardSnippetRepositoryGateway } from '@/contexts/board/domain/gateways/board-snippet-repository.gateway';
+
+const generateId = () => 'generated-id';
+
+let boardSnippetRepo: BoardSnippetRepositoryGateway;
+let boardCardRepo: BoardCardRepositoryGateway;
+let usecase: CreateBoardSnippetUsecase;
+
+beforeEach(() => {
+  boardSnippetRepo = {
+    findById: vi.fn().mockResolvedValue(null),
+    findByIds: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  boardCardRepo = {
+    findByDateAndView: vi.fn().mockResolvedValue([]),
+    findRefIdsByDateAndView: vi.fn().mockResolvedValue([]),
+    saveMany: vi.fn().mockResolvedValue(undefined),
+    updatePositions: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteByRefId: vi.fn().mockResolvedValue(undefined),
+  };
+  usecase = new CreateBoardSnippetUsecase(boardSnippetRepo, boardCardRepo, generateId);
+});
+
+describe('CreateBoardSnippetUsecase', () => {
+  it('snippet と card を同時作成できる', async () => {
+    const result = await usecase.execute('user-1', {
+      text: '重要な気づき',
+      dateKey: '2026-04-11',
+    });
+
+    expect(boardSnippetRepo.save).toHaveBeenCalled();
+    expect(boardCardRepo.saveMany).toHaveBeenCalled();
+    expect(result.text).toBe('重要な気づき');
+    expect(result.snippetId).toBe('generated-id');
+    expect(result.cardId).toBe('generated-id');
+  });
+
+  it('空テキストで BoardSnippetValidationError を投げる', async () => {
+    await expect(usecase.execute('user-1', { text: '', dateKey: '2026-04-11' })).rejects.toThrow(
+      BoardSnippetValidationError,
+    );
+  });
+
+  it('51文字超で BoardSnippetValidationError を投げる', async () => {
+    await expect(
+      usecase.execute('user-1', { text: 'a'.repeat(51), dateKey: '2026-04-11' }),
+    ).rejects.toThrow(BoardSnippetValidationError);
+  });
+});

--- a/apps/server/test/contexts/board/application/usecases/delete-board-snippet.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/delete-board-snippet.usecase.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteBoardSnippetUsecase } from '@/contexts/board/application/usecases/delete-board-snippet.usecase';
+import type { BoardCardRepositoryGateway } from '@/contexts/board/domain/gateways/board-card-repository.gateway';
+import type { BoardSnippetRepositoryGateway } from '@/contexts/board/domain/gateways/board-snippet-repository.gateway';
+
+let boardSnippetRepo: BoardSnippetRepositoryGateway;
+let boardCardRepo: BoardCardRepositoryGateway;
+let usecase: DeleteBoardSnippetUsecase;
+
+beforeEach(() => {
+  boardSnippetRepo = {
+    findById: vi.fn().mockResolvedValue(null),
+    findByIds: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  boardCardRepo = {
+    findByDateAndView: vi.fn().mockResolvedValue([]),
+    findRefIdsByDateAndView: vi.fn().mockResolvedValue([]),
+    saveMany: vi.fn().mockResolvedValue(undefined),
+    updatePositions: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteByRefId: vi.fn().mockResolvedValue(undefined),
+  };
+  usecase = new DeleteBoardSnippetUsecase(boardSnippetRepo, boardCardRepo);
+});
+
+describe('DeleteBoardSnippetUsecase', () => {
+  it('snippet と関連カードを同時削除する', async () => {
+    await usecase.execute('snippet-1', 'user-1');
+
+    expect(boardCardRepo.deleteByRefId).toHaveBeenCalledWith('snippet-1', 'user-1');
+    expect(boardSnippetRepo.delete).toHaveBeenCalledWith('snippet-1');
+  });
+});

--- a/apps/server/test/contexts/board/application/usecases/load-board.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/load-board.usecase.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
   };
   entryRepo = {
     findById: vi.fn().mockResolvedValue(null),
+    findByIds: vi.fn().mockResolvedValue([]),
     listByUserId: vi.fn().mockResolvedValue([]),
     listByUserIdAndDate: vi.fn().mockResolvedValue([]),
     save: vi.fn().mockResolvedValue(undefined),
@@ -70,7 +71,7 @@ describe('LoadBoardUsecase', () => {
     vi.mocked(boardCardRepo.findByDateAndView).mockResolvedValue([card]);
     vi.mocked(boardCardRepo.findRefIdsByDateAndView).mockResolvedValue(['entry-1']);
     vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
-    vi.mocked(entryRepo.findById).mockResolvedValue(entry);
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([entry]);
 
     const result = await usecase.execute('user-1', '2026-04-11');
 
@@ -96,7 +97,7 @@ describe('LoadBoardUsecase', () => {
     });
 
     vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
-    vi.mocked(entryRepo.findById).mockResolvedValue(entry);
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([entry]);
 
     const result = await usecase.execute('user-1', '2026-04-11');
 

--- a/apps/server/test/contexts/board/application/usecases/load-board.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/load-board.usecase.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoadBoardUsecase } from '@/contexts/board/application/usecases/load-board.usecase';
+import type { BoardCardRepositoryGateway } from '@/contexts/board/domain/gateways/board-card-repository.gateway';
+import type { BoardSnippetRepositoryGateway } from '@/contexts/board/domain/gateways/board-snippet-repository.gateway';
+import { BoardCard } from '@/contexts/board/domain/models/board-card';
+import { BoardSnippet } from '@/contexts/board/domain/models/board-snippet';
+import type { EntryRepositoryGateway } from '@/contexts/entry/domain/gateways/entry-repository.gateway';
+import { Entry } from '@/contexts/entry/domain/models/entry';
+
+const generateId = () => 'generated-id';
+
+let boardCardRepo: BoardCardRepositoryGateway;
+let boardSnippetRepo: BoardSnippetRepositoryGateway;
+let entryRepo: EntryRepositoryGateway;
+let usecase: LoadBoardUsecase;
+
+beforeEach(() => {
+  boardCardRepo = {
+    findByDateAndView: vi.fn().mockResolvedValue([]),
+    findRefIdsByDateAndView: vi.fn().mockResolvedValue([]),
+    saveMany: vi.fn().mockResolvedValue(undefined),
+    updatePositions: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteByRefId: vi.fn().mockResolvedValue(undefined),
+  };
+  boardSnippetRepo = {
+    findById: vi.fn().mockResolvedValue(null),
+    findByIds: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  entryRepo = {
+    findById: vi.fn().mockResolvedValue(null),
+    listByUserId: vi.fn().mockResolvedValue([]),
+    listByUserIdAndDate: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  usecase = new LoadBoardUsecase(boardCardRepo, boardSnippetRepo, entryRepo, generateId);
+});
+
+describe('LoadBoardUsecase', () => {
+  it('既存カードを返す', async () => {
+    const card = BoardCard.fromProps({
+      id: 'card-1',
+      userId: 'user-1',
+      cardType: 'entry',
+      refId: 'entry-1',
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      x: 100,
+      y: 200,
+      rotation: 0,
+      width: 340,
+      height: 280,
+      zIndex: 0,
+      createdAt: '2026-04-11T00:00:00Z',
+      updatedAt: '2026-04-11T00:00:00Z',
+    });
+    const entry = Entry.fromProps({
+      id: 'entry-1',
+      userId: 'user-1',
+      content: 'タイトル\n本文テキスト',
+      mediaUrls: [],
+      createdAt: '2026-04-11T10:00:00Z',
+      updatedAt: '2026-04-11T10:00:00Z',
+    });
+
+    vi.mocked(boardCardRepo.findByDateAndView).mockResolvedValue([card]);
+    vi.mocked(boardCardRepo.findRefIdsByDateAndView).mockResolvedValue(['entry-1']);
+    vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
+    vi.mocked(entryRepo.findById).mockResolvedValue(entry);
+
+    const result = await usecase.execute('user-1', '2026-04-11');
+
+    expect(result.dateKey).toBe('2026-04-11');
+    expect(result.viewType).toBe('daily');
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].id).toBe('card-1');
+    expect(result.cards[0].content).toEqual({
+      title: 'タイトル',
+      preview: 'タイトル\n本文テキスト',
+      createdAt: '2026-04-11T10:00:00Z',
+    });
+  });
+
+  it('カード未作成のエントリを自動追加する', async () => {
+    const entry = Entry.fromProps({
+      id: 'entry-new',
+      userId: 'user-1',
+      content: '新しいエントリ',
+      mediaUrls: [],
+      createdAt: '2026-04-11T10:00:00Z',
+      updatedAt: '2026-04-11T10:00:00Z',
+    });
+
+    vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
+    vi.mocked(entryRepo.findById).mockResolvedValue(entry);
+
+    const result = await usecase.execute('user-1', '2026-04-11');
+
+    expect(boardCardRepo.saveMany).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ refId: 'entry-new' })]),
+    );
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].cardType).toBe('entry');
+  });
+
+  it('既にカードがあるエントリは重複追加しない', async () => {
+    const entry = Entry.fromProps({
+      id: 'entry-1',
+      userId: 'user-1',
+      content: '既存',
+      mediaUrls: [],
+      createdAt: '2026-04-11T10:00:00Z',
+      updatedAt: '2026-04-11T10:00:00Z',
+    });
+
+    vi.mocked(boardCardRepo.findRefIdsByDateAndView).mockResolvedValue(['entry-1']);
+    vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
+
+    await usecase.execute('user-1', '2026-04-11');
+
+    expect(boardCardRepo.saveMany).not.toHaveBeenCalled();
+  });
+
+  it('snippet カードのコンテンツを hydrate する', async () => {
+    const card = BoardCard.fromProps({
+      id: 'card-s1',
+      userId: 'user-1',
+      cardType: 'snippet',
+      refId: 'snippet-1',
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      x: 500,
+      y: 200,
+      rotation: 2,
+      width: 260,
+      height: 150,
+      zIndex: 1,
+      createdAt: '2026-04-11T00:00:00Z',
+      updatedAt: '2026-04-11T00:00:00Z',
+    });
+    const snippet = BoardSnippet.fromProps({
+      id: 'snippet-1',
+      userId: 'user-1',
+      text: '重要な気づき',
+      createdAt: '2026-04-11T00:00:00Z',
+      updatedAt: '2026-04-11T00:00:00Z',
+    });
+
+    vi.mocked(boardCardRepo.findByDateAndView).mockResolvedValue([card]);
+    vi.mocked(boardSnippetRepo.findByIds).mockResolvedValue([snippet]);
+
+    const result = await usecase.execute('user-1', '2026-04-11');
+
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].content).toEqual({ text: '重要な気づき' });
+  });
+});

--- a/apps/server/test/contexts/board/application/usecases/save-card-positions.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/save-card-positions.usecase.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BoardCardValidationError } from '@/contexts/board/application/errors/board.errors';
+import { SaveCardPositionsUsecase } from '@/contexts/board/application/usecases/save-card-positions.usecase';
+import type { BoardCardRepositoryGateway } from '@/contexts/board/domain/gateways/board-card-repository.gateway';
+
+let boardCardRepo: BoardCardRepositoryGateway;
+let usecase: SaveCardPositionsUsecase;
+
+beforeEach(() => {
+  boardCardRepo = {
+    findByDateAndView: vi.fn().mockResolvedValue([]),
+    findRefIdsByDateAndView: vi.fn().mockResolvedValue([]),
+    saveMany: vi.fn().mockResolvedValue(undefined),
+    updatePositions: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteByRefId: vi.fn().mockResolvedValue(undefined),
+  };
+  usecase = new SaveCardPositionsUsecase(boardCardRepo);
+});
+
+describe('SaveCardPositionsUsecase', () => {
+  it('カード位置を一括更新できる', async () => {
+    const cards = [
+      { id: 'c-1', x: 100, y: 200, rotation: -3, width: 340, height: 280, zIndex: 1 },
+      { id: 'c-2', x: 500, y: 300, rotation: 2, width: 260, height: 150, zIndex: 2 },
+    ];
+
+    await usecase.execute(cards);
+
+    expect(boardCardRepo.updatePositions).toHaveBeenCalledWith(cards);
+  });
+
+  it('120px 未満のサイズで BoardCardValidationError を投げる', async () => {
+    const cards = [{ id: 'c-1', x: 100, y: 200, rotation: 0, width: 119, height: 280, zIndex: 1 }];
+
+    await expect(usecase.execute(cards)).rejects.toThrow(BoardCardValidationError);
+  });
+});

--- a/apps/server/test/contexts/board/application/usecases/update-board-snippet.usecase.test.ts
+++ b/apps/server/test/contexts/board/application/usecases/update-board-snippet.usecase.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BoardSnippetNotFoundError,
+  BoardSnippetValidationError,
+} from '@/contexts/board/application/errors/board.errors';
+import { UpdateBoardSnippetUsecase } from '@/contexts/board/application/usecases/update-board-snippet.usecase';
+import type { BoardSnippetRepositoryGateway } from '@/contexts/board/domain/gateways/board-snippet-repository.gateway';
+import { BoardSnippet } from '@/contexts/board/domain/models/board-snippet';
+
+let boardSnippetRepo: BoardSnippetRepositoryGateway;
+let usecase: UpdateBoardSnippetUsecase;
+
+beforeEach(() => {
+  boardSnippetRepo = {
+    findById: vi.fn().mockResolvedValue(null),
+    findByIds: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+  usecase = new UpdateBoardSnippetUsecase(boardSnippetRepo);
+});
+
+describe('UpdateBoardSnippetUsecase', () => {
+  it('snippet のテキストを更新できる', async () => {
+    const existing = BoardSnippet.fromProps({
+      id: 's-1',
+      userId: 'user-1',
+      text: 'オリジナル',
+      createdAt: '2026-04-11T00:00:00Z',
+      updatedAt: '2026-04-11T00:00:00Z',
+    });
+    vi.mocked(boardSnippetRepo.findById).mockResolvedValue(existing);
+
+    await usecase.execute('s-1', '更新後');
+
+    expect(boardSnippetRepo.update).toHaveBeenCalledWith(
+      expect.objectContaining({ text: '更新後' }),
+    );
+  });
+
+  it('存在しない snippet で BoardSnippetNotFoundError を投げる', async () => {
+    await expect(usecase.execute('no-exist', 'text')).rejects.toThrow(BoardSnippetNotFoundError);
+  });
+
+  it('空テキストで BoardSnippetValidationError を投げる', async () => {
+    const existing = BoardSnippet.fromProps({
+      id: 's-1',
+      userId: 'user-1',
+      text: 'オリジナル',
+      createdAt: '2026-04-11T00:00:00Z',
+      updatedAt: '2026-04-11T00:00:00Z',
+    });
+    vi.mocked(boardSnippetRepo.findById).mockResolvedValue(existing);
+
+    await expect(usecase.execute('s-1', '')).rejects.toThrow(BoardSnippetValidationError);
+  });
+});

--- a/apps/server/test/contexts/board/domain/models/board-card.test.ts
+++ b/apps/server/test/contexts/board/domain/models/board-card.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import { BoardCard } from '@/contexts/board/domain/models/board-card';
+
+const generateId = () => 'test-card-id';
+
+const validParams = {
+  userId: 'user-1',
+  cardType: 'entry',
+  refId: 'ref-1',
+  dateKey: '2026-04-11',
+  viewType: 'daily',
+  x: 100,
+  y: 200,
+  rotation: -3.5,
+  width: 340,
+  height: 280,
+  zIndex: 1,
+};
+
+describe('BoardCard', () => {
+  describe('create', () => {
+    it('有効なパラメータで BoardCard を作成できる', () => {
+      const result = BoardCard.create(validParams, generateId);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('test-card-id');
+        expect(result.value.userId).toBe('user-1');
+        expect(result.value.cardType).toBe('entry');
+        expect(result.value.refId).toBe('ref-1');
+        expect(result.value.dateKey).toBe('2026-04-11');
+        expect(result.value.viewType).toBe('daily');
+        expect(result.value.x).toBe(100);
+        expect(result.value.y).toBe(200);
+        expect(result.value.rotation).toBe(-3.5);
+        expect(result.value.width).toBe(340);
+        expect(result.value.height).toBe(280);
+        expect(result.value.zIndex).toBe(1);
+      }
+    });
+
+    it('snippet タイプでも作成できる', () => {
+      const result = BoardCard.create({ ...validParams, cardType: 'snippet' }, generateId);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.cardType).toBe('snippet');
+      }
+    });
+
+    it('weekly ビュータイプでも作成できる', () => {
+      const result = BoardCard.create({ ...validParams, viewType: 'weekly' }, generateId);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.viewType).toBe('weekly');
+      }
+    });
+
+    it('無効な cardType で INVALID_CARD_TYPE エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, cardType: 'invalid' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('INVALID_CARD_TYPE');
+      }
+    });
+
+    it('無効な viewType で INVALID_VIEW_TYPE エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, viewType: 'monthly' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('INVALID_VIEW_TYPE');
+      }
+    });
+
+    it('空の refId で MISSING_REF_ID エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, refId: '' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('MISSING_REF_ID');
+      }
+    });
+
+    it('空白のみの refId で MISSING_REF_ID エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, refId: '   ' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('MISSING_REF_ID');
+      }
+    });
+
+    it('width が 120 未満で INVALID_DIMENSIONS エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, width: 119 }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('INVALID_DIMENSIONS');
+      }
+    });
+
+    it('height が 120 未満で INVALID_DIMENSIONS エラーを返す', () => {
+      const result = BoardCard.create({ ...validParams, height: 119 }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('INVALID_DIMENSIONS');
+      }
+    });
+
+    it('width/height が 120 ちょうどなら成功する', () => {
+      const result = BoardCard.create({ ...validParams, width: 120, height: 120 }, generateId);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('fromProps / toProps', () => {
+    it('Props から復元し、同じ Props に変換できる', () => {
+      const props = {
+        id: 'c-1',
+        userId: 'u-1',
+        cardType: 'entry' as const,
+        refId: 'ref-1',
+        dateKey: '2026-04-11',
+        viewType: 'daily' as const,
+        x: 10,
+        y: 20,
+        rotation: 5,
+        width: 300,
+        height: 200,
+        zIndex: 3,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const card = BoardCard.fromProps(props);
+      expect(card.toProps()).toEqual(props);
+    });
+  });
+
+  describe('withPosition', () => {
+    const card = BoardCard.fromProps({
+      id: 'c-1',
+      userId: 'u-1',
+      cardType: 'entry',
+      refId: 'ref-1',
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      x: 10,
+      y: 20,
+      rotation: 0,
+      width: 300,
+      height: 200,
+      zIndex: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    it('位置を更新した新しい BoardCard を返す', () => {
+      const updated = card.withPosition(50, 60, -3);
+      expect(updated.x).toBe(50);
+      expect(updated.y).toBe(60);
+      expect(updated.rotation).toBe(-3);
+      expect(updated.id).toBe('c-1');
+    });
+
+    it('元の BoardCard は変更されない（イミュータブル）', () => {
+      card.withPosition(999, 999, 45);
+      expect(card.x).toBe(10);
+      expect(card.y).toBe(20);
+      expect(card.rotation).toBe(0);
+    });
+  });
+
+  describe('withDimensions', () => {
+    const card = BoardCard.fromProps({
+      id: 'c-1',
+      userId: 'u-1',
+      cardType: 'entry',
+      refId: 'ref-1',
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      x: 10,
+      y: 20,
+      rotation: 0,
+      width: 300,
+      height: 200,
+      zIndex: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    it('サイズを更新した新しい BoardCard を返す', () => {
+      const result = card.withDimensions(400, 350);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.width).toBe(400);
+        expect(result.value.height).toBe(350);
+      }
+    });
+
+    it('120 未満の width で INVALID_DIMENSIONS エラーを返す', () => {
+      const result = card.withDimensions(119, 200);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('INVALID_DIMENSIONS');
+      }
+    });
+
+    it('元の BoardCard は変更されない（イミュータブル）', () => {
+      card.withDimensions(500, 500);
+      expect(card.width).toBe(300);
+      expect(card.height).toBe(200);
+    });
+  });
+
+  describe('withZIndex', () => {
+    const card = BoardCard.fromProps({
+      id: 'c-1',
+      userId: 'u-1',
+      cardType: 'entry',
+      refId: 'ref-1',
+      dateKey: '2026-04-11',
+      viewType: 'daily',
+      x: 10,
+      y: 20,
+      rotation: 0,
+      width: 300,
+      height: 200,
+      zIndex: 1,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    it('zIndex を更新した新しい BoardCard を返す', () => {
+      const updated = card.withZIndex(10);
+      expect(updated.zIndex).toBe(10);
+      expect(updated.id).toBe('c-1');
+    });
+
+    it('元の BoardCard は変更されない（イミュータブル）', () => {
+      card.withZIndex(99);
+      expect(card.zIndex).toBe(1);
+    });
+  });
+});

--- a/apps/server/test/contexts/board/domain/models/board-snippet.test.ts
+++ b/apps/server/test/contexts/board/domain/models/board-snippet.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { BoardSnippet } from '@/contexts/board/domain/models/board-snippet';
+
+const generateId = () => 'test-snippet-id';
+
+describe('BoardSnippet', () => {
+  describe('create', () => {
+    it('有効なテキストで BoardSnippet を作成できる', () => {
+      const result = BoardSnippet.create({ userId: 'user-1', text: '重要な気づき' }, generateId);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('test-snippet-id');
+        expect(result.value.userId).toBe('user-1');
+        expect(result.value.text).toBe('重要な気づき');
+      }
+    });
+
+    it('空文字のテキストで EMPTY_TEXT エラーを返す', () => {
+      const result = BoardSnippet.create({ userId: 'user-1', text: '' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('EMPTY_TEXT');
+      }
+    });
+
+    it('空白のみのテキストで EMPTY_TEXT エラーを返す', () => {
+      const result = BoardSnippet.create({ userId: 'user-1', text: '   ' }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('EMPTY_TEXT');
+      }
+    });
+
+    it('51文字以上のテキストで TEXT_TOO_LONG エラーを返す', () => {
+      const longText = 'a'.repeat(51);
+      const result = BoardSnippet.create({ userId: 'user-1', text: longText }, generateId);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('TEXT_TOO_LONG');
+      }
+    });
+
+    it('50文字ちょうどのテキストは成功する', () => {
+      const maxText = 'a'.repeat(50);
+      const result = BoardSnippet.create({ userId: 'user-1', text: maxText }, generateId);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('fromProps / toProps', () => {
+    it('Props から復元し、同じ Props に変換できる', () => {
+      const props = {
+        id: 's-1',
+        userId: 'u-1',
+        text: 'テスト',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      };
+      const snippet = BoardSnippet.fromProps(props);
+      expect(snippet.toProps()).toEqual(props);
+    });
+  });
+
+  describe('withText', () => {
+    const snippet = BoardSnippet.fromProps({
+      id: 's-1',
+      userId: 'u-1',
+      text: 'オリジナル',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    it('テキストを更新した新しい BoardSnippet を返す', () => {
+      const result = snippet.withText('更新後');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.text).toBe('更新後');
+        expect(result.value.id).toBe('s-1');
+      }
+    });
+
+    it('空文字で EMPTY_TEXT エラーを返す', () => {
+      const result = snippet.withText('');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('EMPTY_TEXT');
+      }
+    });
+
+    it('51文字で TEXT_TOO_LONG エラーを返す', () => {
+      const result = snippet.withText('a'.repeat(51));
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('TEXT_TOO_LONG');
+      }
+    });
+
+    it('元の BoardSnippet は変更されない（イミュータブル）', () => {
+      snippet.withText('変更');
+      expect(snippet.text).toBe('オリジナル');
+    });
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,2 +1,8 @@
 export const MAX_CONTENT_LENGTH = 100_000;
 export const MAX_QUESTION_STRING_LENGTH = 64;
+
+// Board
+export const MAX_SNIPPET_TEXT_LENGTH = 50;
+export const MIN_CARD_SIZE = 120;
+export const BOARD_CARD_TYPES = ['entry', 'snippet'] as const;
+export const BOARD_VIEW_TYPES = ['daily', 'weekly'] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,17 @@
-export { MAX_CONTENT_LENGTH, MAX_QUESTION_STRING_LENGTH } from './constants.js';
-export { createEntrySchema, credentialsSchema, questionStringSchema } from './schemas.js';
+export {
+  BOARD_CARD_TYPES,
+  BOARD_VIEW_TYPES,
+  MAX_CONTENT_LENGTH,
+  MAX_QUESTION_STRING_LENGTH,
+  MAX_SNIPPET_TEXT_LENGTH,
+  MIN_CARD_SIZE,
+} from './constants.js';
+export {
+  boardCardUpdateSchema,
+  boardQuerySchema,
+  boardSnippetCreateSchema,
+  boardSnippetUpdateSchema,
+  createEntrySchema,
+  credentialsSchema,
+  questionStringSchema,
+} from './schemas.js';

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -16,3 +16,31 @@ export const credentialsSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6),
 });
+
+// Board schemas
+export const boardQuerySchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export const boardCardUpdateSchema = z.object({
+  cards: z.array(
+    z.object({
+      id: z.string().uuid(),
+      x: z.number(),
+      y: z.number(),
+      rotation: z.number(),
+      width: z.number().min(120),
+      height: z.number().min(120),
+      zIndex: z.number().int(),
+    }),
+  ),
+});
+
+export const boardSnippetCreateSchema = z.object({
+  text: z.string().min(1).max(50),
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export const boardSnippetUpdateSchema = z.object({
+  text: z.string().min(1).max(50),
+});

--- a/supabase/migrations/00005_create_board.sql
+++ b/supabase/migrations/00005_create_board.sql
@@ -1,0 +1,51 @@
+-- Board snippets (user-created short text notes)
+create table board_snippets (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  text text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table board_snippets enable row level security;
+create policy "board_snippets_own_data" on board_snippets
+  for all using (user_id = auth.uid());
+
+-- Board cards (layout/position metadata for each card on the canvas)
+create table board_cards (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  card_type text not null check (card_type in ('entry', 'snippet')),
+  ref_id uuid not null,
+  date_key text not null,
+  view_type text not null check (view_type in ('daily', 'weekly')),
+  x double precision not null default 0,
+  y double precision not null default 0,
+  rotation double precision not null default 0,
+  width double precision not null default 260,
+  height double precision not null default 200,
+  z_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_board_cards_user_date on board_cards(user_id, date_key, view_type);
+create unique index idx_board_cards_unique_ref on board_cards(user_id, ref_id, date_key, view_type);
+
+alter table board_cards enable row level security;
+create policy "board_cards_own_data" on board_cards
+  for all using (user_id = auth.uid());
+
+-- Clean up board_cards when an entry is deleted
+create or replace function cleanup_board_cards_on_entry_delete()
+returns trigger as $$
+begin
+  delete from board_cards where ref_id = old.id and card_type = 'entry';
+  return old;
+end;
+$$ language plpgsql security definer;
+
+create trigger trg_cleanup_board_cards_on_entry_delete
+  before delete on entries
+  for each row
+  execute function cleanup_board_cards_on_entry_delete();


### PR DESCRIPTION
## Summary
- 2Dキャンバス上でエントリやスニペットをカードとして自由に配置・操作できるBoard画面を追加
- Backend: board コンテキスト (DDD レイヤー完備) + 6 API エンドポイント + ドメイン/ユースケーステスト
- Frontend: board feature slice (3 hooks, 8 コンポーネント) + hooks テスト
- DB: `board_cards` + `board_snippets` テーブル (RLS付き、マイグレーション適用済み)

### 機能
- エントリカードの自動配置（その日のエントリがランダム位置で出現）
- スニペット（短文メモ）の作成/編集/削除
- カードのドラッグ/回転/リサイズ/削除
- カード位置の500msデバウンス自動保存
- 日付ナビゲーション（前日/翌日切り替え）
- サイドバーに Board ナビアイテム追加

## Test plan
- [x] `pnpm typecheck` — 全パス
- [x] `pnpm test` — server 33ファイル 132テスト + client 6ファイル 25テスト 全パス
- [x] `pnpm dep-cruise` — 違反なし
- [x] `pnpm knip` — 未使用コードなし
- [ ] `/board` にアクセスしてキャンバスが表示されることを確認
- [ ] エントリカードが自動配置されることを確認
- [ ] ドラッグ/回転/リサイズが動作することを確認
- [ ] スニペット作成/編集/削除が動作することを確認
- [ ] 日付ナビで前日/翌日切り替え確認
- [ ] リロード後もカード位置が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)