### PR TITLE
feat: add admin dashboard with Vercel AI Gateway cost tracking

### DIFF
--- a/.claude/rules/client-architecture.md
+++ b/.claude/rules/client-architecture.md
@@ -4,9 +4,15 @@ paths:
   - "apps/client/src/**/*.tsx"
   - "apps/client/test/**/*.ts"
   - "apps/client/test/**/*.tsx"
+  - "apps/admin/src/**/*.ts"
+  - "apps/admin/src/**/*.tsx"
+  - "apps/admin/test/**/*.ts"
+  - "apps/admin/test/**/*.tsx"
 ---
 
-# クライアントアーキテクチャルール
+# フロントエンドアーキテクチャルール
+
+`apps/client`（ユーザー向け）と `apps/admin`（管理画面）の両方に適用される。
 
 設計の正は **`docs/client-architecture-guide.md`** を参照。
 テスト戦略の正は **`docs/client-testing-guide.md`** を参照。

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:        # 手動実行も可能
 
 jobs:
-  e2e:
-    name: Playwright E2E
+  e2e-client:
+    name: Playwright E2E (Client)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -38,6 +38,43 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-client
           path: apps/client/test-results/
+          retention-days: 7
+
+  e2e-admin:
+    name: Playwright E2E (Admin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @oryzae/admin exec playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: pnpm --filter @oryzae/admin exec playwright test
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-admin
+          path: apps/admin/test-results/
           retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,12 @@
 
 ```bash
 pnpm install                                # 依存インストール
-pnpm --filter @oryzae/client dev            # 起動 (port 3000, API 内蔵)
-pnpm typecheck                              # 型チェック（server + shared + client）
-pnpm test                                   # テスト実行（server + client）
+pnpm --filter @oryzae/client dev            # クライアント起動 (port 3000, API 内蔵)
+pnpm --filter @oryzae/admin dev             # 管理画面起動 (port 3001, API 内蔵)
+pnpm typecheck                              # 型チェック（server + shared + client + admin）
+pnpm test                                   # テスト実行（server + client + admin）
 pnpm lint                                   # Biome lint
-pnpm dep-cruise                             # アーキテクチャ依存チェック（server + client）
+pnpm dep-cruise                             # アーキテクチャ依存チェック（server + client + admin）
 pnpm knip                                   # デッドコード検出
 ```
 
@@ -29,14 +30,17 @@ pnpm knip                                   # デッドコード検出
 - domain: Result<T,E> で返す（throw 禁止）→ application: throw に変換
 - 1 ユースケース = 1 ファイル
 
-### Frontend (`apps/client`)
+### Frontend (`apps/client`, `apps/admin`)
 
-Feature-Sliced Architecture:
+両アプリとも同じ Feature-Sliced Architecture を採用:
 
 - `app/` — Next.js ページ（薄いラッパー、API 呼び出し禁止）
 - `features/` — 機能スライス（components, hooks, types）
 - `components/ui/` — 汎用 UI（feature 依存禁止）
 - `lib/` — 横断ユーティリティ
+
+`apps/client` はユーザー向け（port 3000）、`apps/admin` は管理画面（port 3001）。
+ガードレール・テスト戦略・アーキテクチャルールは完全に同一。
 
 ### Shared (`packages/shared`)
 

--- a/apps/admin/.dependency-cruiser.cjs
+++ b/apps/admin/.dependency-cruiser.cjs
@@ -1,0 +1,48 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    // === Feature isolation ===
+    {
+      name: 'feature-isolation',
+      comment: 'Features must not import from other features',
+      severity: 'error',
+      from: { path: '^src/features/([^/]+)' },
+      to: { path: '^src/features/([^/]+)', pathNot: '^src/features/$1' },
+    },
+
+    // === UI components independence ===
+    {
+      name: 'ui-components-independence',
+      comment: 'Shared UI components must not depend on features or app',
+      severity: 'error',
+      from: { path: '^src/components/' },
+      to: { path: '^src/(features|app)/' },
+    },
+
+    // === lib independence ===
+    {
+      name: 'lib-independence',
+      comment: 'lib/ is cross-cutting infra, must not depend on features/app/components',
+      severity: 'error',
+      from: { path: '^src/lib/' },
+      to: { path: '^src/(features|app|components)/' },
+    },
+
+    // === No circular dependencies ===
+    {
+      name: 'no-circular',
+      severity: 'error',
+      from: {},
+      to: { circular: true },
+    },
+  ],
+  options: {
+    doNotFollow: { path: 'node_modules' },
+    tsPreCompilationDeps: true,
+    tsConfig: { fileName: './tsconfig.json' },
+    enhancedResolveOptions: {
+      exportsFields: ['exports'],
+      conditionNames: ['import', 'require', 'node', 'default'],
+    },
+  },
+};

--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  transpilePackages: ['@oryzae/server'],
+  turbopack: {},
+};
+
+export default nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@oryzae/admin",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run test/",
+    "test:watch": "vitest",
+    "dep-cruise": "depcruise src --config .dependency-cruiser.cjs",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "dependencies": {
+    "@oryzae/server": "workspace:*",
+    "next": "16.2.2",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "dependency-cruiser": "^17.3.10",
+    "jsdom": "^26.0.0",
+    "postcss": "^8",
+    "tailwindcss": "^4",
+    "typescript": "^5",
+    "vitest": "^3.1.0"
+  }
+}

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command:
+      'pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/admin dev',
+    url: 'http://localhost:3001',
+    reuseExistingServer: !process.env.CI,
+    cwd: '../..',
+    timeout: 120000,
+  },
+});

--- a/apps/admin/postcss.config.mjs
+++ b/apps/admin/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/apps/admin/src/app/(auth)/login/page.tsx
+++ b/apps/admin/src/app/(auth)/login/page.tsx
@@ -1,0 +1,5 @@
+import { AdminLoginForm } from '@/features/auth/components/admin-login-form';
+
+export default function AdminLoginPage() {
+  return <AdminLoginForm />;
+}

