### PR TITLE
feat: 発酵一覧メールアドレス表示 + ジャーナリング内容のサーバーサイドマスク

### DIFF
--- a/apps/admin/src/app/(protected)/fermentations/[id]/page.tsx
+++ b/apps/admin/src/app/(protected)/fermentations/[id]/page.tsx
@@ -47,6 +47,12 @@ export default function FermentationDetailPage() {
 
       <FermentationDetailHeader data={data} onRetry={retryFermentation} />
 
+      {data.masked && (
+        <div className="rounded-md border border-border/50 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          他のユーザーのジャーナリング内容はプライバシー保護のためマスクされています
+        </div>
+      )}
+
       {data.worksheet && <FermentationWorksheet worksheet={data.worksheet} />}
 
       <FermentationSnippets snippets={data.snippets} />

--- a/apps/admin/src/features/fermentations/components/fermentation-table.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-table.tsx
@@ -68,8 +68,8 @@ export function FermentationTable({ items, onRetry, onRowClick }: FermentationTa
             <TableCell className="whitespace-nowrap font-mono text-xs">
               {formatDate(item.created_at)}
             </TableCell>
-            <TableCell className="font-mono text-xs text-muted-foreground">
-              {item.user_id.slice(0, 8)}
+            <TableCell className="text-xs text-muted-foreground">
+              {item.user_email || item.user_id.slice(0, 8)}
             </TableCell>
             <TableCell className="text-sm">{item.target_period}</TableCell>
             <TableCell>

--- a/apps/admin/src/features/fermentations/hooks/use-fermentation-detail.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-fermentation-detail.ts
@@ -55,6 +55,7 @@ export interface FermentationDetailResponse {
   userEmail: string;
   questionText: string;
   cost: unknown;
+  masked: boolean;
   worksheet: WorksheetData | null;
   snippets: SnippetData[];
   letter: LetterData | null;

--- a/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
@@ -7,6 +7,7 @@ import { getAccessToken } from '@/lib/auth';
 export interface FermentationItem {
   id: string;
   user_id: string;
+  user_email: string;
   question_id: string;
   entry_id: string;
   target_period: string;

--- a/apps/admin/test/features/fermentations/hooks/use-fermentation-detail.test.ts
+++ b/apps/admin/test/features/fermentations/hooks/use-fermentation-detail.test.ts
@@ -28,6 +28,7 @@ const mockData: FermentationDetailResponse = {
   userEmail: 'test@example.com',
   questionText: 'What motivates you?',
   cost: { totalCost: 0.001234 },
+  masked: false,
   worksheet: {
     id: 'w1',
     fermentationResultId: 'f1',

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -98,8 +98,20 @@ export const adminFermentations = new Hono<Env>()
 
     if (error) return c.json({ error: error.message }, 500);
 
+    // Resolve user emails
+    const { data: usersData } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 });
+    const emailMap = new Map<string, string>();
+    for (const u of usersData?.users ?? []) {
+      emailMap.set(u.id, u.email ?? '');
+    }
+
+    const items = (data ?? []).map((row) => ({
+      ...row,
+      user_email: emailMap.get(row.user_id) ?? '',
+    }));
+
     return c.json({
-      data: data ?? [],
+      data: items,
       pagination: { page, limit, total: count ?? 0 },
     });
   })
@@ -253,6 +265,11 @@ export const adminFermentations = new Hono<Env>()
       updatedAt: row.updated_at,
     }));
 
+    // Mask content if viewing another user's fermentation
+    const adminUserId = c.get('adminUserId');
+    const isOwner = fermentation.user_id === adminUserId;
+    const MASKED = '[masked]';
+
     return c.json({
       id: fermentation.id,
       userId: fermentation.user_id,
@@ -265,12 +282,27 @@ export const adminFermentations = new Hono<Env>()
       createdAt: fermentation.created_at,
       updatedAt: fermentation.updated_at,
       userEmail,
-      questionText,
+      questionText: isOwner ? questionText : MASKED,
       cost,
-      worksheet,
-      snippets,
-      letter,
-      keywords,
+      masked: !isOwner,
+      worksheet: isOwner
+        ? worksheet
+        : worksheet
+          ? {
+              ...worksheet,
+              worksheetMarkdown: MASKED,
+              resultDiagramMarkdown: MASKED,
+            }
+          : null,
+      snippets: isOwner
+        ? snippets
+        : snippets.map((s) => ({
+            ...s,
+            originalText: MASKED,
+            selectionReason: MASKED,
+          })),
+      letter: isOwner ? letter : letter ? { ...letter, bodyText: MASKED } : null,
+      keywords: isOwner ? keywords : keywords.map((k) => ({ ...k, description: MASKED })),
     });
   })
   .post('/trigger-scheduled', async (c) => {


### PR DESCRIPTION
## Summary

- **一覧**: User 列を user_id → メールアドレス表示に変更（バックエンドで auth.users から解決）
- **詳細 API**: ログイン admin と発酵の user_id が異なる場合、サーバーサイドでジャーナリング内容をマスク
  - マスク対象: questionText, worksheet (markdown), snippets (originalText, selectionReason), letter (bodyText), keywords (description)
  - レスポンスに `masked: true` フラグを含め、フロントでバナー表示
  - **ブラウザの検証ツールでもマスク済みデータしか見えない**（クライアントに生データが渡らない）

## Test plan

- [x] typecheck 全パス
- [x] 272 tests 全パス
- [x] dep-cruise 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)