### PR TITLE
feat: Google OAuth, セッション維持改善, パスワードリセット

### DIFF
--- a/apps/client/src/app/(auth)/callback/page.tsx
+++ b/apps/client/src/app/(auth)/callback/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import posthog from 'posthog-js';
+import { Suspense, useEffect, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { setTokens } from '@/lib/auth';
+
+function CallbackHandler() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function handleCallback() {
+      const code = searchParams.get('code');
+      if (!code) {
+        setError('認証コードが見つかりません');
+        return;
+      }
+
+      const client = createApiClient();
+      const res = await client.fetch('/api/v1/auth/oauth/callback', {
+        method: 'POST',
+        body: JSON.stringify({ code }),
+      });
+
+      if (!res.ok) {
+        setError('認証に失敗しました。もう一度お試しください。');
+        return;
+      }
+
+      const data = (await res.json()) as {
+        user: { id: string; email: string };
+        session: { accessToken: string; refreshToken: string };
+      };
+
+      setTokens(data.session.accessToken, data.session.refreshToken);
+      posthog.identify(data.user.id, { email: data.user.email });
+      router.push('/entries');
+    }
+
+    handleCallback();
+  }, [searchParams, router]);
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>
+        <a href="/login" className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          ログインに戻る
+        </a>
+      </div>
+    );
+  }
+
+  return <p className="text-sm text-center text-zinc-500">認証中...</p>;
+}
+
+export default function CallbackPage() {
+  return (
+    <Suspense fallback={<p className="text-sm text-center text-zinc-500">読み込み中...</p>}>
+      <CallbackHandler />
+    </Suspense>
+  );
+}

--- a/apps/client/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/client/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordForm } from '@/features/auth/components/forgot-password-form';
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/apps/client/src/app/(auth)/reset-password/page.tsx
+++ b/apps/client/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,5 @@
+import { ResetPasswordForm } from '@/features/auth/components/reset-password-form';
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />;
+}

