### PR TITLE
fix(server): fermentation cron の対象日を JST 前日に修正

### DIFF
--- a/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
@@ -6,6 +6,7 @@ import { getSupabaseClient } from '../../../shared/infrastructure/supabase-clien
 import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
+import { getFermentationTargetDateKey } from './cron-target-date.js';
 
 const generateId = () => crypto.randomUUID();
 
@@ -55,11 +56,8 @@ export const cronFermentation = new Hono()
       listActiveUserIds,
     );
 
-    // Use "today" in JST (UTC+9) since the cron fires at 3 AM JST
-    const now = new Date();
-    const jstOffset = 9 * 60 * 60 * 1000;
-    const jstDate = new Date(now.getTime() + jstOffset);
-    const dateKey = jstDate.toISOString().slice(0, 10);
+    // Cron は JST 03:00 に発火するため、対象は「直前に閉じた一日」= JST での前日
+    const dateKey = getFermentationTargetDateKey(new Date());
 
     const result = await usecase.execute(dateKey);
 

--- a/apps/server/src/contexts/fermentation/presentation/routes/cron-target-date.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/cron-target-date.ts
@@ -1,0 +1,14 @@
+/**
+ * Cron は JST 03:00 (UTC 18:00) に発火する。
+ * この時点で処理すべきは「直前に閉じた一日」= JST での前日分のエントリ。
+ *
+ * 例: UTC 2026-04-16T18:00:00Z (= JST 2026-04-17T03:00:00)
+ *     → targetDateKey = "2026-04-16" (JST での「昨日」)
+ */
+export function getFermentationTargetDateKey(now: Date): string {
+  const jstOffsetMs = 9 * 60 * 60 * 1000;
+  const jstNow = new Date(now.getTime() + jstOffsetMs);
+  // 発火時の JST 日付から 1 日引くことで、直前に閉じた一日を対象にする
+  jstNow.setUTCDate(jstNow.getUTCDate() - 1);
+  return jstNow.toISOString().slice(0, 10);
+}

--- a/apps/server/test/contexts/fermentation/presentation/routes/cron-target-date.test.ts
+++ b/apps/server/test/contexts/fermentation/presentation/routes/cron-target-date.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getFermentationTargetDateKey } from '@/contexts/fermentation/presentation/routes/cron-target-date.js';
+
+describe('getFermentationTargetDateKey', () => {
+  it('returns the previous JST day when cron fires at JST 03:00 (UTC 18:00)', () => {
+    // 2026-04-16T18:00:00Z = JST 2026-04-17T03:00:00
+    // Cron fires here, but target is entries written on 2026-04-16 (JST)
+    const now = new Date('2026-04-16T18:00:00.000Z');
+    expect(getFermentationTargetDateKey(now)).toBe('2026-04-16');
+  });
+
+  it('handles month boundaries correctly', () => {
+    // Cron fires at JST 2026-05-01T03:00:00 (= UTC 2026-04-30T18:00:00)
+    // Target should be JST 2026-04-30
+    const now = new Date('2026-04-30T18:00:00.000Z');
+    expect(getFermentationTargetDateKey(now)).toBe('2026-04-30');
+  });
+
+  it('handles year boundaries correctly', () => {
+    // Cron fires at JST 2027-01-01T03:00:00 (= UTC 2026-12-31T18:00:00)
+    // Target should be JST 2026-12-31
+    const now = new Date('2026-12-31T18:00:00.000Z');
+    expect(getFermentationTargetDateKey(now)).toBe('2026-12-31');
+  });
+
+  it('handles leap day boundaries', () => {
+    // Cron fires at JST 2028-03-01T03:00:00 (= UTC 2028-02-29T18:00:00)
+    // Target should be JST 2028-02-29
+    const now = new Date('2028-02-29T18:00:00.000Z');
+    expect(getFermentationTargetDateKey(now)).toBe('2028-02-29');
+  });
+});


### PR DESCRIPTION
## Summary
- Fermentation の自動発火（JST 03:00 / UTC 18:00）が、対象日を JST での「今日」として計算していたため、前日に書かれたエントリを拾えず `totalFermentations: 0` で終わっていた。
- 発火時刻から JST での前日を返す純粋関数 `getFermentationTargetDateKey` を追加し、`cron-fermentation` ルートから使うように変更。

## 原因
`cron-fermentation.ts` の従来ロジックは `now + 9h` を ISO 文字列に変換して「JST の今日」を取得していた。03:00 発火時点では、処理すべきは直前に閉じた一日＝JST 前日だが、当日の dateKey を渡していたため `listByUserIdAndDate` が空配列を返し、fermentation の起動に至らなかった。

## 修正
- `apps/server/src/contexts/fermentation/presentation/routes/cron-target-date.ts` — 発火時刻を受け取り JST 前日の dateKey を返すヘルパー。
- `apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts` — 新ヘルパーに置換。
- `apps/server/test/contexts/fermentation/presentation/routes/cron-target-date.test.ts` — 通常日・月末・年末・閏年の4ケース。

## Test plan
- [x] `pnpm --filter @oryzae/server test` — 全 177 件通過
- [x] `pnpm typecheck` — クリーン
- [x] `pnpm dep-cruise` — 違反なし
- [ ] デプロイ後、次回 03:00 JST 発火で `fermentation_results` に当日分のレコードが入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)