### PR TITLE
feat: jar画面グラフィック要素のフェードインアニメーション

### DIFF
--- a/apps/client/src/features/fermentation/components/jar-view.tsx
+++ b/apps/client/src/features/fermentation/components/jar-view.tsx
@@ -105,6 +105,7 @@ function QuestionCircleWithData({
   return (
     <div
       className={`transition-opacity duration-500 ${isHidden ? 'pointer-events-none opacity-0' : 'opacity-100'}`}
+      style={{ animation: 'fadeIn 0.5s ease-out forwards' }}
     >
       <QuestionCircle
         questionId={question.id}
@@ -246,7 +247,11 @@ export function JarView({
         className="pointer-events-none absolute inset-0 z-[1] h-full w-full"
         viewBox="0 0 1000 500"
         preserveAspectRatio="none"
-        style={{ opacity: zoomedId ? 0 : 1, transition: 'opacity 0.5s ease' }}
+        style={{
+          opacity: zoomedId ? 0 : 1,
+          transition: 'opacity 0.5s ease',
+          animation: 'fadeIn 0.5s ease-out forwards',
+        }}
       >
         {questions.slice(0, 3).map((q, i) => {
           const pos = CIRCLE_POSITIONS[i];
@@ -294,6 +299,7 @@ export function JarView({
           transform: 'translate(-50%, -55%)',
           width: '420px',
           height: '520px',
+          animation: 'fadeIn 0.5s ease-out forwards',
         }}
       >
         {/* Jar glow */}
@@ -456,7 +462,10 @@ export function JarView({
 
       {/* Question list (bottom center) */}
       {!zoomedId && (
-        <div className="absolute bottom-12 left-1/2 z-[30] flex -translate-x-1/2 flex-col items-center gap-2.5">
+        <div
+          className="absolute bottom-12 left-1/2 z-[30] flex -translate-x-1/2 flex-col items-center gap-2.5"
+          style={{ animation: 'fadeIn 0.5s ease-out forwards' }}
+        >
           <div
             className="h-6 w-px"
             style={{

--- a/apps/client/src/features/fermentation/components/question-circle.tsx
+++ b/apps/client/src/features/fermentation/components/question-circle.tsx
@@ -124,6 +124,10 @@ export function QuestionCircle({
           from { transform: translate(-50%, -50%) rotate(0deg); }
           to { transform: translate(-50%, -50%) rotate(360deg); }
         }
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
       `}</style>
 
       {/* Circle glow */}
@@ -208,7 +212,11 @@ export function QuestionCircle({
         }}
       >
         {hasData ? (
-          <>
+          <div
+            style={{
+              animation: 'fadeIn 0.5s ease-out forwards',
+            }}
+          >
             {/* Keywords with attached microbe */}
             {detail.keywords.slice(0, 5).map((kw, i) => {
               const pos = KEYWORD_POSITIONS[i] ?? { top: 35 + i * 12, left: 20 + i * 15 };
@@ -435,7 +443,7 @@ export function QuestionCircle({
                 </div>
               </div>
             )}
-          </>
+          </div>
         ) : (
           /* Empty state: floating microbes */
           EMPTY_MICROBE_POSITIONS.map((p, i) => {


### PR DESCRIPTION
## Summary
- jar画面の各種グラフィック要素（瓶、接続線、円形要素、キーワード、スニペット、手紙）にAPI読み出し後0.5秒のフェードインアニメーションを追加
- `fadeIn` CSS keyframe（opacity 0→1、0.5s ease-out）を使用
- question-circle内のコンテンツ要素はデータ取得完了後にフェードイン

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス
- [x] `pnpm dep-cruise` パス
- [x] `pnpm knip` パス

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)