### PR TITLE
feat(admin): 発酵プロセスの手動発火機能を追加

### DIFF
--- a/apps/admin/src/app/(protected)/fermentations/page.tsx
+++ b/apps/admin/src/app/(protected)/fermentations/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { DateRangeSelector } from '@/components/ui/date-range-selector';
 import { FermentationTable } from '@/features/fermentations/components/fermentation-table';
+import { TriggerScheduledFermentationPanel } from '@/features/fermentations/components/trigger-scheduled-fermentation-panel';
 import { useFermentations } from '@/features/fermentations/hooks/use-fermentations';
 import { useDateRange } from '@/lib/use-date-range';
 
@@ -49,6 +50,8 @@ export default function FermentationsPage() {
           </Button>
         </div>
       </div>
+
+      <TriggerScheduledFermentationPanel onCompleted={refresh} />
 
       {error && (
         <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/apps/admin/src/features/fermentations/components/trigger-scheduled-fermentation-panel.tsx
+++ b/apps/admin/src/features/fermentations/components/trigger-scheduled-fermentation-panel.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Play } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useTriggerScheduledFermentation } from '../hooks/use-trigger-scheduled-fermentation';
+
+/**
+ * JST での「昨日」を YYYY-MM-DD で返す。input[type=date] の初期値 + UX プレビュー用。
+ * サーバ側でも dateKey 未指定時は JST 前日がデフォルト。
+ */
+function getJstYesterdayDateKey(): string {
+  const now = new Date();
+  const jstOffsetMs = 9 * 60 * 60 * 1000;
+  const jst = new Date(now.getTime() + jstOffsetMs);
+  jst.setUTCDate(jst.getUTCDate() - 1);
+  return jst.toISOString().slice(0, 10);
+}
+
+interface Props {
+  onCompleted?: () => void;
+}
+
+export function TriggerScheduledFermentationPanel({ onCompleted }: Props) {
+  const [dateKey, setDateKey] = useState(getJstYesterdayDateKey());
+  const [confirming, setConfirming] = useState(false);
+  const { trigger, loading, error, result } = useTriggerScheduledFermentation();
+
+  const handleRun = async () => {
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+    setConfirming(false);
+    const ok = await trigger(dateKey);
+    if (ok) onCompleted?.();
+  };
+
+  return (
+    <div className="rounded-md border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium">手動で発酵プロセスを発火</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            指定日 (JST) のエントリに対して ScheduledFermentation を実行します
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Input
+            type="date"
+            value={dateKey}
+            onChange={(e) => {
+              setDateKey(e.target.value);
+              setConfirming(false);
+            }}
+            disabled={loading}
+            className="w-auto h-8 text-xs"
+          />
+          <Button
+            variant={confirming ? 'destructive' : 'default'}
+            size="sm"
+            onClick={handleRun}
+            disabled={loading || !dateKey}
+          >
+            <Play className={`h-3 w-3 mr-1.5 ${loading ? 'animate-pulse' : ''}`} />
+            {loading ? '実行中...' : confirming ? '本当に実行する' : '実行'}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-md bg-muted/50 px-3 py-2 text-xs space-y-1">
+          <div className="font-mono text-muted-foreground">
+            {result.dateKey} — users: {result.totalUsers} · fermentations:{' '}
+            {result.totalFermentations} · succeeded: {result.succeeded} · failed: {result.failed}
+          </div>
+          {result.errors.length > 0 && (
+            <details className="text-destructive">
+              <summary className="cursor-pointer">errors ({result.errors.length})</summary>
+              <ul className="mt-1 space-y-0.5 font-mono">
+                {result.errors.map((e) => (
+                  <li key={`${e.userId}-${e.questionId}`}>
+                    {e.userId.slice(0, 8)} / {e.questionId.slice(0, 8)}: {e.error}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/fermentations/hooks/use-trigger-scheduled-fermentation.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-trigger-scheduled-fermentation.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+export interface TriggerScheduledFermentationResult {
+  dateKey: string;
+  totalUsers: number;
+  totalFermentations: number;
+  succeeded: number;
+  failed: number;
+  errors: Array<{ userId: string; questionId: string; error: string }>;
+}
+
+export function useTriggerScheduledFermentation() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<TriggerScheduledFermentationResult | null>(null);
+
+  const trigger = useCallback(async (dateKey?: string): Promise<boolean> => {
+    const token = getAccessToken();
+    if (!token) return false;
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/admin/fermentations/trigger-scheduled', {
+      method: 'POST',
+      body: JSON.stringify(dateKey ? { dateKey } : {}),
+    });
+
+    if (res.ok) {
+      const body = (await res.json()) as TriggerScheduledFermentationResult;
+      setResult(body);
+      setLoading(false);
+      return true;
+    }
+
+    setError('発酵プロセスの発火に失敗しました');
+    setLoading(false);
+    return false;
+  }, []);
+
+  return { trigger, loading, error, result };
+}

--- a/apps/admin/src/features/fermentations/hooks/use-trigger-scheduled-fermentation.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-trigger-scheduled-fermentation.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
 
-export interface TriggerScheduledFermentationResult {
+interface TriggerScheduledFermentationResult {
   dateKey: string;
   totalUsers: number;
   totalFermentations: number;

--- a/apps/admin/test/features/fermentations/hooks/use-trigger-scheduled-fermentation.test.ts
+++ b/apps/admin/test/features/fermentations/hooks/use-trigger-scheduled-fermentation.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTriggerScheduledFermentation } from '@/features/fermentations/hooks/use-trigger-scheduled-fermentation';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 500,
+  } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
+}
+
+describe('useTriggerScheduledFermentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_admin_access_token', 'test-token');
+  });
+
+  it('sends POST with dateKey and stores the result on success', async () => {
+    const body = {
+      dateKey: '2026-04-15',
+      totalUsers: 2,
+      totalFermentations: 3,
+      succeeded: 3,
+      failed: 0,
+      errors: [],
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse(true, body));
+
+    const { result } = renderHook(() => useTriggerScheduledFermentation());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.trigger('2026-04-15');
+    });
+
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/fermentations/trigger-scheduled',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ dateKey: '2026-04-15' }),
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.result).toEqual(body);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sends empty body when dateKey is omitted', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(true, {
+        dateKey: '2026-04-15',
+        totalUsers: 0,
+        totalFermentations: 0,
+        succeeded: 0,
+        failed: 0,
+        errors: [],
+      }),
+    );
+
+    const { result } = renderHook(() => useTriggerScheduledFermentation());
+
+    await act(async () => {
+      await result.current.trigger();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/fermentations/trigger-scheduled',
+      expect.objectContaining({
+        body: JSON.stringify({}),
+      }),
+    );
+  });
+
+  it('sets error on failure and returns false', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(false, {}));
+
+    const { result } = renderHook(() => useTriggerScheduledFermentation());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.trigger('2026-04-15');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toBe('発酵プロセスの発火に失敗しました');
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -1,9 +1,22 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { gateway } from 'ai';
 import { Hono } from 'hono';
