### PR TITLE
fix: Dependabot を root のみに制限（pnpm monorepo 対応）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,68 +1,9 @@
 version: 2
 updates:
-  # Root (devDependencies: biome, knip, lint-staged, simple-git-hooks)
+  # Root — pnpm monorepo の lockfile はルートで管理されるため、
+  # ルートのみを対象にする。個別ディレクトリを指定すると lockfile が競合する。
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 10
-
-  # apps/client
-  - package-ecosystem: "npm"
-    directory: "/apps/client"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 10
-
-  # apps/server
-  - package-ecosystem: "npm"
-    directory: "/apps/server"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 10
-
-  # apps/admin
-  - package-ecosystem: "npm"
-    directory: "/apps/admin"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    open-pull-requests-limit: 10
-
-  # packages/shared
-  - package-ecosystem: "npm"
-    directory: "/packages/shared"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

- pnpm monorepo では lockfile がルートで一元管理されるため、個別ディレクトリ（`/apps/client` 等）の Dependabot 設定を削除
- per-directory PR は lockfile コンフリクトで CI が全て失敗していた問題を解消
- root `/` + GitHub Actions のみに絞り、PR の重複・競合を防止

## Test plan

- [x] lint + typecheck パス
- [ ] 次回の Dependabot 実行で root のみから PR が作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)