--- a/apps/client/src/features/auth/components/forgot-password-form.tsx
+++ b/apps/client/src/features/auth/components/forgot-password-form.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { translateAuthError } from '@/features/auth/utils/error-messages';
+import { createApiClient } from '@/lib/api';
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    const redirectTo = `${window.location.origin}/reset-password`;
+    const client = createApiClient();
+    const res = await client.fetch('/api/v1/auth/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({ email, redirectTo }),
+    });
+
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      setError(translateAuthError(data.error));
+      setLoading(false);
+      return;
+    }
+
+    setSent(true);
+    setLoading(false);
+  }
+
+  if (sent) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <h1 className="text-2xl font-bold">メールを確認してください</h1>
+        <p className="text-sm text-zinc-500">
+          {email}{' '}
+          にパスワードリセットリンクを送信しました。メール内のリンクをクリックして、新しいパスワードを設定してください。
+        </p>
+        <Link href="/login" className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          ログインに戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold text-center">パスワードをリセット</h1>
+      <p className="text-sm text-center text-zinc-500">
+        登録済みのメールアドレスを入力してください。パスワードリセットリンクをお送りします。
+      </p>
+
+      {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium">メールアドレス</span>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {loading ? '送信中...' : 'リセットリンクを送信'}
+      </button>
+
+      <p className="text-sm text-center text-zinc-500">
+        <Link href="/login" className="font-medium text-zinc-900 dark:text-zinc-100">
+          ログインに戻る
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/apps/client/src/features/auth/components/google-login-button.tsx
+++ b/apps/client/src/features/auth/components/google-login-button.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { createApiClient } from '@/lib/api';
+
+export function GoogleLoginButton() {
+  const [loading, setLoading] = useState(false);
+
+  async function handleClick() {
+    setLoading(true);
+    try {
+      const callbackUrl = `${window.location.origin}/callback`;
+      const client = createApiClient();
+      const res = await client.fetch('/api/v1/auth/oauth/google', {
+        method: 'POST',
+        body: JSON.stringify({ redirectTo: callbackUrl }),
+      });
+
+      if (!res.ok) {
+        setLoading(false);
+        return;
+      }
+
+      const data = (await res.json()) as { url: string };
+      window.location.href = data.url;
+    } catch {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={loading}
+      className="flex w-full items-center justify-center gap-2 rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+    >
+      <svg className="h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+      {loading ? '接続中...' : 'Google でログイン'}
+    </button>
+  );
+}

--- a/apps/client/src/features/auth/components/login-form.tsx
+++ b/apps/client/src/features/auth/components/login-form.tsx
@@ -3,7 +3,9 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { GoogleLoginButton } from '@/features/auth/components/google-login-button';
 import { useAuth } from '@/features/auth/hooks/use-auth';
+import { translateAuthError } from '@/features/auth/utils/error-messages';
 
 export function LoginForm() {
   const [email, setEmail] = useState('');
@@ -20,7 +22,7 @@ export function LoginForm() {
 
     const err = await login(email, password);
     if (err) {
-      setError(err);
+      setError(translateAuthError(err));
       setLoading(false);
       return;
     }
@@ -32,6 +34,14 @@ export function LoginForm() {
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <h1 className="text-2xl font-bold text-center">Oryzae</h1>
       <p className="text-sm text-center text-zinc-500">ログインして続ける</p>
+
+      <GoogleLoginButton />
+
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+        <span className="text-xs text-zinc-400">または</span>
+        <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+      </div>
 
       {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
 
@@ -57,6 +67,15 @@ export function LoginForm() {
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
         />
       </label>
+
+      <div className="flex justify-end">
+        <Link
+          href="/forgot-password"
+          className="text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+        >
+          パスワードを忘れた方
+        </Link>
+      </div>
 
       <button
         type="submit"

--- a/apps/client/src/features/auth/components/reset-password-form.tsx
+++ b/apps/client/src/features/auth/components/reset-password-form.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useState } from 'react';
+import { translateAuthError } from '@/features/auth/utils/error-messages';
+import { createApiClient } from '@/lib/api';
+
+function ResetPasswordHandler() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const accessToken = searchParams.get('access_token');
+
+  if (!accessToken) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">
+          無効なリセットリンクです。もう一度パスワードリセットをお試しください。
+        </p>
+        <Link
+          href="/forgot-password"
+          className="text-sm font-medium text-zinc-900 dark:text-zinc-100"
+        >
+          パスワードリセットに戻る
+        </Link>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+
+    if (password !== confirmPassword) {
+      setError('パスワードが一致しません');
+      return;
+    }
+
+    setLoading(true);
+
+    const client = createApiClient();
+    const res = await client.fetch('/api/v1/auth/update-password', {
+      method: 'POST',
+      body: JSON.stringify({ accessToken, password }),
+    });
+
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      setError(translateAuthError(data.error));
+      setLoading(false);
+      return;
+    }
+
+    router.push('/login');
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold text-center">新しいパスワード</h1>
+      <p className="text-sm text-center text-zinc-500">新しいパスワードを入力してください。</p>
+
+      {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium">新しいパスワード</span>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium">パスワード確認</span>
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          minLength={6}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        {loading ? '更新中...' : 'パスワードを更新'}
+      </button>
+    </form>
+  );
+}
+
+export function ResetPasswordForm() {
+  return (
+    <Suspense fallback={<p className="text-sm text-center text-zinc-500">読み込み中...</p>}>
+      <ResetPasswordHandler />
+    </Suspense>
+  );
+}

--- a/apps/client/src/features/auth/components/signup-form.tsx
+++ b/apps/client/src/features/auth/components/signup-form.tsx
@@ -3,7 +3,9 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { GoogleLoginButton } from '@/features/auth/components/google-login-button';
 import { useAuth } from '@/features/auth/hooks/use-auth';
+import { translateAuthError } from '@/features/auth/utils/error-messages';
 
 export function SignupForm() {
   const [email, setEmail] = useState('');
@@ -20,7 +22,7 @@ export function SignupForm() {
 
     const err = await signup(email, password);
     if (err) {
-      setError(err);
+      setError(translateAuthError(err));
       setLoading(false);
       return;
     }
@@ -32,6 +34,14 @@ export function SignupForm() {
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <h1 className="text-2xl font-bold text-center">Oryzae</h1>
       <p className="text-sm text-center text-zinc-500">アカウントを作成</p>
+
+      <GoogleLoginButton />
+
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+        <span className="text-xs text-zinc-400">または</span>
+        <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+      </div>
 
       {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
 

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -3,7 +3,7 @@
 import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 import { type ApiClient, createApiClient } from '@/lib/api';
-import { clearTokens, getAccessToken, setTokens } from '@/lib/auth';
+import { clearTokens, getAccessToken, getRefreshToken, setTokens } from '@/lib/auth';
 
 interface AuthState {
   accessToken: string;
@@ -17,25 +17,69 @@ export function useAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = getAccessToken();
-    if (token) {
+    async function restoreSession() {
+      const token = getAccessToken();
+      if (!token) {
+        setLoading(false);
+        return;
+      }
+
       const client = createApiClient(token);
-      setApi(client);
-      client
-        .fetch('/api/v1/auth/me')
-        .then(async (res) => {
-          if (res.ok) {
-            const data = (await res.json()) as { user: { id: string; email: string } };
-            setAuth({ accessToken: token, refreshToken: '', user: data.user });
-            posthog.identify(data.user.id, { email: data.user.email });
-          } else {
-            clearTokens();
-          }
-        })
-        .finally(() => setLoading(false));
-    } else {
+      const meRes = await client.fetch('/api/v1/auth/me');
+
+      if (meRes.ok) {
+        const data = (await meRes.json()) as { user: { id: string; email: string } };
+        setAuth({ accessToken: token, refreshToken: getRefreshToken() ?? '', user: data.user });
+        setApi(client);
+        posthog.identify(data.user.id, { email: data.user.email });
+        setLoading(false);
+        return;
+      }
+
+      // Access token expired — try refresh
+      const refreshToken = getRefreshToken();
+      if (!refreshToken) {
+        clearTokens();
+        setLoading(false);
+        return;
+      }
+
+      const refreshRes = await createApiClient().fetch('/api/v1/auth/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ refreshToken }),
+      });
+
+      if (!refreshRes.ok) {
+        clearTokens();
+        setLoading(false);
+        return;
+      }
+
+      const refreshData = (await refreshRes.json()) as {
+        session: { accessToken: string; refreshToken: string };
+      };
+      setTokens(refreshData.session.accessToken, refreshData.session.refreshToken);
+
+      const newClient = createApiClient(refreshData.session.accessToken);
+      const retryRes = await newClient.fetch('/api/v1/auth/me');
+
+      if (retryRes.ok) {
+        const userData = (await retryRes.json()) as { user: { id: string; email: string } };
+        setAuth({
+          accessToken: refreshData.session.accessToken,
+          refreshToken: refreshData.session.refreshToken,
+          user: userData.user,
+        });
+        setApi(newClient);
+        posthog.identify(userData.user.id, { email: userData.user.email });
+      } else {
+        clearTokens();
+      }
+
       setLoading(false);
     }
+
+    restoreSession();
   }, []);
 
   async function login(email: string, password: string): Promise<string | null> {

--- a/apps/client/src/features/auth/utils/error-messages.ts
+++ b/apps/client/src/features/auth/utils/error-messages.ts
@@ -1,0 +1,22 @@
+const ERROR_MAP: Record<string, string> = {
+  'Invalid login credentials': 'メールアドレスまたはパスワードが正しくありません',
+  'Email not confirmed': 'メールアドレスが確認されていません。確認メールをご確認ください',
+  'User already registered': 'このメールアドレスは既に登録されています',
+  'Password should be at least 6 characters': 'パスワードは6文字以上で入力してください',
+  'Email rate limit exceeded': 'しばらく時間をおいてから再度お試しください',
+  'For security purposes, you can only request this after':
+    'セキュリティのため、しばらく時間をおいてから再度お試しください',
+  'Unable to validate email address: invalid format': 'メールアドレスの形式が正しくありません',
+  'Signup requires a valid password': '有効なパスワードを入力してください',
+  'User not found': 'ユーザーが見つかりません',
+  'New password should be different from the old password':
+    '新しいパスワードは現在のパスワードと異なるものにしてください',
+  'Auth session missing!': 'セッションが切れました。もう一度ログインしてください',
+};
+
+export function translateAuthError(message: string): string {
+  for (const [key, value] of Object.entries(ERROR_MAP)) {
+    if (message.includes(key)) return value;
+  }
+  return message;
+}

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -1,7 +1,31 @@
+import { clearTokens, getRefreshToken, setTokens } from '@/lib/auth';
+
 export interface ApiClient {
   baseUrl: string;
   headers: Record<string, string>;
   fetch(path: string, init?: RequestInit): Promise<Response>;
+}
+
+async function tryRefreshToken(): Promise<string | null> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return null;
+
+  const res = await fetch('/api/v1/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!res.ok) {
+    clearTokens();
+    return null;
+  }
+
+  const data = (await res.json()) as {
+    session: { accessToken: string; refreshToken: string };
+  };
+  setTokens(data.session.accessToken, data.session.refreshToken);
+  return data.session.accessToken;
 }
 
 export function createApiClient(accessToken?: string): ApiClient {
@@ -12,23 +36,35 @@ export function createApiClient(accessToken?: string): ApiClient {
     headers.Authorization = `Bearer ${accessToken}`;
   }
 
+  async function doFetch(path: string, init?: RequestInit): Promise<Response> {
+    const isFormData = init?.body instanceof FormData;
+    const requestHeaders = isFormData
+      ? (() => {
+          const h: Record<string, string> = {};
+          if (headers.Authorization) h.Authorization = headers.Authorization;
+          return h;
+        })()
+      : { ...headers, ...init?.headers };
+
+    const res = await fetch(path, { ...init, headers: requestHeaders });
+
+    // Don't retry auth endpoints to avoid loops
+    if (res.status !== 401 || path.startsWith('/api/v1/auth/')) return res;
+
+    const newToken = await tryRefreshToken();
+    if (!newToken) return res;
+
+    headers.Authorization = `Bearer ${newToken}`;
+    const retryHeaders = isFormData
+      ? { Authorization: `Bearer ${newToken}` }
+      : { ...headers, ...init?.headers };
+
+    return fetch(path, { ...init, headers: retryHeaders });
+  }
+
   return {
     baseUrl: '',
     headers,
-    fetch(path: string, init?: RequestInit) {
-      // If body is FormData, let browser set Content-Type with boundary
-      const isFormData = init?.body instanceof FormData;
-      if (isFormData) {
-        const h: Record<string, string> = {};
-        if (headers.Authorization) {
-          h.Authorization = headers.Authorization;
-        }
-        return fetch(path, { ...init, headers: h });
-      }
-      return fetch(path, {
-        ...init,
-        headers: { ...headers, ...init?.headers },
-      });
-    },
+    fetch: doFetch,
   };
 }

--- a/apps/client/src/lib/auth.ts
+++ b/apps/client/src/lib/auth.ts
@@ -11,6 +11,11 @@ export function setTokens(accessToken: string, refreshToken: string): void {
   localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
 }
 
+export function getRefreshToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
 export function clearTokens(): void {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN_KEY);

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -80,6 +80,78 @@ export const authRoutes = new Hono()
       },
     });
   })
+  .post('/oauth/google', async (c) => {
+    const { redirectTo } = z.object({ redirectTo: z.string().url() }).parse(await c.req.json());
+    const supabase = getSupabaseAuthClient();
+
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo,
+        queryParams: { access_type: 'offline', prompt: 'consent' },
+      },
+    });
+
+    if (error) {
+      return c.json({ error: error.message }, 400);
+    }
+
+    return c.json({ url: data.url });
+  })
+  .post('/oauth/callback', async (c) => {
+    const { code } = z.object({ code: z.string() }).parse(await c.req.json());
+    const supabase = getSupabaseAuthClient();
+
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (error) {
+      return c.json({ error: error.message }, 400);
+    }
+
+    return c.json({
+      user: { id: data.user.id, email: data.user.email },
+      session: {
+        accessToken: data.session.access_token,
+        refreshToken: data.session.refresh_token,
+        expiresAt: data.session.expires_at,
+      },
+    });
+  })
+  .post('/reset-password', async (c) => {
+    const { email, redirectTo } = z
+      .object({ email: z.string().email(), redirectTo: z.string().url() })
+      .parse(await c.req.json());
+    const supabase = getSupabaseAuthClient();
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
+
+    if (error) {
+      return c.json({ error: error.message }, 400);
+    }
+
+    return c.json({ message: 'Password reset email sent' });
+  })
+  .post('/update-password', async (c) => {
+    const { accessToken, password } = z
+      .object({ accessToken: z.string(), password: z.string().min(6) })
+      .parse(await c.req.json());
+
+    const url = process.env.SUPABASE_URL;
+    const anonKey = process.env.SUPABASE_ANON_KEY;
+    if (!url || !anonKey) return c.json({ error: 'Server config error' }, 500);
+
+    const supabase = createClient(url, anonKey, {
+      global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    });
+
+    const { error } = await supabase.auth.updateUser({ password });
+
+    if (error) {
+      return c.json({ error: error.message }, 400);
+    }
+
+    return c.json({ message: 'Password updated' });
+  })
   .get('/me', async (c) => {
     const authHeader = c.req.header('Authorization');
     if (!authHeader?.startsWith('Bearer ')) {

--- a/docs/plans/auth-improvement.md
+++ b/docs/plans/auth-improvement.md
@@ -1,0 +1,236 @@
+# 認証改善プラン
+
+## ステータス: Phase 1 未着手
+
+最終更新: 2026-04-12
+
+---
+
+## 背景・課題
+
+現状の認証は email/password のみで、以下の問題がある:
+
+1. **毎回ログインが必要** — トークン期限切れ時の自動リフレッシュが不十分。`useAuth` 初期化時に `/auth/me` で検証するが、失敗時に refresh token を使った自動更新を行わず即座にトークンをクリアしている
+2. **SSO/OAuth 未対応** — Google 等のソーシャルログインがなく、会員登録の障壁が高い
+3. **パスワードリセット未実装** — パスワードを忘れたユーザーが復帰できない
+4. **ログイン/サインアップ UI が最小限** — エラーメッセージが英語（Supabase 原文）、ソーシャルボタンなし
+
+## 現状のアーキテクチャ
+
+```
+Browser (localStorage)
+  ├── oryzae_access_token (JWT)
+  └── oryzae_refresh_token
+        │
+        ▼
+  useAuth() hook
+    ├── 初期化: getAccessToken() → GET /auth/me → OK なら認証状態セット
+    ├── login(): POST /auth/login → setTokens()
+    ├── signup(): POST /auth/signup → setTokens()
+    └── logout(): clearTokens()
+        │
+        ▼
+  Hono Server (apps/server)
+    ├── POST /api/v1/auth/signup   — supabase.auth.signUp()
+    ├── POST /api/v1/auth/login    — supabase.auth.signInWithPassword()
+    ├── POST /api/v1/auth/refresh  — supabase.auth.refreshSession()
+    └── GET  /api/v1/auth/me       — supabase.auth.getUser()
+```
+
+**アーキテクチャ方針（変えない部分）:**
+- クライアントから Supabase への直接アクセスは禁止（バックエンド API 経由のみ）
+- JWT ベースのステートレス認証
+- localStorage によるトークン保管
+
+---
+
+## Phase 1: セッション維持の改善
+
+**目的:** 「毎回ログイン」問題を解消する
+
+### 1.1 トークン自動リフレッシュ
+
+**現状の問題:**
+- `useAuth` 初期化時に `/auth/me` が 401 を返すと即座に `clearTokens()` する
+- refresh token を使った自動更新を試みていない
+
+**変更内容:**
+
+`apps/client/src/features/auth/hooks/use-auth.ts`:
+- `/auth/me` が 401 を返した場合、localStorage の refresh token を使って `/auth/refresh` を呼ぶ
+- refresh 成功 → 新しいトークンで `/auth/me` をリトライ
+- refresh 失敗 → `clearTokens()` してログイン画面へ
+
+`apps/client/src/lib/auth.ts`:
+- `getRefreshToken()` 関数を追加
+
+**変更ファイル:**
+- `apps/client/src/features/auth/hooks/use-auth.ts`
+- `apps/client/src/lib/auth.ts`
+- `test/features/auth/hooks/use-auth.test.ts`（テスト追加・更新）
+
+### 1.2 API クライアントのインターセプタ
+
+**目的:** API 呼び出し中にトークン期限切れが発生した場合もシームレスにリフレッシュ
+
+**変更内容:**
+
+`apps/client/src/lib/api.ts`:
+- `fetch()` が 401 を返した場合、refresh token で `/auth/refresh` を呼び、リトライする
+- 無限ループ防止のため、リトライは 1 回のみ
+
+**変更ファイル:**
+- `apps/client/src/lib/api.ts`
+
+---
+
+## Phase 2: Google OAuth
+
+**目的:** Google アカウントでワンクリックログインできるようにする
+
+### 2.1 Supabase 設定（手動）
+
+- Supabase Dashboard → Authentication → Providers → Google を有効化
+- Google Cloud Console で OAuth クライアント ID/シークレットを取得
+- Supabase に callback URL を設定: `https://<supabase-project>.supabase.co/auth/v1/callback`
+
+### 2.2 サーバー側: OAuth コールバック処理
+
+**方針:**
+- Supabase の OAuth フローは PKCE（Proof Key for Code Exchange）ベース
+- クライアントがフローを開始し、Supabase が直接 Google と通信
+- サーバーは「code → session 交換」エンドポイントを提供
+
+**新規エンドポイント:**
+
+`POST /api/v1/auth/oauth/google` — OAuth フロー開始 URL を返す
+```typescript
+// リクエスト: { redirectTo: string }
+// レスポンス: { url: string } — Google 認証画面の URL
+```
+
+`POST /api/v1/auth/oauth/callback` — 認可コードからセッションを取得
+```typescript
+// リクエスト: { code: string }
+// レスポンス: { user: {...}, session: { accessToken, refreshToken, expiresAt } }
+```
+
+**変更ファイル:**
+- `apps/server/src/contexts/shared/presentation/routes/auth.ts` — 既存ファイルに追加
+- `apps/server/src/app.ts` — ルーティングは既存の `/api/v1/auth` に含まれるため変更不要
+
+### 2.3 クライアント側: OAuth ログインフロー
+
+**新規コンポーネント:**
+
+`apps/client/src/features/auth/components/google-login-button.tsx`
+- 「Google でログイン」ボタン
+- クリック → `POST /api/v1/auth/oauth/google` → 返された URL にリダイレクト
+- Google 認証後、Supabase が callback URL にリダイレクト
+
+**新規ページ:**
+
+`apps/client/src/app/(auth)/callback/page.tsx`
+- Supabase からの OAuth callback を処理するページ
+- URL パラメータの `code` を取得 → `POST /api/v1/auth/oauth/callback` → トークン保存 → `/entries` にリダイレクト
+
+**既存ファイル変更:**
+- `apps/client/src/features/auth/components/login-form.tsx` — Google ボタンを追加
+- `apps/client/src/features/auth/components/signup-form.tsx` — Google ボタンを追加
+- `apps/client/src/features/auth/hooks/use-auth.ts` — `loginWithOAuthCode()` メソッド追加
+
+**テスト:**
+- `test/features/auth/hooks/use-auth.test.ts` — OAuth ログインのテスト追加
+- `e2e/auth.spec.ts` — callback ページの基本テスト追加
+
+### 2.4 環境変数
+
+追加不要（Supabase Dashboard 側の設定のみ。サーバーの既存 `SUPABASE_URL` / `SUPABASE_ANON_KEY` で動作）
+
+---
+
+## Phase 3: パスワードリセット
+
+**目的:** パスワードを忘れたユーザーが自力で復帰できるようにする
+
+### 3.1 サーバー側
+
+**新規エンドポイント:**
+
+`POST /api/v1/auth/reset-password` — リセットメール送信
+```typescript
+// リクエスト: { email: string }
+// レスポンス: { message: string }
+// 内部: supabase.auth.resetPasswordForEmail(email, { redirectTo })
+```
+
+`POST /api/v1/auth/update-password` — 新パスワード設定
+```typescript
+// リクエスト: { accessToken: string, password: string }
+// レスポンス: { message: string }
+// 内部: supabase.auth.updateUser({ password }) （リセットトークンで認証済みセッションを使用）
+```
+
+**変更ファイル:**
+- `apps/server/src/contexts/shared/presentation/routes/auth.ts`
+- `packages/shared/src/schemas/credentials.ts` — パスワードリセット用スキーマ追加
+
+### 3.2 クライアント側
+
+**新規ページ・コンポーネント:**
+- `apps/client/src/app/(auth)/forgot-password/page.tsx`
+- `apps/client/src/features/auth/components/forgot-password-form.tsx` — メアド入力 → リセットメール送信
+- `apps/client/src/app/(auth)/reset-password/page.tsx`
+- `apps/client/src/features/auth/components/reset-password-form.tsx` — 新パスワード入力 → 更新
+
+**既存ファイル変更:**
+- `apps/client/src/features/auth/components/login-form.tsx` — 「パスワードを忘れた方」リンク追加
+
+---
+
+## Phase 4: ログイン/サインアップ UI 改善
+
+**目的:** よりリッチで信頼感のあるログイン体験
+
+### 4.1 エラーメッセージの日本語化
+
+Supabase の英語エラーメッセージをユーザーフレンドリーな日本語に変換:
+
+| Supabase エラー | 表示メッセージ |
+|---|---|
+| `Invalid login credentials` | メールアドレスまたはパスワードが正しくありません |
+| `User already registered` | このメールアドレスは既に登録されています |
+| `Password should be at least 6 characters` | パスワードは6文字以上で入力してください |
+| `Email rate limit exceeded` | しばらく時間をおいてから再度お試しください |
+
+**変更ファイル:**
+- `apps/client/src/features/auth/utils/error-messages.ts`（新規）
+- `apps/client/src/features/auth/components/login-form.tsx`
+- `apps/client/src/features/auth/components/signup-form.tsx`
+
+### 4.2 UI の仕上げ
+
+- ログイン/サインアップフォーム間のセパレーター（「または」）
+- Google ログインボタンを上部に配置
+- フォームの loading 状態をスケルトン/スピナーで改善
+
+---
+
+## 実装順序
+
+```
+Phase 1 (セッション維持) → Phase 2 (Google OAuth) → Phase 3 (パスワードリセット) → Phase 4 (UI改善)
+```
+
+Phase 1 は既存コードの修正のみで完了でき、最も体験改善のインパクトが大きい。
+Phase 2 は Supabase Dashboard での手動設定が前提条件。
+Phase 3, 4 は Phase 2 と並行して進められる。
+
+---
+
+## 対象外（スコープ外）
+
+- MFA（多要素認証）— 将来的に検討
+- Apple / GitHub 等の追加 OAuth プロバイダー — Google で基盤を作った後に横展開
+- メールアドレス確認フロー — Supabase デフォルト設定に依存（現状は自動確認）
+- admin アプリの OAuth 対応 — admin は email/password のまま（セキュリティ上の理由）


### PR DESCRIPTION
## Summary
- **セッション維持改善**: access token 期限切れ時に refresh token で自動リフレッシュ。API クライアントも 401 レスポンス時に自動リトライ
- **Google OAuth**: サーバーに OAuth フロー開始・コールバックのエンドポイント追加。ログイン/サインアップ画面に「Google でログイン」ボタン
- **パスワードリセット**: リセットメール送信・新パスワード設定のフロー一式
- **UI 改善**: Supabase エラーメッセージの日本語化、OAuth とメール/パスワードの「または」セパレーター

## 前提条件（手動設定済み）
- Supabase Dashboard で Google OAuth Provider を有効化
- Google Cloud Console で OAuth クライアント ID/シークレットを取得・設定

## 変更ファイル
- `apps/server/.../routes/auth.ts` — OAuth, パスワードリセットエンドポイント追加
- `apps/client/src/lib/auth.ts` — `getRefreshToken()` 追加
- `apps/client/src/lib/api.ts` — 401 自動リトライ
- `apps/client/src/features/auth/hooks/use-auth.ts` — refresh token による自動セッション復元
- `apps/client/src/features/auth/components/` — Google ボタン, パスワードリセットフォーム (新規)
- `apps/client/src/features/auth/utils/error-messages.ts` — エラー日本語化 (新規)
- `apps/client/src/app/(auth)/` — callback, forgot-password, reset-password ページ (新規)
- `docs/plans/auth-improvement.md` — 設計ドキュメント (新規)

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過（既存 warning のみ）
- [x] `pnpm test` 全 196 テスト通過
- [x] `pnpm dep-cruise` 依存違反なし
- [x] `pnpm knip` デッドコードなし
- [x] ログイン画面で Google ボタン・セパレーター・パスワードリセットリンクが表示されることを確認
- [x] サインアップ画面で Google ボタン・セパレーターが表示されることを確認
- [x] パスワードリセット画面が正常に表示されることを確認
- [ ] Google OAuth でのログインフローを本番/ステージングで E2E 確認
- [ ] パスワードリセットメールの送信・リセットフローを E2E 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)