### PR TITLE
fix: /costs ルーティング衝突を解消

### DIFF
--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -90,6 +90,67 @@ export const adminFermentations = new Hono<Env>()
       pagination: { page, limit, total: count ?? 0 },
     });
   })
+  .get('/costs', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const page = Number(c.req.query('page') ?? '1');
+    const limit = Number(c.req.query('limit') ?? '10');
+    const offset = (page - 1) * limit;
+    const dateFrom = c.req.query('date_from');
+    const dateTo = c.req.query('date_to');
+
+    let costsQuery = supabase
+      .from('fermentation_results')
+      .select('id, user_id, status, generation_id, created_at', { count: 'exact' })
+      .not('generation_id', 'is', null);
+    if (dateFrom) costsQuery = costsQuery.gte('created_at', dateFrom);
+    if (dateTo) costsQuery = costsQuery.lte('created_at', `${dateTo}T23:59:59.999Z`);
+
+    const { data, error, count } = await costsQuery
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) return c.json({ error: error.message }, 500);
+
+    const items = await Promise.all(
+      (data ?? []).map(async (row) => {
+        try {
+          const info = await gateway.getGenerationInfo({ id: row.generation_id });
+          return { ...row, cost: info };
+        } catch {
+          return { ...row, cost: null };
+        }
+      }),
+    );
+
+    return c.json({
+      data: items,
+      pagination: { page, limit, total: count ?? 0 },
+    });
+  })
+  .get('/:id/cost', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const id = c.req.param('id');
+
+    const { data, error } = await supabase
+      .from('fermentation_results')
+      .select('generation_id')
+      .eq('id', id)
+      .single();
+
+    if (error || !data) return c.json({ error: 'Fermentation result not found' }, 404);
+
+    if (!data.generation_id) {
+      return c.json({ error: 'No generation ID available for cost tracking' }, 404);
+    }
+
+    const info = await gateway.getGenerationInfo({ id: data.generation_id });
+
+    return c.json({
+      fermentationResultId: id,
+      generationId: data.generation_id,
+      cost: info,
+    });
+  })
   .get('/:id', async (c) => {
     const supabase = c.get('adminSupabase');
     const id = c.req.param('id');
@@ -197,67 +258,6 @@ export const adminFermentations = new Hono<Env>()
       snippets,
       letter,
       keywords,
-    });
-  })
-  .get('/:id/cost', async (c) => {
-    const supabase = c.get('adminSupabase');
-    const id = c.req.param('id');
-
-    const { data, error } = await supabase
-      .from('fermentation_results')
-      .select('generation_id')
-      .eq('id', id)
-      .single();
-
-    if (error || !data) return c.json({ error: 'Fermentation result not found' }, 404);
-
-    if (!data.generation_id) {
-      return c.json({ error: 'No generation ID available for cost tracking' }, 404);
-    }
-
-    const info = await gateway.getGenerationInfo({ id: data.generation_id });
-
-    return c.json({
-      fermentationResultId: id,
-      generationId: data.generation_id,
-      cost: info,
-    });
-  })
-  .get('/costs', async (c) => {
-    const supabase = c.get('adminSupabase');
-    const page = Number(c.req.query('page') ?? '1');
-    const limit = Number(c.req.query('limit') ?? '10');
-    const offset = (page - 1) * limit;
-    const dateFrom = c.req.query('date_from');
-    const dateTo = c.req.query('date_to');
-
-    let costsQuery = supabase
-      .from('fermentation_results')
-      .select('id, user_id, status, generation_id, created_at', { count: 'exact' })
-      .not('generation_id', 'is', null);
-    if (dateFrom) costsQuery = costsQuery.gte('created_at', dateFrom);
-    if (dateTo) costsQuery = costsQuery.lte('created_at', `${dateTo}T23:59:59.999Z`);
-
-    const { data, error, count } = await costsQuery
-      .order('created_at', { ascending: false })
-      .range(offset, offset + limit - 1);
-
-    if (error) return c.json({ error: error.message }, 500);
-
-    const items = await Promise.all(
-      (data ?? []).map(async (row) => {
-        try {
-          const info = await gateway.getGenerationInfo({ id: row.generation_id });
-          return { ...row, cost: info };
-        } catch {
-          return { ...row, cost: null };
-        }
-      }),
-    );
-
-    return c.json({
-      data: items,
-      pagination: { page, limit, total: count ?? 0 },
     });
   })
   .post('/:id/retry', async (c) => {


### PR DESCRIPTION
## Summary

`/costs` リクエストが `/:id` ルートにマッチして 404 を返していた。
`/costs` と `/:id/cost` を `/:id` より前に移動して正しくルーティング。

## 原因

PR #127 で `/:id` ルート（発酵詳細）が追加された際、既存の `/costs` より前に配置されたため、
Hono が `/costs` を `/:id` として解釈し `id = "costs"` で DB 検索 → 404。

## Test plan

- [x] typecheck 全パス
- [x] 167 server tests 全パス
- [x] API: `/costs?page=1&limit=10` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)