--- a/apps/admin/src/app/(protected)/costs/page.tsx
+++ b/apps/admin/src/app/(protected)/costs/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { CostTable } from '@/features/cost-tracking/components/cost-table';
+import { useCostData } from '@/features/cost-tracking/hooks/use-cost-data';
+
+export default function CostsPage() {
+  const [page, setPage] = useState(1);
+  const { data, pagination, loading, error, refresh } = useCostData(page);
+
+  const totalPages = Math.ceil(pagination.total / pagination.limit);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Cost Tracking</h1>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="rounded border border-[var(--border)] px-3 py-1.5 text-sm text-[var(--muted)] hover:bg-gray-50 disabled:opacity-50"
+        >
+          {loading ? '更新中...' : '更新'}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {loading && data.length === 0 ? (
+        <p className="text-sm text-[var(--muted)]">読み込み中...</p>
+      ) : (
+        <>
+          <CostTable items={data} />
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="rounded border border-[var(--border)] px-3 py-1.5 text-sm disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span className="text-sm text-[var(--muted)]">
+                {page} / {totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="rounded border border-[var(--border)] px-3 py-1.5 text-sm disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/dashboard/page.tsx
+++ b/apps/admin/src/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { StatsCards } from '@/features/dashboard/components/stats-cards';
+import { useDashboardStats } from '@/features/dashboard/hooks/use-dashboard-stats';
+
+export default function DashboardPage() {
+  const { stats, loading, error, refresh } = useDashboardStats();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Dashboard</h1>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="rounded border border-[var(--border)] px-3 py-1.5 text-sm text-[var(--muted)] hover:bg-gray-50 disabled:opacity-50"
+        >
+          {loading ? '更新中...' : '更新'}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {stats ? (
+        <StatsCards stats={stats} />
+      ) : loading ? (
+        <p className="text-sm text-[var(--muted)]">読み込み中...</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { AdminSidebar } from '@/features/auth/components/admin-sidebar';
+import { useAdminAuth } from '@/features/auth/hooks/use-admin-auth';
+
+export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
+  const { auth, loading } = useAdminAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !auth) {
+      router.push('/login');
+    }
+  }, [loading, auth, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <p className="text-sm text-[var(--muted)]">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!auth) return null;
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <AdminSidebar />
+      <main className="flex-1 overflow-auto p-6">{children}</main>
+    </div>
+  );
+}

--- a/apps/admin/src/app/api/[...path]/route.ts
+++ b/apps/admin/src/app/api/[...path]/route.ts
@@ -1,0 +1,5 @@
+import app from '@oryzae/server';
+
+const handler = (req: Request) => app.fetch(req);
+
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH };

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1,0 +1,10 @@
+@import "tailwindcss";
+
+:root {
+  --bg: #f8fafc;
+  --fg: #1e293b;
+  --accent: #3b82f6;
+  --accent-light: rgba(59, 130, 246, 0.08);
+  --border: #e2e8f0;
+  --muted: #64748b;
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Oryzae Admin',
+  description: 'Oryzae 管理画面',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ja" className="h-full antialiased">
+      <body className="min-h-full flex flex-col bg-[var(--bg)] text-[var(--fg)]">{children}</body>
+    </html>
+  );
+}

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function RootPage() {
+  redirect('/dashboard');
+}

--- a/apps/admin/src/features/auth/components/admin-login-form.tsx
+++ b/apps/admin/src/features/auth/components/admin-login-form.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAdminAuth } from '../hooks/use-admin-auth';
+
+export function AdminLoginForm() {
+  const { login } = useAdminAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const err = await login(email, password);
+    if (err) {
+      setError(err);
+      setSubmitting(false);
+    } else {
+      router.push('/dashboard');
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4 p-8">
+        <h1 className="text-2xl font-semibold text-center">Oryzae Admin</h1>
+
+        {error && <p className="text-sm text-red-600 bg-red-50 p-2 rounded">{error}</p>}
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-[var(--muted)] mb-1">
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full rounded border border-[var(--border)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-[var(--muted)] mb-1">
+            パスワード
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full rounded border border-[var(--border)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full rounded bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting ? 'ログイン中...' : 'ログイン'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/admin/src/features/auth/components/admin-sidebar.tsx
+++ b/apps/admin/src/features/auth/components/admin-sidebar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAdminAuth } from '../hooks/use-admin-auth';
+
+const NAV_ITEMS = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/costs', label: 'Cost Tracking' },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAdminAuth();
+
+  function handleLogout() {
+    logout();
+    router.push('/login');
+  }
+
+  return (
+    <aside className="flex w-56 flex-col border-r border-[var(--border)] bg-white">
+      <div className="p-4 border-b border-[var(--border)]">
+        <h2 className="text-lg font-semibold">Oryzae Admin</h2>
+      </div>
+
+      <nav className="flex-1 p-2 space-y-1">
+        {NAV_ITEMS.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`block rounded px-3 py-2 text-sm ${
+              pathname === item.href
+                ? 'bg-[var(--accent-light)] text-[var(--accent)] font-medium'
+                : 'text-[var(--muted)] hover:bg-gray-50'
+            }`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+
+      <div className="p-2 border-t border-[var(--border)]">
+        <button
+          type="button"
+          onClick={handleLogout}
+          className="w-full rounded px-3 py-2 text-sm text-[var(--muted)] hover:bg-gray-50 text-left"
+        >
+          Logout
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/admin/src/features/auth/hooks/use-admin-auth.ts
+++ b/apps/admin/src/features/auth/hooks/use-admin-auth.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { type ApiClient, createApiClient } from '@/lib/api';
+import { clearTokens, getAccessToken, setTokens } from '@/lib/auth';
+
+interface AdminAuthState {
+  accessToken: string;
+  user: { id: string; email: string };
+}
+
+export function useAdminAuth() {
+  const [auth, setAuth] = useState<AdminAuthState | null>(null);
+  const [api, setApi] = useState<ApiClient | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const token = getAccessToken();
+    if (token) {
+      const client = createApiClient(token);
+      setApi(client);
+      // Verify token by calling an admin endpoint
+      client
+        .fetch('/api/v1/admin/dashboard/stats')
+        .then(async (res) => {
+          if (res.ok) {
+            // Token is valid and user is admin
+            const meRes = await client.fetch('/api/v1/auth/me');
+            if (meRes.ok) {
+              const meData = (await meRes.json()) as { user: { id: string; email: string } };
+              setAuth({ accessToken: token, user: meData.user });
+            } else {
+              clearTokens();
+            }
+          } else {
+            clearTokens();
+          }
+        })
+        .finally(() => setLoading(false));
+    } else {
+      setLoading(false);
+    }
+  }, []);
+
+  async function login(email: string, password: string): Promise<string | null> {
+    const client = createApiClient();
+    const res = await client.fetch('/api/v1/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      return data.error;
+    }
+    const data = (await res.json()) as {
+      user: { id: string; email: string };
+      session: { accessToken: string; refreshToken: string };
+    };
+
+    // Verify admin access
+    const adminClient = createApiClient(data.session.accessToken);
+    const adminRes = await adminClient.fetch('/api/v1/admin/dashboard/stats');
+    if (!adminRes.ok) {
+      return '管理者権限がありません';
+    }
+
+    setTokens(data.session.accessToken, data.session.refreshToken);
+    setAuth({ accessToken: data.session.accessToken, user: data.user });
+    setApi(adminClient);
+    return null;
+  }
+
+  function logout() {
+    clearTokens();
+    setAuth(null);
+    setApi(null);
+  }
+
+  return { auth, api, loading, login, logout };
+}

--- a/apps/admin/src/features/cost-tracking/components/cost-table.tsx
+++ b/apps/admin/src/features/cost-tracking/components/cost-table.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import type { CostItem } from '../hooks/use-cost-data';
+
+interface CostTableProps {
+  items: CostItem[];
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatCost(cost: number | undefined): string {
+  if (cost === undefined) return '-';
+  return `$${cost.toFixed(4)}`;
+}
+
+export function CostTable({ items }: CostTableProps) {
+  const totalCost = items.reduce((sum, item) => sum + (item.cost?.totalCost ?? 0), 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-[var(--border)] bg-white p-4">
+        <p className="text-sm text-[var(--muted)]">Page Total Cost</p>
+        <p className="text-2xl font-semibold">{formatCost(totalCost)}</p>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-[var(--border)]">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 border-b border-[var(--border)]">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium text-[var(--muted)]">Date</th>
+              <th className="px-4 py-3 text-left font-medium text-[var(--muted)]">User ID</th>
+              <th className="px-4 py-3 text-left font-medium text-[var(--muted)]">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-[var(--muted)]">Input Tokens</th>
+              <th className="px-4 py-3 text-right font-medium text-[var(--muted)]">
+                Output Tokens
+              </th>
+              <th className="px-4 py-3 text-right font-medium text-[var(--muted)]">Cost</th>
+              <th className="px-4 py-3 text-right font-medium text-[var(--muted)]">Latency</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-[var(--border)]">
+            {items.map((item) => (
+              <tr key={item.id} className="hover:bg-gray-50">
+                <td className="px-4 py-3 whitespace-nowrap">{formatDate(item.created_at)}</td>
+                <td className="px-4 py-3 font-mono text-xs">{item.user_id.slice(0, 8)}...</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${
+                      item.status === 'completed'
+                        ? 'bg-green-50 text-green-700'
+                        : item.status === 'failed'
+                          ? 'bg-red-50 text-red-700'
+                          : 'bg-yellow-50 text-yellow-700'
+                    }`}
+                  >
+                    {item.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right font-mono">
+                  {item.cost?.promptTokens?.toLocaleString() ?? '-'}
+                </td>
+                <td className="px-4 py-3 text-right font-mono">
+                  {item.cost?.completionTokens?.toLocaleString() ?? '-'}
+                </td>
+                <td className="px-4 py-3 text-right font-mono font-medium">
+                  {formatCost(item.cost?.totalCost)}
+                </td>
+                <td className="px-4 py-3 text-right font-mono">
+                  {item.cost?.latency ? `${item.cost.latency}ms` : '-'}
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-[var(--muted)]">
+                  コスト追跡データがありません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/cost-tracking/hooks/use-cost-data.ts
+++ b/apps/admin/src/features/cost-tracking/hooks/use-cost-data.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+export interface CostItem {
+  id: string;
+  user_id: string;
+  status: string;
+  generation_id: string | null;
+  created_at: string;
+  cost: {
+    totalCost: number;
+    promptTokens: number;
+    completionTokens: number;
+    latency: number;
+  } | null;
+}
+
+interface CostDataResponse {
+  data: CostItem[];
+  pagination: { page: number; limit: number; total: number };
+}
+
+export function useCostData(page = 1, limit = 20) {
+  const [data, setData] = useState<CostItem[]>([]);
+  const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCosts = useCallback(async () => {
+    const token = getAccessToken();
+    if (!token) return;
+
+    setLoading(true);
+    setError(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch(`/api/v1/admin/fermentations/costs?page=${page}&limit=${limit}`);
+    if (res.ok) {
+      const body = (await res.json()) as CostDataResponse;
+      setData(body.data);
+      setPagination(body.pagination);
+    } else {
+      setError('コストデータの取得に失敗しました');
+    }
+    setLoading(false);
+  }, [page, limit]);
+
+  useEffect(() => {
+    fetchCosts();
+  }, [fetchCosts]);
+
+  return { data, pagination, loading, error, refresh: fetchCosts };
+}

--- a/apps/admin/src/features/dashboard/components/stats-cards.tsx
+++ b/apps/admin/src/features/dashboard/components/stats-cards.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { DashboardStats } from '../hooks/use-dashboard-stats';
+
+interface StatsCardsProps {
+  stats: DashboardStats;
+}
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-white p-6">
+      <p className="text-sm text-[var(--muted)]">{label}</p>
+      <p className="mt-1 text-3xl font-semibold">{value.toLocaleString()}</p>
+    </div>
+  );
+}
+
+export function StatsCards({ stats }: StatsCardsProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard label="Total Users" value={stats.totalUsers} />
+      <StatCard label="Total Entries" value={stats.totalEntries} />
+      <StatCard label="Total Fermentations" value={stats.totalFermentations} />
+      <StatCard label="With Cost Tracking" value={stats.fermentationsWithCostTracking} />
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/hooks/use-dashboard-stats.ts
+++ b/apps/admin/src/features/dashboard/hooks/use-dashboard-stats.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+export interface DashboardStats {
+  totalUsers: number;
+  totalEntries: number;
+  totalFermentations: number;
+  fermentationsWithCostTracking: number;
+}
+
+export function useDashboardStats() {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    const token = getAccessToken();
+    if (!token) return;
+
+    setLoading(true);
+    setError(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/admin/dashboard/stats');
+    if (res.ok) {
+      const data = (await res.json()) as DashboardStats;
+      setStats(data);
+    } else {
+      setError('統計情報の取得に失敗しました');
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  return { stats, loading, error, refresh: fetchStats };
+}

--- a/apps/admin/src/lib/api.ts
+++ b/apps/admin/src/lib/api.ts
@@ -1,0 +1,23 @@
+export interface ApiClient {
+  headers: Record<string, string>;
+  fetch(path: string, init?: RequestInit): Promise<Response>;
+}
+
+export function createApiClient(accessToken?: string): ApiClient {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return {
+    headers,
+    fetch(path: string, init?: RequestInit) {
+      return fetch(path, {
+        ...init,
+        headers: { ...headers, ...init?.headers },
+      });
+    },
+  };
+}

--- a/apps/admin/src/lib/auth.ts
+++ b/apps/admin/src/lib/auth.ts
@@ -1,0 +1,17 @@
+const TOKEN_KEY = 'oryzae_admin_access_token';
+const REFRESH_TOKEN_KEY = 'oryzae_admin_refresh_token';
+
+export function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setTokens(accessToken: string, refreshToken: string): void {
+  localStorage.setItem(TOKEN_KEY, accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+}
+
+export function clearTokens(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}

--- a/apps/admin/test/features/auth/hooks/use-admin-auth.test.ts
+++ b/apps/admin/test/features/auth/hooks/use-admin-auth.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAdminAuth } from '@/features/auth/hooks/use-admin-auth';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 400,
+  } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
+}
+
+describe('useAdminAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('resolves to loading false and auth null when no token stored', async () => {
+    const { result } = renderHook(() => useAdminAuth());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.auth).toBeNull();
+    expect(result.current.api).toBeNull();
+  });
+
+  it('login returns null on success and stores tokens', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt' };
+    const user = { id: 'u1', email: 'admin@test.com' };
+
+    // 1st call: login
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
+    // 2nd call: admin verification
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { totalUsers: 1 }));
+
+    const { result } = renderHook(() => useAdminAuth());
+
+    let loginResult: string | null = null;
+    await act(async () => {
+      loginResult = await result.current.login('admin@test.com', 'pass');
+    });
+
+    expect(loginResult).toBeNull();
+    expect(localStorage.getItem('oryzae_admin_access_token')).toBe('at');
+    expect(result.current.auth?.user.email).toBe('admin@test.com');
+  });
+
+  it('login returns error when credentials are wrong', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(false, { error: 'Invalid credentials' }));
+
+    const { result } = renderHook(() => useAdminAuth());
+
+    let loginResult: string | null = null;
+    await act(async () => {
+      loginResult = await result.current.login('a@b.com', 'wrong');
+    });
+
+    expect(loginResult).toBe('Invalid credentials');
+    expect(result.current.auth).toBeNull();
+  });
+
+  it('login returns error when user is not admin', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt' };
+    const user = { id: 'u1', email: 'user@test.com' };
+
+    // Login succeeds
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
+    // But admin verification fails (403)
+    mockFetch.mockResolvedValueOnce(mockResponse(false, { error: 'Admin access required' }));
+
+    const { result } = renderHook(() => useAdminAuth());
+
+    let loginResult: string | null = null;
+    await act(async () => {
+      loginResult = await result.current.login('user@test.com', 'pass');
+    });
+
+    expect(loginResult).toBe('管理者権限がありません');
+    expect(result.current.auth).toBeNull();
+  });
+
+  it('logout clears auth and tokens', async () => {
+    const session = { accessToken: 'at', refreshToken: 'rt' };
+    const user = { id: 'u1', email: 'admin@test.com' };
+
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { totalUsers: 1 }));
+
+    const { result } = renderHook(() => useAdminAuth());
+
+    await act(async () => {
+      await result.current.login('admin@test.com', 'pass');
+    });
+
+    expect(result.current.auth).not.toBeNull();
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(result.current.auth).toBeNull();
+    expect(localStorage.getItem('oryzae_admin_access_token')).toBeNull();
+  });
+});

--- a/apps/admin/test/features/cost-tracking/hooks/use-cost-data.test.ts
+++ b/apps/admin/test/features/cost-tracking/hooks/use-cost-data.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCostData } from '@/features/cost-tracking/hooks/use-cost-data';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 500,
+  } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
+}
+
+describe('useCostData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_admin_access_token', 'test-token');
+  });
+
+  it('fetches cost data on mount', async () => {
+    const responseBody = {
+      data: [
+        {
+          id: 'f1',
+          user_id: 'u1',
+          status: 'completed',
+          generation_id: 'gen_123',
+          created_at: '2026-04-11T10:00:00Z',
+          cost: { totalCost: 0.05, promptTokens: 1000, completionTokens: 500, latency: 2000 },
+        },
+      ],
+      pagination: { page: 1, limit: 20, total: 1 },
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse(true, responseBody));
+
+    const { result } = renderHook(() => useCostData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data[0].cost?.totalCost).toBe(0.05);
+    expect(result.current.pagination.total).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on fetch failure', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(false, { error: 'Server error' }));
+
+    const { result } = renderHook(() => useCostData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBe('コストデータの取得に失敗しました');
+  });
+
+  it('passes page and limit to API', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(true, { data: [], pagination: { page: 2, limit: 10, total: 0 } }),
+    );
+
+    renderHook(() => useCostData(2, 10));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('page=2');
+    expect(calledUrl).toContain('limit=10');
+  });
+
+  it('does nothing when no token is stored', async () => {
+    localStorage.clear();
+
+    const { result } = renderHook(() => useCostData());
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/apps/admin/test/features/dashboard/hooks/use-dashboard-stats.test.ts
+++ b/apps/admin/test/features/dashboard/hooks/use-dashboard-stats.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDashboardStats } from '@/features/dashboard/hooks/use-dashboard-stats';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 500,
+  } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
+}
+
+describe('useDashboardStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_admin_access_token', 'test-token');
+  });
+
+  it('fetches stats on mount', async () => {
+    const stats = {
+      totalUsers: 10,
+      totalEntries: 50,
+      totalFermentations: 20,
+      fermentationsWithCostTracking: 5,
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse(true, stats));
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toEqual(stats);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on fetch failure', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(false, { error: 'Unauthorized' }));
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toBeNull();
+    expect(result.current.error).toBe('統計情報の取得に失敗しました');
+  });
+
+  it('does nothing when no token is stored', async () => {
+    localStorage.clear();
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    // Should remain in loading state since fetch is never called
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.stats).toBeNull();
+  });
+});

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    root: '.',
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,4 +1,5 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+AI_GATEWAY_API_KEY=your-ai-gateway-api-key
 PORT=3000

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,7 +22,6 @@
     "dep-cruise": "depcruise src --config .dependency-cruiser.cjs"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.67",
     "@hono/node-server": "^1.14.0",
     "@oryzae/shared": "workspace:*",
     "@supabase/supabase-js": "^2.49.0",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,17 +1,23 @@
 import { Hono } from 'hono';
 import { board } from './contexts/board/presentation/routes/board.js';
 import { entries } from './contexts/entry/presentation/routes/entries.js';
+import { adminFermentations } from './contexts/fermentation/presentation/routes/admin-fermentations.js';
 import { fermentations } from './contexts/fermentation/presentation/routes/fermentations.js';
 import { entryQuestions } from './contexts/question/presentation/routes/entry-questions.js';
 import { questions } from './contexts/question/presentation/routes/questions.js';
+import { adminAuthMiddleware } from './contexts/shared/presentation/middleware/admin-auth.js';
 import { authMiddleware } from './contexts/shared/presentation/middleware/auth.js';
 import { errorHandler } from './contexts/shared/presentation/middleware/error-handler.js';
+import { adminDashboard } from './contexts/shared/presentation/routes/admin-dashboard.js';
 import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
 
 const app = new Hono()
   .onError(errorHandler)
   .get('/health', (c) => c.json({ status: 'ok' }))
   .route('/api/v1/auth', authRoutes)
+  .use('/api/v1/admin/*', adminAuthMiddleware)
+  .route('/api/v1/admin/dashboard', adminDashboard)
+  .route('/api/v1/admin/fermentations', adminFermentations)
   .use('/api/v1/*', authMiddleware)
   .route('/api/v1/board', board)
   .route('/api/v1/entries', entries)

--- a/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
@@ -48,11 +48,18 @@ export class RunFermentationUsecase {
 
     try {
       // 3. Run LLM analysis
-      const output = await this.llmGateway.analyze({
+      const { output, generationId } = await this.llmGateway.analyze({
         question: params.questionText,
         entryContent: params.entryContent,
         targetPeriod,
+        userId: params.userId,
       });
+
+      // 3.5. Save generation ID for cost tracking
+      if (generationId) {
+        const withGen = fermentationResult.withGenerationId(generationId);
+        await this.fermentationRepo.update(withGen);
+      }
 
       // 4. Save all results
       const worksheet = AnalysisWorksheet.create(

--- a/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
@@ -11,10 +11,22 @@ export interface FermentationOutput {
   keywords: { keyword: string; description: string }[];
 }
 
+export interface LlmUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface LlmAnalysisResult {
+  output: FermentationOutput;
+  usage: LlmUsage;
+  generationId: string | undefined;
+}
+
 export interface LlmAnalysisGateway {
   analyze(params: {
     question: string;
     entryContent: string;
     targetPeriod: string;
-  }): Promise<FermentationOutput>;
+    userId: string;
+  }): Promise<LlmAnalysisResult>;
 }

--- a/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
@@ -11,6 +11,7 @@ export interface FermentationResultProps {
   entryId: string;
   targetPeriod: string;
   status: FermentationStatus;
+  generationId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -31,6 +32,7 @@ export class FermentationResult {
   readonly entryId: string;
   readonly targetPeriod: string;
   readonly status: FermentationStatus;
+  readonly generationId: string | null;
   readonly createdAt: string;
   readonly updatedAt: string;
 
@@ -41,6 +43,7 @@ export class FermentationResult {
     this.entryId = props.entryId;
     this.targetPeriod = props.targetPeriod;
     this.status = props.status;
+    this.generationId = props.generationId;
     this.createdAt = props.createdAt;
     this.updatedAt = props.updatedAt;
   }
@@ -60,6 +63,7 @@ export class FermentationResult {
         entryId: params.entryId,
         targetPeriod: params.targetPeriod,
         status: 'pending',
+        generationId: null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       }),
@@ -77,6 +81,10 @@ export class FermentationResult {
     return ok(new FermentationResult({ ...this.toProps(), status }));
   }
 
+  withGenerationId(generationId: string): FermentationResult {
+    return new FermentationResult({ ...this.toProps(), generationId });
+  }
+
   toProps(): FermentationResultProps {
     return {
       id: this.id,
@@ -85,6 +93,7 @@ export class FermentationResult {
       entryId: this.entryId,
       targetPeriod: this.targetPeriod,
       status: this.status,
+      generationId: this.generationId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
@@ -1,9 +1,8 @@
-import { anthropic } from '@ai-sdk/anthropic';
-import { generateObject } from 'ai';
+import { gateway, generateObject } from 'ai';
 import { z } from 'zod';
 import type {
-  FermentationOutput,
   LlmAnalysisGateway,
+  LlmAnalysisResult,
 } from '../../domain/gateways/llm-analysis.gateway.js';
 
 const fermentationSchema = z.object({
@@ -73,14 +72,31 @@ export class VercelAiAnalysisGateway implements LlmAnalysisGateway {
     question: string;
     entryContent: string;
     targetPeriod: string;
-  }): Promise<FermentationOutput> {
-    const { object } = await generateObject({
-      model: anthropic('claude-sonnet-4-20250514'),
+    userId: string;
+  }): Promise<LlmAnalysisResult> {
+    const { object, usage, providerMetadata } = await generateObject({
+      model: gateway('anthropic/claude-sonnet-4-20250514'),
       prompt: buildPrompt(params),
       schema: fermentationSchema,
       maxOutputTokens: 16000,
+      providerOptions: {
+        gateway: {
+          user: params.userId,
+          tags: ['fermentation'],
+        },
+      },
     });
 
-    return object;
+    // @type-assertion-allowed: providerMetadata の gateway 型は AI SDK の型定義に含まれない
+    const meta = providerMetadata as { gateway?: { generationId?: string } } | undefined;
+
+    return {
+      output: object,
+      usage: {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+      },
+      generationId: meta?.gateway?.generationId,
+    };
   }
 }

--- a/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
@@ -31,7 +31,11 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
     const props = result.toProps();
     const { error } = await this.supabase
       .from('fermentation_results')
-      .update({ status: props.status, updated_at: new Date().toISOString() })
+      .update({
+        status: props.status,
+        generation_id: props.generationId,
+        updated_at: new Date().toISOString(),
+      })
       .eq('id', props.id);
     if (error) throw new Error(`Failed to update fermentation result: ${error.message}`);
   }
@@ -50,6 +54,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       entryId: data.entry_id,
       targetPeriod: data.target_period,
       status: data.status,
+      generationId: data.generation_id ?? null,
       createdAt: data.created_at,
       updatedAt: data.updated_at,
     });
@@ -133,6 +138,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         entryId: row.entry_id,
         targetPeriod: row.target_period,
         status: row.status as 'pending' | 'processing' | 'completed' | 'failed',
+        generationId: row.generation_id ?? null,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
       }),

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -1,0 +1,89 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { gateway } from 'ai';
+import { Hono } from 'hono';
+
+type Env = {
+  Variables: {
+    adminUserId: string;
+    adminSupabase: SupabaseClient;
+  };
+};
+
+export const adminFermentations = new Hono<Env>()
+  .get('/', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const page = Number(c.req.query('page') ?? '1');
+    const limit = Number(c.req.query('limit') ?? '50');
+    const offset = (page - 1) * limit;
+
+    const { data, error, count } = await supabase
+      .from('fermentation_results')
+      .select(
+        'id, user_id, question_id, entry_id, target_period, status, generation_id, created_at, updated_at',
+        { count: 'exact' },
+      )
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) return c.json({ error: error.message }, 500);
+
+    return c.json({
+      data: data ?? [],
+      pagination: { page, limit, total: count ?? 0 },
+    });
+  })
+  .get('/:id/cost', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const id = c.req.param('id');
+
+    const { data, error } = await supabase
+      .from('fermentation_results')
+      .select('generation_id')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) return c.json({ error: 'Fermentation result not found' }, 404);
+
+    if (!data.generation_id) {
+      return c.json({ error: 'No generation ID available for cost tracking' }, 404);
+    }
+
+    const info = await gateway.getGenerationInfo({ id: data.generation_id });
+
+    return c.json({
+      fermentationResultId: id,
+      generationId: data.generation_id,
+      cost: info,
+    });
+  })
+  .get('/costs', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const page = Number(c.req.query('page') ?? '1');
+    const limit = Number(c.req.query('limit') ?? '50');
+    const offset = (page - 1) * limit;
+
+    const { data, error, count } = await supabase
+      .from('fermentation_results')
+      .select('id, user_id, status, generation_id, created_at', { count: 'exact' })
+      .not('generation_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) return c.json({ error: error.message }, 500);
+
+    const items = await Promise.all(
+      (data ?? []).map(async (row) => {
+        try {
+          const info = await gateway.getGenerationInfo({ id: row.generation_id });
+          return { ...row, cost: info };
+        } catch {
+          return { ...row, cost: null };
+        }
+      }),
+    );
+
+    return c.json({
+      data: items,
+      pagination: { page, limit, total: count ?? 0 },
+    });
+  });

--- a/apps/server/src/contexts/shared/presentation/middleware/admin-auth.ts
+++ b/apps/server/src/contexts/shared/presentation/middleware/admin-auth.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Context, Next } from 'hono';
+import { getSupabaseClient } from '../../infrastructure/supabase-client.js';
+
+export async function adminAuthMiddleware(c: Context, next: Next) {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
+  }
+
+  const token = authHeader.slice(7);
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return c.json({ error: 'Server configuration error' }, 500);
+  }
+
+  const userSupabase = createClient(url, anonKey, {
+    global: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+
+  const {
+    data: { user },
+    error,
+  } = await userSupabase.auth.getUser();
+
+  if (error || !user) {
+    return c.json({ error: 'Invalid or expired token' }, 401);
+  }
+
+  const isAdmin = user.user_metadata?.is_admin === true;
+  if (!isAdmin) {
+    return c.json({ error: 'Admin access required' }, 403);
+  }
+
+  c.set('adminUserId', user.id);
+  c.set('adminSupabase', getSupabaseClient());
+
+  await next();
+}

--- a/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
@@ -1,0 +1,30 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { Hono } from 'hono';
+
+type Env = {
+  Variables: {
+    adminUserId: string;
+    adminSupabase: SupabaseClient;
+  };
+};
+
+export const adminDashboard = new Hono<Env>().get('/stats', async (c) => {
+  const supabase = c.get('adminSupabase');
+
+  const [usersRes, entriesRes, fermentationsRes, fermentationsWithCostRes] = await Promise.all([
+    supabase.auth.admin.listUsers({ page: 1, perPage: 1 }),
+    supabase.from('entries').select('id', { count: 'exact', head: true }),
+    supabase.from('fermentation_results').select('id', { count: 'exact', head: true }),
+    supabase
+      .from('fermentation_results')
+      .select('id', { count: 'exact', head: true })
+      .not('generation_id', 'is', null),
+  ]);
+
+  return c.json({
+    totalUsers: usersRes.data?.users?.length ?? 0,
+    totalEntries: entriesRes.count ?? 0,
+    totalFermentations: fermentationsRes.count ?? 0,
+    fermentationsWithCostTracking: fermentationsWithCostRes.count ?? 0,
+  });
+});

--- a/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
@@ -22,11 +22,15 @@ function mockRepo(): FermentationRepositoryGateway {
 function mockLlm(): LlmAnalysisGateway {
   return {
     analyze: vi.fn().mockResolvedValue({
-      worksheetMarkdown: '### Worksheet',
-      resultDiagramMarkdown: '### Diagram',
-      snippets: [{ type: 'core', text: 'test text', sourceDate: '12/1', reason: 'test reason' }],
-      letterBody: 'Dear user...',
-      keywords: [{ keyword: 'test', description: 'a test keyword' }],
+      output: {
+        worksheetMarkdown: '### Worksheet',
+        resultDiagramMarkdown: '### Diagram',
+        snippets: [{ type: 'core', text: 'test text', sourceDate: '12/1', reason: 'test reason' }],
+        letterBody: 'Dear user...',
+        keywords: [{ keyword: 'test', description: 'a test keyword' }],
+      },
+      usage: { inputTokens: 100, outputTokens: 200 },
+      generationId: 'gen_test123',
     }),
   };
 }
@@ -47,7 +51,7 @@ describe('RunFermentationUsecase', () => {
 
     expect(result.id).toBe('test-id');
     expect(repo.save).toHaveBeenCalledOnce();
-    expect(repo.update).toHaveBeenCalledTimes(2); // processing + completed
+    expect(repo.update).toHaveBeenCalledTimes(3); // processing + generationId + completed
     expect(llm.analyze).toHaveBeenCalledOnce();
     expect(repo.saveWorksheet).toHaveBeenCalledOnce();
     expect(repo.saveSnippets).toHaveBeenCalledOnce();

--- a/apps/server/test/contexts/fermentation/domain/models/fermentation-result.test.ts
+++ b/apps/server/test/contexts/fermentation/domain/models/fermentation-result.test.ts
@@ -4,7 +4,7 @@ import { FermentationResult } from '@/contexts/fermentation/domain/models/fermen
 const generateId = () => 'test-id';
 
 describe('FermentationResult', () => {
-  it('creates with pending status', () => {
+  it('creates with pending status and null generationId', () => {
     const result = FermentationResult.create(
       {
         userId: 'u1',
@@ -20,6 +20,7 @@ describe('FermentationResult', () => {
       expect(result.value.status).toBe('pending');
       expect(result.value.id).toBe('test-id');
       expect(result.value.questionId).toBe('q1');
+      expect(result.value.generationId).toBeNull();
     }
   });
 
@@ -64,5 +65,31 @@ describe('FermentationResult', () => {
     const props = result.value.toProps();
     const restored = FermentationResult.fromProps(props);
     expect(restored.toProps()).toEqual(props);
+  });
+
+  it('sets generationId with withGenerationId', () => {
+    const result = FermentationResult.create(
+      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      generateId,
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const withGen = result.value.withGenerationId('gen_abc123');
+    expect(withGen.generationId).toBe('gen_abc123');
+    expect(withGen.id).toBe(result.value.id);
+    expect(withGen.status).toBe('pending');
+  });
+
+  it('preserves generationId through toProps/fromProps roundtrip', () => {
+    const result = FermentationResult.create(
+      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      generateId,
+    );
+    if (!result.success) return;
+
+    const withGen = result.value.withGenerationId('gen_xyz');
+    const restored = FermentationResult.fromProps(withGen.toProps());
+    expect(restored.generationId).toBe('gen_xyz');
   });
 });

--- a/apps/server/test/contexts/shared/presentation/middleware/admin-auth.test.ts
+++ b/apps/server/test/contexts/shared/presentation/middleware/admin-auth.test.ts
@@ -1,0 +1,85 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { adminAuthMiddleware } from '@/contexts/shared/presentation/middleware/admin-auth.js';
+
+// Mock supabase-client module for service-role client
+vi.mock('@/contexts/shared/infrastructure/supabase-client.js', () => ({
+  getSupabaseClient: vi.fn().mockReturnValue({ from: vi.fn() }),
+}));
+
+// Mock @supabase/supabase-js
+const mockGetUser = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn().mockReturnValue({
+    auth: { getUser: () => mockGetUser() },
+  }),
+}));
+
+function createApp() {
+  return new Hono()
+    .use('/admin/*', adminAuthMiddleware)
+    .get('/admin/test', (c) => c.json({ ok: true }));
+}
+
+describe('adminAuthMiddleware', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPABASE_URL', 'https://test.supabase.co');
+    vi.stubEnv('SUPABASE_ANON_KEY', 'test-anon-key');
+  });
+
+  it('returns 401 when no Authorization header', async () => {
+    const app = createApp();
+    const res = await app.request('/admin/test');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('bad token') });
+
+    const app = createApp();
+    const res = await app.request('/admin/test', {
+      headers: { Authorization: 'Bearer invalid-token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', user_metadata: {} } },
+      error: null,
+    });
+
+    const app = createApp();
+    const res = await app.request('/admin/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when is_admin is false', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', user_metadata: { is_admin: false } } },
+      error: null,
+    });
+
+    const app = createApp();
+    const res = await app.request('/admin/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('passes through when user is admin', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', user_metadata: { is_admin: true } } },
+      error: null,
+    });
+
+    const app = createApp();
+    const res = await app.request('/admin/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/docs/client-architecture-guide.md
+++ b/docs/client-architecture-guide.md
@@ -1,7 +1,7 @@
-# クライアントアーキテクチャガイド
+# フロントエンドアーキテクチャガイド
 
 Oryzae フロントエンドの横断的なアーキテクチャルール。
-全クライアントコードに適用される。
+`apps/client`（ユーザー向け）と `apps/admin`（管理画面）の両方に適用される。
 
 設計思想は Feature-Sliced Architecture に基づき、機能単位でコードを分割・隔離する。
 
@@ -33,10 +33,9 @@ Feature-Sliced Architecture は、機能（feature）を単位としてコード
 ## ディレクトリ構造
 
 ```
-apps/client/src/
+apps/{client,admin}/src/
 ├── app/                    — Next.js App Router。薄いラッパーのみ
 │   ├── api/[...path]/      — Route Handler: Hono アプリへのリクエスト転送（変更しない）
-│   ├── health/             — Route Handler: ヘルスチェックエンドポイント
 │   ├── layout.tsx          — ルートレイアウト
 │   ├── page.tsx            — トップページ
 │   └── {route}/
@@ -47,6 +46,7 @@ apps/client/src/
 │       ├── components/     — 機能固有 UI コンポーネント
 │       ├── hooks/          — API 呼び出し・状態管理（Custom Hook）
 │       └── types.ts        — 機能固有の型定義
+├── components/ui/          — 汎用 UI コンポーネント（feature 依存禁止）
 └── lib/                    — 横断ユーティリティ（API クライアント設定、定数等）
 ```
 

--- a/docs/client-testing-guide.md
+++ b/docs/client-testing-guide.md
@@ -1,6 +1,7 @@
 # フロントエンドテスト・ガードレールガイド
 
-フロントエンド（Next.js クライアント）のテスト戦略と品質ガードレールの原則。
+フロントエンド（`apps/client` および `apps/admin`）のテスト戦略と品質ガードレールの原則。
+両アプリに同一のルールが適用される。
 
 ---
 
@@ -36,20 +37,20 @@
 ## テストファイル配置
 
 ```
-apps/client/
+apps/{client,admin}/
 ├── src/features/
 │   ├── auth/
 │   │   └── hooks/useAuth.ts
-│   └── entry/
-│       └── hooks/useEntries.ts
+│   └── {feature}/
+│       └── hooks/use-{name}.ts
 └── test/features/          ← src/features/ のミラー構造
     ├── auth/
     │   └── hooks/useAuth.test.ts
-    └── entry/
-        └── hooks/useEntries.test.ts
+    └── {feature}/
+        └── hooks/use-{name}.test.ts
 ```
 
-- テストファイルは `apps/client/test/features/` 配下に、`src/features/` のディレクトリ構造をミラーして配置する
+- テストファイルは `test/features/` 配下に、`src/features/` のディレクトリ構造をミラーして配置する
 - インポートは `@/` エイリアスを使用する（例: `import { useAuth } from '@/features/auth/hooks/useAuth'`）
 
 **なぜソースと分離するか**: テストコードをビルド対象から明確に除外し、`src/` の見通しを良く保つため。ミラー構造により対応関係は一目でわかる。

--- a/knip.json
+++ b/knip.json
@@ -3,15 +3,17 @@
   "ignore": [".claude/**", "docs/**"],
   "workspaces": {
     "apps/server": {
-      "entry": ["src/app.ts"],
       "project": ["src/**/*.ts"],
       "ignore": ["src/contexts/shared/infrastructure/supabase-client.ts"],
       "vitest": true
     },
     "apps/client": {
       "next": true,
-      "vitest": true,
-      "ignoreDependencies": ["@testing-library/dom", "@testing-library/react"]
+      "vitest": true
+    },
+    "apps/admin": {
+      "next": true,
+      "vitest": true
     },
     "packages/shared": {
       "project": ["src/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "typecheck": "pnpm --filter @oryzae/server typecheck && pnpm --filter @oryzae/shared typecheck && pnpm --filter @oryzae/client typecheck",
-    "test": "pnpm --filter @oryzae/server test && pnpm --filter @oryzae/client test",
+    "typecheck": "pnpm --filter @oryzae/server typecheck && pnpm --filter @oryzae/shared typecheck && pnpm --filter @oryzae/client typecheck && pnpm --filter @oryzae/admin typecheck",
+    "test": "pnpm --filter @oryzae/server test && pnpm --filter @oryzae/client test && pnpm --filter @oryzae/admin test",
     "knip": "knip",
-    "dep-cruise": "pnpm --filter @oryzae/server dep-cruise && pnpm --filter @oryzae/client dep-cruise",
+    "dep-cruise": "pnpm --filter @oryzae/server dep-cruise && pnpm --filter @oryzae/client dep-cruise && pnpm --filter @oryzae/admin dep-cruise",
     "postinstall": "simple-git-hooks"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,61 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
 
+  apps/admin:
+    dependencies:
+      '@oryzae/server':
+        specifier: workspace:*
+        version: link:../server
+      next:
+        specifier: 16.2.2
+        version: 16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.2.2
+      '@testing-library/dom':
+        specifier: ^10.0.0
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      dependency-cruiser:
+        specifier: ^17.3.10
+        version: 17.3.10
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      postcss:
+        specifier: ^8
+        version: 8.5.8
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.2
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@20.19.39)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   apps/client:
     dependencies:
       '@oryzae/server':
@@ -78,9 +133,6 @@ importers:
 
   apps/server:
     dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.67
-        version: 3.0.67(zod@3.25.76)
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.19.11(hono@4.12.8)
@@ -127,12 +179,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@ai-sdk/anthropic@3.0.67':
-    resolution: {integrity: sha512-FFX4P5Fd6lcQJc2OLngZQkbbJHa0IDDZi087Edb8qRZx6h90krtM61ArbMUL8us/7ZUwojCXnyJ/wQ2Eflx2jQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/gateway@3.0.91':
     resolution: {integrity: sha512-J39Dh6Gyg6HjG3A7OFKnJMp3QyZ3Eex+XDiX8aFBdRwwZm3jGWaMhkCxQPH7yiQ9kRiErZwHXX/Oexx4SyGGGA==}
@@ -2169,12 +2215,6 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
-
-  '@ai-sdk/anthropic@3.0.67(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
-      zod: 3.25.76
 
   '@ai-sdk/gateway@3.0.91(zod@3.25.76)':
     dependencies:

--- a/supabase/migrations/00007_add_generation_id_to_fermentation_results.sql
+++ b/supabase/migrations/00007_add_generation_id_to_fermentation_results.sql
@@ -1,0 +1,7 @@
+-- Add Vercel AI Gateway generation_id for per-request cost tracking
+ALTER TABLE fermentation_results
+  ADD COLUMN generation_id text;
+
+CREATE INDEX idx_fermentation_results_generation_id
+  ON fermentation_results(generation_id)
+  WHERE generation_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- 管理画面（`apps/admin`）を独立した Next.js アプリとして新設
- Vercel AI Gateway 経由のコスト追跡基盤（`generation_id` per-request）
- `adminAuthMiddleware`（`is_admin` チェック + service-role Supabase クライアント）
- Admin API: ダッシュボード統計 + 発酵コスト照会

## 変更内容

### Backend
- `fermentation_results` に `generation_id` カラム追加（migration 00007）
- `VercelAiAnalysisGateway` を Vercel AI Gateway 経由に切り替え（`@ai-sdk/anthropic` → `gateway()`）
- `FermentationResult` ドメインモデルに `generationId` フィールド + `withGenerationId()` 追加
- Admin API ルート: `/api/v1/admin/dashboard/stats`, `/api/v1/admin/fermentations/*`

### Frontend (`apps/admin`)
- Feature-Sliced Architecture: `auth`, `dashboard`, `cost-tracking`
- 画面: ログイン → ダッシュボード（統計カード）→ コスト追跡（テーブル）
- `apps/client` と完全に同一のガードレール設定

### Config / Docs
- ルートスクリプト (`typecheck`, `test`, `dep-cruise`) に `@oryzae/admin` 追加
- `.claude/rules`, `docs/`, CI ワークフローを admin 対応に更新
- `knip.json` に admin workspace 追加

## Test plan
- [x] `pnpm typecheck` — server + shared + client + admin 全通過
- [x] `pnpm test` — 188 テスト通過（server 151 + client 25 + admin 12）
- [x] `pnpm dep-cruise` — 3 アプリ依存ルール違反なし
- [x] `pnpm knip` — デッドコードなし
- [ ] ローカル起動確認: `pnpm --filter @oryzae/admin dev` → `http://localhost:3001`
- [ ] admin ユーザーでログイン → ダッシュボード表示確認
- [ ] 発酵実行後にコスト追跡画面にデータ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)