### PR TITLE
feat: Fermentations に User ID / ステータスフィルタ追加

### DIFF
--- a/apps/admin/src/app/(protected)/fermentations/page.tsx
+++ b/apps/admin/src/app/(protected)/fermentations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Search, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -10,19 +10,42 @@ import { TriggerScheduledFermentationPanel } from '@/features/fermentations/comp
 import { useFermentations } from '@/features/fermentations/hooks/use-fermentations';
 import { useDateRange } from '@/lib/use-date-range';
 
+const STATUS_OPTIONS = ['all', 'completed', 'failed', 'processing', 'pending'] as const;
+
 export default function FermentationsPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
+  const [userFilter, setUserFilter] = useState('');
+  const [appliedUser, setAppliedUser] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
   const { preset, dateFrom, dateTo, selectPreset, setCustomRange } = useDateRange('30d');
   const { data, pagination, loading, error, refresh, retryFermentation } = useFermentations({
     page,
     dateFrom,
     dateTo,
+    userId: appliedUser || undefined,
+    status: statusFilter === 'all' ? undefined : statusFilter,
   });
 
   const totalPages = Math.ceil(pagination.total / pagination.limit);
   const completed = data.filter((i) => i.status === 'completed').length;
   const failed = data.filter((i) => i.status === 'failed').length;
+
+  function handleUserSearch() {
+    setAppliedUser(userFilter.trim());
+    setPage(1);
+  }
+
+  function clearUserFilter() {
+    setUserFilter('');
+    setAppliedUser('');
+    setPage(1);
+  }
+
+  function handleStatusChange(s: string) {
+    setStatusFilter(s);
+    setPage(1);
+  }
 
   return (
     <div className="space-y-4">
@@ -48,6 +71,46 @@ export default function FermentationsPage() {
           <Button variant="ghost" size="icon-xs" onClick={refresh} disabled={loading}>
             <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
           </Button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex items-center">
+          <Search className="absolute left-2 h-3 w-3 text-muted-foreground" />
+          <input
+            type="text"
+            value={userFilter}
+            onChange={(e) => setUserFilter(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleUserSearch()}
+            placeholder="User ID or email..."
+            className="h-7 w-56 rounded-md border border-border bg-transparent pl-7 pr-7 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          {appliedUser && (
+            <button
+              type="button"
+              onClick={clearUserFilter}
+              className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-0.5">
+          {STATUS_OPTIONS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => handleStatusChange(s)}
+              className={`rounded-md px-2 py-1 text-xs transition-colors ${
+                statusFilter === s
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {s}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
@@ -27,6 +27,8 @@ interface UseFermentationsParams {
   limit?: number;
   dateFrom?: string;
   dateTo?: string;
+  userId?: string;
+  status?: string;
 }
 
 export function useFermentations(params?: UseFermentationsParams) {
@@ -34,6 +36,8 @@ export function useFermentations(params?: UseFermentationsParams) {
   const limit = params?.limit ?? 30;
   const dateFrom = params?.dateFrom;
   const dateTo = params?.dateTo;
+  const userId = params?.userId;
+  const status = params?.status;
   const [data, setData] = useState<FermentationItem[]>([]);
   const [pagination, setPagination] = useState({ page: 1, limit: 30, total: 0 });
   const [loading, setLoading] = useState(true);
@@ -52,6 +56,8 @@ export function useFermentations(params?: UseFermentationsParams) {
     searchParams.set('limit', String(limit));
     if (dateFrom) searchParams.set('date_from', dateFrom);
     if (dateTo) searchParams.set('date_to', dateTo);
+    if (userId) searchParams.set('user_id', userId);
+    if (status) searchParams.set('status', status);
 
     const res = await api.fetch(`/api/v1/admin/fermentations?${searchParams.toString()}`);
     if (res.ok) {
@@ -62,7 +68,7 @@ export function useFermentations(params?: UseFermentationsParams) {
       setError('発酵データの取得に失敗しました');
     }
     setLoading(false);
-  }, [page, limit, dateFrom, dateTo]);
+  }, [page, limit, dateFrom, dateTo, userId, status]);
 
   useEffect(() => {
     fetchData();

--- a/apps/admin/test/features/fermentations/hooks/use-fermentations.test.ts
+++ b/apps/admin/test/features/fermentations/hooks/use-fermentations.test.ts
@@ -48,6 +48,22 @@ describe('useFermentations', () => {
     expect(result.current.data[0].status).toBe('completed');
   });
 
+  it('passes userId and status filters to API', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(true, { data: [], pagination: { page: 1, limit: 30, total: 0 } }),
+    );
+
+    renderHook(() => useFermentations({ userId: 'u123', status: 'failed' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('user_id=u123');
+    expect(calledUrl).toContain('status=failed');
+  });
+
   it('sets error on fetch failure', async () => {
     mockFetch.mockResolvedValueOnce(mockResponse(false, {}));
 

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -83,12 +83,17 @@ export const adminFermentations = new Hono<Env>()
     const dateFrom = c.req.query('date_from');
     const dateTo = c.req.query('date_to');
 
+    const userId = c.req.query('user_id');
+    const status = c.req.query('status');
+
     let listQuery = supabase
       .from('fermentation_results')
       .select(
         'id, user_id, question_id, entry_id, target_period, status, generation_id, error_message, created_at, updated_at',
         { count: 'exact' },
       );
+    if (userId) listQuery = listQuery.eq('user_id', userId);
+    if (status) listQuery = listQuery.eq('status', status);
     if (dateFrom) listQuery = listQuery.gte('created_at', dateFrom);
     if (dateTo) listQuery = listQuery.lte('created_at', `${dateTo}T23:59:59.999Z`);
 


### PR DESCRIPTION
## Summary

Fermentations 一覧ページにフィルタ機能を追加:

- **User ID 検索**: テキスト入力 → Enter で適用。X ボタンでクリア
- **ステータスフィルタ**: all / completed / failed / processing / pending のトグルボタン
- フィルタ適用時にページを 1 に自動リセット

バックエンドに `user_id`, `status` クエリパラメータを追加。

## Test plan

- [x] typecheck 全パス
- [x] 273 tests 全パス (server 177 + client 41 + admin 55)
- [x] dep-cruise 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)