### PR TITLE
feat: admin セッション自動復元 + JWT 有効期限延長ガイド

### DIFF
--- a/apps/admin/src/features/auth/hooks/use-admin-auth.ts
+++ b/apps/admin/src/features/auth/hooks/use-admin-auth.ts
@@ -2,11 +2,40 @@
 
 import { useEffect, useState } from 'react';
 import { type ApiClient, createApiClient } from '@/lib/api';
-import { clearTokens, getAccessToken, setTokens } from '@/lib/auth';
+import { clearTokens, getAccessToken, getRefreshToken, setTokens } from '@/lib/auth';
 
 interface AdminAuthState {
   accessToken: string;
   user: { id: string; email: string };
+}
+
+async function tryRefresh(): Promise<{ accessToken: string; refreshToken: string } | null> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return null;
+
+  const res = await createApiClient().fetch('/api/v1/auth/refresh', {
+    method: 'POST',
+    body: JSON.stringify({ refreshToken }),
+  });
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as {
+    session: { accessToken: string; refreshToken: string };
+  };
+  setTokens(data.session.accessToken, data.session.refreshToken);
+  return data.session;
+}
+
+async function verifyAdminAndGetUser(token: string): Promise<{ id: string; email: string } | null> {
+  const client = createApiClient(token);
+  const adminRes = await client.fetch('/api/v1/admin/dashboard/stats');
+  if (!adminRes.ok) return null;
+
+  const meRes = await client.fetch('/api/v1/auth/me');
+  if (!meRes.ok) return null;
+
+  const meData = (await meRes.json()) as { user: { id: string; email: string } };
+  return meData.user;
 }
 
 export function useAdminAuth() {
@@ -15,31 +44,37 @@ export function useAdminAuth() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = getAccessToken();
-    if (token) {
-      const client = createApiClient(token);
-      setApi(client);
-      // Verify token by calling an admin endpoint
-      client
-        .fetch('/api/v1/admin/dashboard/stats')
-        .then(async (res) => {
-          if (res.ok) {
-            // Token is valid and user is admin
-            const meRes = await client.fetch('/api/v1/auth/me');
-            if (meRes.ok) {
-              const meData = (await meRes.json()) as { user: { id: string; email: string } };
-              setAuth({ accessToken: token, user: meData.user });
-            } else {
-              clearTokens();
-            }
-          } else {
-            clearTokens();
-          }
-        })
-        .finally(() => setLoading(false));
-    } else {
+    async function restoreSession() {
+      // 1. Try existing access token
+      const token = getAccessToken();
+      if (token) {
+        const user = await verifyAdminAndGetUser(token);
+        if (user) {
+          setAuth({ accessToken: token, user });
+          setApi(createApiClient(token));
+          setLoading(false);
+          return;
+        }
+      }
+
+      // 2. Access token expired or missing — try refresh
+      const session = await tryRefresh();
+      if (session) {
+        const user = await verifyAdminAndGetUser(session.accessToken);
+        if (user) {
+          setAuth({ accessToken: session.accessToken, user });
+          setApi(createApiClient(session.accessToken));
+          setLoading(false);
+          return;
+        }
+      }
+
+      // 3. Both failed — clear and require login
+      clearTokens();
       setLoading(false);
     }
+
+    restoreSession();
   }, []);
 
   async function login(email: string, password: string): Promise<string | null> {

--- a/apps/admin/src/lib/auth.ts
+++ b/apps/admin/src/lib/auth.ts
@@ -6,6 +6,11 @@ export function getAccessToken(): string | null {
   return localStorage.getItem(TOKEN_KEY);
 }
 
+export function getRefreshToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
 export function setTokens(accessToken: string, refreshToken: string): void {
   localStorage.setItem(TOKEN_KEY, accessToken);
   localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);


### PR DESCRIPTION
## Summary

admin アプリに refresh token によるセッション自動復元を追加。
リロードや access token 期限切れ時に自動で refresh し、
再ログインが不要になる。

### コード変更
- `use-admin-auth.ts`: client アプリと同じ refresh → verify → restore フローを追加
- `auth.ts`: `getRefreshToken()` を追加

### Supabase 設定変更（手動）
JWT 有効期限を 3600秒(1時間) → 604800秒(1週間) に延長:
https://supabase.com/dashboard/project/bmpfwlcbazgbvjixaamq/settings/auth

## Test plan

- [x] typecheck 全パス
- [x] 272 tests 全パス
- [x] dep-cruise 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)