### PR TITLE
feat: サイドバーにユーザーアバター + アカウントページ

### DIFF
--- a/apps/client/src/app/(protected)/account/page.tsx
+++ b/apps/client/src/app/(protected)/account/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { AccountPage } from '@/features/auth/components/account-page';
+import { useAuth } from '@/features/auth/hooks/use-auth';
+
+export default function AccountRoute() {
+  const { auth, loading } = useAuth();
+
+  if (loading || !auth) {
+    return (
+      <div
+        className="flex h-full items-center justify-center text-xs"
+        style={{ color: 'var(--date-color)' }}
+      >
+        読み込み中...
+      </div>
+    );
+  }
+
+  return <AccountPage user={auth.user} />;
+}

--- a/apps/client/src/components/ui/page-footer.tsx
+++ b/apps/client/src/components/ui/page-footer.tsx
@@ -13,6 +13,7 @@ const FOOTER_ENTRIES: FooterEntry[] = [
   { match: (p) => p === '/entries/new' || p.startsWith('/entries/'), label: 'EDITOR' },
   { match: (p) => p === '/entries', label: 'LIST' },
   { match: (p) => p === '/questions', label: '問い一覧' },
+  { match: (p) => p === '/account', label: 'ACCOUNT' },
 ];
 
 function resolveLabel(pathname: string): string {

--- a/apps/client/src/features/auth/components/account-page.tsx
+++ b/apps/client/src/features/auth/components/account-page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+interface AccountPageProps {
+  user: {
+    id: string;
+    email: string;
+    avatarUrl: string | null;
+    name: string | null;
+  };
+}
+
+export function AccountPage({ user }: AccountPageProps) {
+  const displayName = user.name ?? user.email.split('@')[0];
+  const initials = displayName.charAt(0).toUpperCase();
+
+  return (
+    <div className="mx-auto max-w-md px-6 py-12">
+      <h1
+        className="mb-8 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent)]"
+        style={{ fontFamily: 'Inter, sans-serif' }}
+      >
+        Account
+      </h1>
+
+      {/* Avatar + Name */}
+      <div className="mb-8 flex items-center gap-4">
+        {user.avatarUrl ? (
+          <img
+            src={user.avatarUrl}
+            alt=""
+            className="h-16 w-16 rounded-full object-cover"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--accent)] text-xl font-bold text-white">
+            {initials}
+          </span>
+        )}
+        <div>
+          <p className="text-sm font-medium text-[var(--fg)]">{displayName}</p>
+          <p className="text-xs text-[var(--date-color)]">{user.email}</p>
+        </div>
+      </div>
+
+      {/* Info fields */}
+      <div className="flex flex-col gap-5">
+        <div>
+          <p
+            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
+            style={{ fontFamily: 'Inter, sans-serif' }}
+          >
+            名前
+          </p>
+          <p className="text-sm text-[var(--fg)]">{displayName}</p>
+        </div>
+        <div>
+          <p
+            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
+            style={{ fontFamily: 'Inter, sans-serif' }}
+          >
+            メールアドレス
+          </p>
+          <p className="text-sm text-[var(--fg)]">{user.email}</p>
+        </div>
+        <div>
+          <p
+            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
+            style={{ fontFamily: 'Inter, sans-serif' }}
+          >
+            ユーザーID
+          </p>
+          <p className="font-mono text-xs text-[var(--date-color)]">{user.id}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
+import { UserAvatar } from '@/features/auth/components/user-avatar';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { COLLAPSED_WIDTH, EXPANDED_WIDTH, useSidebar } from '@/lib/sidebar-context';
 import { useTheme } from '@/lib/theme-context';
@@ -52,7 +53,7 @@ const NAV_ITEMS: NavItem[] = [
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { logout } = useAuth();
+  const { auth, logout } = useAuth();
   const { expanded, toggle } = useSidebar();
   const { theme, toggle: toggleTheme } = useTheme();
 
@@ -135,6 +136,16 @@ export function Sidebar() {
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* User avatar */}
+        {auth && (
+          <UserAvatar
+            avatarUrl={auth.user.avatarUrl}
+            name={auth.user.name}
+            email={auth.user.email}
+            expanded={expanded}
+          />
+        )}
 
         {/* Dark mode toggle */}
         <button

--- a/apps/client/src/features/auth/components/user-avatar.tsx
+++ b/apps/client/src/features/auth/components/user-avatar.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface UserAvatarProps {
+  avatarUrl: string | null;
+  name: string | null;
+  email: string;
+  expanded: boolean;
+}
+
+export function UserAvatar({ avatarUrl, name, email, expanded }: UserAvatarProps) {
+  const pathname = usePathname();
+  const isActive = pathname === '/account';
+  const displayName = name ?? email.split('@')[0];
+  const initials = displayName.charAt(0).toUpperCase();
+
+  return (
+    <Link
+      href="/account"
+      title="アカウント"
+      className={`flex items-center gap-3 transition-all ${
+        isActive
+          ? 'bg-[var(--accent-light)] text-[var(--accent)]'
+          : 'text-[var(--date-color)] hover:bg-[var(--toolbar-hover)] hover:text-[var(--fg)]'
+      } ${expanded ? 'mx-2 rounded-lg px-2.5 py-2' : 'self-center rounded-full px-2.5 py-1.5'}`}
+    >
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt=""
+          className="h-[18px] w-[18px] shrink-0 rounded-full object-cover"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[8px] font-bold text-white">
+          {initials}
+        </span>
+      )}
+      {expanded && (
+        <span
+          className="truncate text-[11px] font-medium tracking-[0.08em]"
+          style={{ fontFamily: 'Inter, sans-serif' }}
+        >
+          {displayName}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -8,7 +8,7 @@ import { clearTokens, getAccessToken, getRefreshToken, setTokens } from '@/lib/a
 interface AuthState {
   accessToken: string;
   refreshToken: string;
-  user: { id: string; email: string };
+  user: { id: string; email: string; avatarUrl: string | null; name: string | null };
 }
 
 export function useAuth() {
@@ -28,7 +28,9 @@ export function useAuth() {
       const meRes = await client.fetch('/api/v1/auth/me');
 
       if (meRes.ok) {
-        const data = (await meRes.json()) as { user: { id: string; email: string } };
+        const data = (await meRes.json()) as {
+          user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+        };
         setAuth({ accessToken: token, refreshToken: getRefreshToken() ?? '', user: data.user });
         setApi(client);
         posthog.identify(data.user.id, { email: data.user.email });
@@ -64,7 +66,9 @@ export function useAuth() {
       const retryRes = await newClient.fetch('/api/v1/auth/me');
 
       if (retryRes.ok) {
-        const userData = (await retryRes.json()) as { user: { id: string; email: string } };
+        const userData = (await retryRes.json()) as {
+          user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+        };
         setAuth({
           accessToken: refreshData.session.accessToken,
           refreshToken: refreshData.session.refreshToken,
@@ -93,7 +97,7 @@ export function useAuth() {
       return data.error;
     }
     const data = (await res.json()) as {
-      user: { id: string; email: string };
+      user: { id: string; email: string; avatarUrl: string | null; name: string | null };
       session: { accessToken: string; refreshToken: string };
     };
     setTokens(data.session.accessToken, data.session.refreshToken);
@@ -118,7 +122,7 @@ export function useAuth() {
       return data.error;
     }
     const data = (await res.json()) as {
-      user: { id: string; email: string };
+      user: { id: string; email: string; avatarUrl: string | null; name: string | null };
       session: { accessToken: string; refreshToken: string } | null;
     };
     if (data.session) {

--- a/apps/client/test/features/auth/hooks/use-auth.test.ts
+++ b/apps/client/test/features/auth/hooks/use-auth.test.ts
@@ -21,7 +21,12 @@ describe('useAuth', () => {
 
   it('login returns null on success and stores tokens', async () => {
     const session = { accessToken: 'at', refreshToken: 'rt' };
-    const user = { id: 'u1', email: 'a@b.com' };
+    const user = {
+      id: 'u1',
+      email: 'a@b.com',
+      avatarUrl: 'https://example.com/avatar.jpg',
+      name: 'Test User',
+    };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
     const { result } = renderHook(() => useAuth());
@@ -53,7 +58,7 @@ describe('useAuth', () => {
 
   it('signup returns null on success and stores tokens', async () => {
     const session = { accessToken: 'at2', refreshToken: 'rt2' };
-    const user = { id: 'u2', email: 'b@c.com' };
+    const user = { id: 'u2', email: 'b@c.com', avatarUrl: null, name: null };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
     const { result } = renderHook(() => useAuth());
@@ -85,7 +90,12 @@ describe('useAuth', () => {
 
   it('logout clears tokens and resets state', async () => {
     const session = { accessToken: 'at', refreshToken: 'rt' };
-    const user = { id: 'u1', email: 'a@b.com' };
+    const user = {
+      id: 'u1',
+      email: 'a@b.com',
+      avatarUrl: 'https://example.com/avatar.jpg',
+      name: 'Test User',
+    };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
     const { result } = renderHook(() => useAuth());
@@ -109,7 +119,16 @@ describe('useAuth', () => {
   it('initial load with valid token sets auth state', async () => {
     localStorage.setItem('oryzae_access_token', 'existing-token');
 
-    mockFetch.mockResolvedValueOnce(mockResponse(true, { user: { id: 'u1', email: 'a@b.com' } }));
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(true, {
+        user: {
+          id: 'u1',
+          email: 'a@b.com',
+          avatarUrl: 'https://example.com/avatar.jpg',
+          name: 'Test User',
+        },
+      }),
+    );
 
     const { result } = renderHook(() => useAuth());
 

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -10,6 +10,25 @@ function getSupabaseAuthClient() {
   return createClient(url, anonKey);
 }
 
+function extractUserProfile(user: {
+  id: string;
+  email?: string;
+  user_metadata?: Record<string, unknown>;
+}) {
+  const meta = user.user_metadata ?? {};
+  return {
+    id: user.id,
+    email: user.email,
+    avatarUrl: typeof meta.avatar_url === 'string' ? meta.avatar_url : null,
+    name:
+      typeof meta.full_name === 'string'
+        ? meta.full_name
+        : typeof meta.name === 'string'
+          ? meta.name
+          : null,
+  };
+}
+
 export const authRoutes = new Hono()
   .post('/signup', async (c) => {
     const body = credentialsSchema.parse(await c.req.json());
@@ -26,7 +45,9 @@ export const authRoutes = new Hono()
 
     return c.json(
       {
-        user: { id: data.user?.id, email: data.user?.email },
+        user: data.user
+          ? extractUserProfile(data.user)
+          : { id: undefined, email: undefined, avatarUrl: null, name: null },
         session: data.session
           ? {
               accessToken: data.session.access_token,
@@ -52,7 +73,7 @@ export const authRoutes = new Hono()
     }
 
     return c.json({
-      user: { id: data.user.id, email: data.user.email },
+      user: extractUserProfile(data.user),
       session: {
         accessToken: data.session.access_token,
         refreshToken: data.session.refresh_token,
@@ -109,7 +130,7 @@ export const authRoutes = new Hono()
     }
 
     return c.json({
-      user: { id: data.user.id, email: data.user.email },
+      user: extractUserProfile(data.user),
       session: {
         accessToken: data.session.access_token,
         refreshToken: data.session.refresh_token,
@@ -175,5 +196,5 @@ export const authRoutes = new Hono()
       return c.json({ error: 'Invalid token' }, 401);
     }
 
-    return c.json({ user: { id: user.id, email: user.email } });
+    return c.json({ user: extractUserProfile(user) });
   });


### PR DESCRIPTION
## Summary
- サーバー `/auth/me`, `/login`, `/signup` のレスポンスに `avatarUrl` と `name` を追加（Supabase `user_metadata` から取得）
- サイドバー下部にユーザーアバターを表示（Google OAuth: プロフィール画像、email/password: イニシャルフォールバック）
- クリックで `/account` ページに遷移し、ユーザー情報を閲覧可能
- `AuthState.user` に `avatarUrl`, `name` フィールドを追加

## 変更ファイル
- `apps/server/.../routes/auth.ts` — `extractUserProfile()` ヘルパー追加、全認証レスポンスに適用
- `apps/client/src/features/auth/hooks/use-auth.ts` — user 型に `avatarUrl`, `name` 追加
- `apps/client/src/features/auth/components/user-avatar.tsx` — アバターコンポーネント (新規)
- `apps/client/src/features/auth/components/sidebar.tsx` — アバター統合
- `apps/client/src/features/auth/components/account-page.tsx` — アカウントページ (新規)
- `apps/client/src/app/(protected)/account/page.tsx` — ページルート (新規)
- `apps/client/src/components/ui/page-footer.tsx` — ACCOUNT エントリ追加

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全 196 テスト通過
- [x] `pnpm dep-cruise` 依存違反なし
- [x] `pnpm knip` デッドコードなし
- [ ] ブラウザ確認: ログイン → サイドバーにアバター表示 → クリック → `/account` ページ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)