+import { z } from 'zod';
+import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
+import { SupabaseQuestionRepository } from '../../../question/infrastructure/repositories/supabase-question.repository.js';
+import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
+import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
+import { getFermentationTargetDateKey } from './cron-target-date.js';
+
+const triggerScheduledSchema = z.object({
+  dateKey: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'dateKey must be in YYYY-MM-DD format')
+    .optional(),
+});
 
 type Env = {
   Variables: {
@@ -259,6 +272,39 @@ export const adminFermentations = new Hono<Env>()
       letter,
       keywords,
     });
+  })
+  .post('/trigger-scheduled', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const body = triggerScheduledSchema.parse(await c.req.json().catch(() => ({})));
+
+    // 省略時は cron と同じ「JST 前日」
+    const dateKey = body.dateKey ?? getFermentationTargetDateKey(new Date());
+
+    const entryRepo = new SupabaseEntryRepository(supabase);
+    const questionRepo = new SupabaseQuestionRepository(supabase);
+    const questionTransactionRepo = new SupabaseQuestionTransactionRepository(supabase);
+    const fermentationRepo = new SupabaseFermentationRepository(supabase);
+    const llmGateway = new VercelAiAnalysisGateway();
+
+    const listActiveUserIds = async (): Promise<string[]> => {
+      const { data, error } = await supabase.from('entries').select('user_id').limit(1000);
+      if (error) throw error;
+      return [...new Set((data ?? []).map((row: { user_id: string }) => row.user_id))];
+    };
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      questionTransactionRepo,
+      fermentationRepo,
+      llmGateway,
+      () => crypto.randomUUID(),
+      listActiveUserIds,
+    );
+
+    const result = await usecase.execute(dateKey);
+
+    return c.json({ dateKey, ...result });
   })
   .post('/:id/retry', async (c) => {
     const supabase = c.get('adminSupabase');


### PR DESCRIPTION
## Summary
- Admin 画面の Fermentations ページ上部に、任意日付の ScheduledFermentation を手動発火するパネルを追加。
- 新規 admin エンドポイント `POST /api/v1/admin/fermentations/trigger-scheduled` を追加。`dateKey` (YYYY-MM-DD) を任意で受け取り、省略時は cron と同じ「JST 前日」がデフォルト。
- `ScheduledFermentationUsecase` を再利用して発火結果 (`totalUsers`, `totalFermentations`, `succeeded`, `failed`, `errors`) を返し、UI に表示。

## 変更ファイル
- server: `apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts`
- admin:
  - `apps/admin/src/features/fermentations/hooks/use-trigger-scheduled-fermentation.ts`
  - `apps/admin/src/features/fermentations/components/trigger-scheduled-fermentation-panel.tsx`
  - `apps/admin/src/app/(protected)/fermentations/page.tsx`
- test: `apps/admin/test/features/fermentations/hooks/use-trigger-scheduled-fermentation.test.ts`

## UX
- 日付ピッカー（初期値は JST 前日）+ 実行ボタン。
- 誤爆防止に 2 段階確認（1 回目クリックで「本当に実行する」に変化 → 2 回目で発火）。
- 実行後に結果サマリを表示し、エラーがあれば折り畳みで詳細展開。
- 成功時は Fermentations 一覧を自動再取得。

## Test plan
- [x] `pnpm typecheck` — クリーン
- [x] `pnpm test` — server 177 / admin 54 全通過
- [x] `pnpm dep-cruise` — 違反なし
- [ ] デプロイ後、admin → Fermentations ページで日付選択 → 実行 → 結果が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)