### PR TITLE
fix: OAuth callback で implicit flow を処理

### DIFF
--- a/apps/client/src/app/(auth)/callback/page.tsx
+++ b/apps/client/src/app/(auth)/callback/page.tsx
@@ -6,6 +6,18 @@ import { Suspense, useEffect, useState } from 'react';
 import { createApiClient } from '@/lib/api';
 import { setTokens } from '@/lib/auth';
 
+function parseHashParams(hash: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  const stripped = hash.startsWith('#') ? hash.slice(1) : hash;
+  for (const pair of stripped.split('&')) {
+    const [key, value] = pair.split('=');
+    if (key && value) {
+      params[decodeURIComponent(key)] = decodeURIComponent(value);
+    }
+  }
+  return params;
+}
+
 function CallbackHandler() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -13,31 +25,56 @@ function CallbackHandler() {
 
   useEffect(() => {
     async function handleCallback() {
+      // Supabase PKCE flow: code in query params
       const code = searchParams.get('code');
-      if (!code) {
-        setError('認証コードが見つかりません');
+      if (code) {
+        const client = createApiClient();
+        const res = await client.fetch('/api/v1/auth/oauth/callback', {
+          method: 'POST',
+          body: JSON.stringify({ code }),
+        });
+
+        if (!res.ok) {
+          setError('認証に失敗しました。もう一度お試しください。');
+          return;
+        }
+
+        const data = (await res.json()) as {
+          user: { id: string; email: string };
+          session: { accessToken: string; refreshToken: string };
+        };
+
+        setTokens(data.session.accessToken, data.session.refreshToken);
+        posthog.identify(data.user.id, { email: data.user.email });
+        router.push('/entries');
         return;
       }
 
-      const client = createApiClient();
-      const res = await client.fetch('/api/v1/auth/oauth/callback', {
-        method: 'POST',
-        body: JSON.stringify({ code }),
-      });
+      // Supabase implicit flow: tokens in URL hash fragment
+      const hash = window.location.hash;
+      if (hash) {
+        const params = parseHashParams(hash);
+        const accessToken = params.access_token;
+        const refreshToken = params.refresh_token;
 
-      if (!res.ok) {
-        setError('認証に失敗しました。もう一度お試しください。');
-        return;
+        if (accessToken && refreshToken) {
+          setTokens(accessToken, refreshToken);
+
+          // Verify token and get user info
+          const client = createApiClient(accessToken);
+          const meRes = await client.fetch('/api/v1/auth/me');
+
+          if (meRes.ok) {
+            const data = (await meRes.json()) as { user: { id: string; email: string } };
+            posthog.identify(data.user.id, { email: data.user.email });
+          }
+
+          router.push('/entries');
+          return;
+        }
       }
 
-      const data = (await res.json()) as {
-        user: { id: string; email: string };
-        session: { accessToken: string; refreshToken: string };
-      };
-
-      setTokens(data.session.accessToken, data.session.refreshToken);
-      posthog.identify(data.user.id, { email: data.user.email });
-      router.push('/entries');
+      setError('認証コードが見つかりません');
     }
 
     handleCallback();


### PR DESCRIPTION
## Summary
- OAuth callback ページが Supabase implicit flow（`#access_token=...` ハッシュフラグメント）を処理できるよう修正
- PKCE flow（`?code=...`）も引き続きサポート
- Supabase Dashboard の Site URL / Redirect URLs 設定も修正済み

## 原因
Supabase のサーバーサイド `signInWithOAuth` は implicit flow を使用し、トークンを URL ハッシュフラグメントで返す。callback ページは `searchParams.get('code')` のみを処理していたため、implicit flow のトークンを取得できなかった。

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全 196 テスト通過
- [ ] 本番で Google OAuth ログインフローを E2E 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)