### PR TITLE
feat: ニックネームログイン + アカウントページ + ライティング統計 (#85)

### DIFF
--- a/apps/client/src/features/auth/components/account-page.tsx
+++ b/apps/client/src/features/auth/components/account-page.tsx
@@ -4,13 +4,14 @@ interface AccountPageProps {
   user: {
     id: string;
     email: string;
+    nickname: string | null;
     avatarUrl: string | null;
     name: string | null;
   };
 }
 
 export function AccountPage({ user }: AccountPageProps) {
-  const displayName = user.name ?? user.email.split('@')[0];
+  const displayName = user.nickname ?? user.email.split('@')[0];
   const initials = displayName.charAt(0).toUpperCase();
 
   return (

--- a/apps/client/src/features/auth/components/account-page.tsx
+++ b/apps/client/src/features/auth/components/account-page.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import { useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+import { WritingStats } from './writing-stats';
+
 interface AccountPageProps {
   user: {
     id: string;
@@ -10,15 +15,142 @@ interface AccountPageProps {
   };
 }
 
+function EditableField({
+  label,
+  value,
+  onSave,
+  type = 'text',
+}: {
+  label: string;
+  value: string;
+  onSave: (val: string) => Promise<string | null>;
+  type?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    if (draft === value) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const err = await onSave(draft);
+    if (err) {
+      setError(err);
+    } else {
+      setEditing(false);
+    }
+    setSaving(false);
+  }
+
+  return (
+    <div>
+      <p
+        className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em]"
+        style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+      >
+        {label}
+      </p>
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type={type}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="flex-1 rounded-md border px-2 py-1 text-sm focus:outline-none focus:ring-1"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              backgroundColor: 'var(--bg)',
+              color: 'var(--fg)',
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs font-medium"
+            style={{ color: 'var(--accent)' }}
+          >
+            {saving ? '...' : '保存'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setEditing(false);
+              setDraft(value);
+              setError(null);
+            }}
+            className="text-xs"
+            style={{ color: 'var(--date-color)' }}
+          >
+            取消
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <p className="text-sm" style={{ color: 'var(--fg)' }}>
+            {value || '-'}
+          </p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-xs"
+            style={{ color: 'var(--date-color)' }}
+          >
+            編集
+          </button>
+        </div>
+      )}
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}
+
 export function AccountPage({ user }: AccountPageProps) {
-  const displayName = user.nickname ?? user.email.split('@')[0];
+  const displayName = user.nickname ?? user.name ?? user.email.split('@')[0];
   const initials = displayName.charAt(0).toUpperCase();
+
+  async function updateProfile(field: string, value: string): Promise<string | null> {
+    const token = getAccessToken();
+    if (!token) return 'ログインが必要です';
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/auth/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ [field]: value }),
+    });
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      return data.error;
+    }
+    return null;
+  }
+
+  async function updatePassword(newPassword: string): Promise<string | null> {
+    const token = getAccessToken();
+    if (!token) return 'ログインが必要です';
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/auth/update-password', {
+      method: 'POST',
+      body: JSON.stringify({ accessToken: token, password: newPassword }),
+    });
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      return data.error;
+    }
+    return null;
+  }
 
   return (
     <div className="mx-auto max-w-md px-6 py-12">
       <h1
-        className="mb-8 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent)]"
-        style={{ fontFamily: 'Inter, sans-serif' }}
+        className="mb-8 text-xs font-semibold uppercase tracking-[0.2em]"
+        style={{ color: 'var(--accent)', fontFamily: 'Inter, sans-serif' }}
       >
         Account
       </h1>
@@ -26,6 +158,7 @@ export function AccountPage({ user }: AccountPageProps) {
       {/* Avatar + Name */}
       <div className="mb-8 flex items-center gap-4">
         {user.avatarUrl ? (
+          // biome-ignore lint/performance/noImgElement: external avatar URL
           <img
             src={user.avatarUrl}
             alt=""
@@ -33,46 +166,66 @@ export function AccountPage({ user }: AccountPageProps) {
             referrerPolicy="no-referrer"
           />
         ) : (
-          <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--accent)] text-xl font-bold text-white">
+          <span
+            className="flex h-16 w-16 items-center justify-center rounded-full text-xl font-bold text-white"
+            style={{ backgroundColor: 'var(--accent)' }}
+          >
             {initials}
           </span>
         )}
         <div>
-          <p className="text-sm font-medium text-[var(--fg)]">{displayName}</p>
-          <p className="text-xs text-[var(--date-color)]">{user.email}</p>
+          <p className="text-sm font-medium" style={{ color: 'var(--fg)' }}>
+            {displayName}
+          </p>
+          <p className="text-xs" style={{ color: 'var(--date-color)' }}>
+            {user.email}
+          </p>
         </div>
       </div>
 
-      {/* Info fields */}
+      {/* Profile fields */}
       <div className="flex flex-col gap-5">
+        <EditableField
+          label="ニックネーム"
+          value={user.nickname ?? ''}
+          onSave={(val) => updateProfile('nickname', val)}
+        />
+        <EditableField
+          label="メールアドレス"
+          value={user.email}
+          type="email"
+          onSave={() => Promise.resolve('メールアドレスの変更はサポートに連絡してください')}
+        />
+        <EditableField
+          label="パスワード"
+          value="••••••••"
+          type="password"
+          onSave={updatePassword}
+        />
         <div>
           <p
-            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
-            style={{ fontFamily: 'Inter, sans-serif' }}
-          >
-            名前
-          </p>
-          <p className="text-sm text-[var(--fg)]">{displayName}</p>
-        </div>
-        <div>
-          <p
-            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
-            style={{ fontFamily: 'Inter, sans-serif' }}
-          >
-            メールアドレス
-          </p>
-          <p className="text-sm text-[var(--fg)]">{user.email}</p>
-        </div>
-        <div>
-          <p
-            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--date-color)]"
-            style={{ fontFamily: 'Inter, sans-serif' }}
+            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em]"
+            style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
           >
             ユーザーID
           </p>
-          <p className="font-mono text-xs text-[var(--date-color)]">{user.id}</p>
+          <p className="font-mono text-xs" style={{ color: 'var(--date-color)' }}>
+            {user.id}
+          </p>
         </div>
       </div>
+
+      {/* Divider */}
+      <div className="my-8 h-px" style={{ backgroundColor: 'var(--border-subtle)' }} />
+
+      {/* Writing Statistics */}
+      <h2
+        className="mb-6 text-xs font-semibold uppercase tracking-[0.2em]"
+        style={{ color: 'var(--accent)', fontFamily: 'Inter, sans-serif' }}
+      >
+        Writing Stats
+      </h2>
+      <WritingStats />
     </div>
   );
 }

--- a/apps/client/src/features/auth/components/login-form.tsx
+++ b/apps/client/src/features/auth/components/login-form.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/features/auth/hooks/use-auth';
 import { translateAuthError } from '@/features/auth/utils/error-messages';
 
 export function LoginForm() {
-  const [email, setEmail] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -20,7 +20,7 @@ export function LoginForm() {
     setError('');
     setLoading(true);
 
-    const err = await login(email, password);
+    const err = await login(identifier, password);
     if (err) {
       setError(translateAuthError(err));
       setLoading(false);
@@ -46,12 +46,13 @@ export function LoginForm() {
       {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
 
       <label className="flex flex-col gap-1">
-        <span className="text-sm font-medium">メールアドレス</span>
+        <span className="text-sm font-medium">ニックネームまたはメールアドレス</span>
         <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          type="text"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
           required
+          placeholder="nickname or email@example.com"
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
         />
       </label>

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -45,7 +45,7 @@ const NAV_ITEMS: NavItem[] = [
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { logout } = useAuth();
+  const { auth, logout } = useAuth();
   const { theme, toggle: toggleTheme } = useTheme();
   const { unreadCount } = useUnread();
 
@@ -190,6 +190,32 @@ export function Sidebar() {
           </svg>
         )}
       </button>
+
+      {/* Account avatar */}
+      <Link
+        href="/account"
+        title="アカウント"
+        className="group mb-2 flex h-12 w-12 items-center justify-center rounded-[20px] transition-all duration-300 hover:bg-[rgba(140,133,126,0.1)]"
+      >
+        {auth?.user.avatarUrl ? (
+          // biome-ignore lint/performance/noImgElement: external avatar URL from OAuth
+          <img
+            src={auth.user.avatarUrl}
+            alt=""
+            className="h-7 w-7 rounded-full object-cover"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <span
+            className="flex h-7 w-7 items-center justify-center rounded-full text-[10px] font-bold text-white"
+            style={{ backgroundColor: auth ? 'var(--accent)' : '#ccc' }}
+          >
+            {auth?.user.nickname?.charAt(0).toUpperCase() ??
+              auth?.user.email?.charAt(0).toUpperCase() ??
+              '?'}
+          </span>
+        )}
+      </Link>
 
       {/* Logout */}
       <button

--- a/apps/client/src/features/auth/components/signup-form.tsx
+++ b/apps/client/src/features/auth/components/signup-form.tsx
@@ -8,8 +8,10 @@ import { useAuth } from '@/features/auth/hooks/use-auth';
 import { translateAuthError } from '@/features/auth/utils/error-messages';
 
 export function SignupForm() {
+  const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
@@ -18,9 +20,15 @@ export function SignupForm() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError('');
+
+    if (password !== passwordConfirm) {
+      setError('パスワードが一致しません');
+      return;
+    }
+
     setLoading(true);
 
-    const err = await signup(email, password);
+    const err = await signup(nickname, email, password);
     if (err) {
       setError(translateAuthError(err));
       setLoading(false);
@@ -46,6 +54,22 @@ export function SignupForm() {
       {error && <p className="text-sm text-red-600 bg-red-50 rounded-md px-3 py-2">{error}</p>}
 
       <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium">ニックネーム（ログインID）</span>
+        <input
+          type="text"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          required
+          minLength={2}
+          maxLength={30}
+          pattern="^[a-zA-Z0-9_-]+$"
+          placeholder="my_nickname"
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
+        />
+        <span className="text-xs text-zinc-400">英数字、ハイフン、アンダースコアのみ</span>
+      </label>
+
+      <label className="flex flex-col gap-1">
         <span className="text-sm font-medium">メールアドレス</span>
         <input
           type="email"
@@ -62,6 +86,18 @@ export function SignupForm() {
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium">パスワード確認</span>
+        <input
+          type="password"
+          value={passwordConfirm}
+          onChange={(e) => setPasswordConfirm(e.target.value)}
           required
           minLength={6}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900 dark:border-zinc-700 dark:bg-zinc-900"

--- a/apps/client/src/features/auth/components/writing-stats.tsx
+++ b/apps/client/src/features/auth/components/writing-stats.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useUserStats } from '@/features/auth/hooks/use-user-stats';
+
+function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+  return (
+    <div className="rounded-lg p-4" style={{ border: '1px solid var(--border-subtle)' }}>
+      <p
+        className="text-[10px] font-medium uppercase tracking-[0.1em]"
+        style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+      >
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold" style={{ color: 'var(--fg)' }}>
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </p>
+      {sub && (
+        <p className="mt-0.5 text-xs" style={{ color: 'var(--date-color)' }}>
+          {sub}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function WritingStats() {
+  const { stats, loading } = useUserStats();
+
+  if (loading) {
+    return (
+      <p className="py-8 text-center text-sm" style={{ color: 'var(--date-color)' }}>
+        読み込み中...
+      </p>
+    );
+  }
+
+  if (!stats) return null;
+
+  const maxMonthlyChars = Math.max(...stats.monthlyTrend.map((m) => m.chars), 1);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatCard label="連続記録" value={`${stats.streak}日`} />
+        <StatCard label="累計エントリ" value={stats.totalEntries} />
+        <StatCard label="累計文字数" value={stats.totalChars} />
+        <StatCard label="発酵回数" value={stats.totalFermentations} />
+        <StatCard label="今週の文字数" value={stats.weeklyChars} />
+        <StatCard label="今月の文字数" value={stats.monthlyChars} />
+      </div>
+
+      {/* Monthly trend */}
+      <div>
+        <p
+          className="mb-3 text-[10px] font-medium uppercase tracking-[0.1em]"
+          style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+        >
+          月別推移
+        </p>
+        <div className="flex flex-col gap-1">
+          {stats.monthlyTrend.map((m) => (
+            <div key={m.month} className="flex items-center gap-2 text-xs">
+              <span className="w-14 text-right" style={{ color: 'var(--date-color)' }}>
+                {m.month.slice(2)}
+              </span>
+              <div
+                className="h-4 flex-1 overflow-hidden rounded-sm"
+                style={{ backgroundColor: 'var(--border-subtle)' }}
+              >
+                <div
+                  className="h-full rounded-sm"
+                  style={{
+                    width: `${(m.chars / maxMonthlyChars) * 100}%`,
+                    backgroundColor: 'var(--accent)',
+                    opacity: 0.6,
+                  }}
+                />
+              </div>
+              <span className="w-16 text-right font-mono" style={{ color: 'var(--fg)' }}>
+                {m.chars.toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Entries by question */}
+      {stats.entriesByQuestion.length > 0 && (
+        <div>
+          <p
+            className="mb-3 text-[10px] font-medium uppercase tracking-[0.1em]"
+            style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+          >
+            問い別エントリ数
+          </p>
+          <div className="flex flex-col gap-2">
+            {stats.entriesByQuestion.map((q) => (
+              <div key={q.questionId} className="flex items-center justify-between text-sm">
+                <span className="truncate pr-4" style={{ color: 'var(--fg)' }}>
+                  {q.questionText || '(無題)'}
+                </span>
+                <span className="shrink-0 font-mono" style={{ color: 'var(--date-color)' }}>
+                  {q.count}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -8,7 +8,13 @@ import { clearTokens, getAccessToken, getRefreshToken, setTokens } from '@/lib/a
 interface AuthState {
   accessToken: string;
   refreshToken: string;
-  user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+  user: {
+    id: string;
+    email: string;
+    nickname: string | null;
+    avatarUrl: string | null;
+    name: string | null;
+  };
 }
 
 export function useAuth() {
@@ -29,7 +35,13 @@ export function useAuth() {
 
       if (meRes.ok) {
         const data = (await meRes.json()) as {
-          user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+          user: {
+            id: string;
+            email: string;
+            nickname: string | null;
+            avatarUrl: string | null;
+            name: string | null;
+          };
         };
         setAuth({ accessToken: token, refreshToken: getRefreshToken() ?? '', user: data.user });
         setApi(client);
@@ -67,7 +79,13 @@ export function useAuth() {
 
       if (retryRes.ok) {
         const userData = (await retryRes.json()) as {
-          user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+          user: {
+            id: string;
+            email: string;
+            nickname: string | null;
+            avatarUrl: string | null;
+            name: string | null;
+          };
         };
         setAuth({
           accessToken: refreshData.session.accessToken,
@@ -86,18 +104,24 @@ export function useAuth() {
     restoreSession();
   }, []);
 
-  async function login(email: string, password: string): Promise<string | null> {
+  async function login(identifier: string, password: string): Promise<string | null> {
     const client = createApiClient();
     const res = await client.fetch('/api/v1/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ identifier, password }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error: string };
       return data.error;
     }
     const data = (await res.json()) as {
-      user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+      user: {
+        id: string;
+        email: string;
+        nickname: string | null;
+        avatarUrl: string | null;
+        name: string | null;
+      };
       session: { accessToken: string; refreshToken: string };
     };
     setTokens(data.session.accessToken, data.session.refreshToken);
@@ -111,18 +135,24 @@ export function useAuth() {
     return null;
   }
 
-  async function signup(email: string, password: string): Promise<string | null> {
+  async function signup(nickname: string, email: string, password: string): Promise<string | null> {
     const client = createApiClient();
     const res = await client.fetch('/api/v1/auth/signup', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ nickname, email, password }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error: string };
       return data.error;
     }
     const data = (await res.json()) as {
-      user: { id: string; email: string; avatarUrl: string | null; name: string | null };
+      user: {
+        id: string;
+        email: string;
+        nickname: string | null;
+        avatarUrl: string | null;
+        name: string | null;
+      };
       session: { accessToken: string; refreshToken: string } | null;
     };
     if (data.session) {

--- a/apps/client/src/features/auth/hooks/use-user-stats.ts
+++ b/apps/client/src/features/auth/hooks/use-user-stats.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+export interface UserStats {
+  streak: number;
+  totalEntries: number;
+  totalChars: number;
+  totalFermentations: number;
+  weeklyChars: number;
+  monthlyChars: number;
+  entriesByQuestion: { questionId: string; questionText: string; count: number }[];
+  monthlyTrend: { month: string; entries: number; chars: number }[];
+}
+
+export function useUserStats() {
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    const token = getAccessToken();
+    if (!token) return;
+
+    setLoading(true);
+    setError(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/users/me/stats');
+    if (res.ok) {
+      setStats((await res.json()) as UserStats);
+    } else {
+      setError('統計データの取得に失敗しました');
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  return { stats, loading, error, refresh: fetchStats };
+}

--- a/apps/client/src/features/auth/hooks/use-user-stats.ts
+++ b/apps/client/src/features/auth/hooks/use-user-stats.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
 
-export interface UserStats {
+interface UserStats {
   streak: number;
   totalEntries: number;
   totalChars: number;

--- a/apps/client/test/features/auth/hooks/use-auth.test.ts
+++ b/apps/client/test/features/auth/hooks/use-auth.test.ts
@@ -65,7 +65,7 @@ describe('useAuth', () => {
 
     let signupResult: string | null = null;
     await act(async () => {
-      signupResult = await result.current.signup('b@c.com', 'pass');
+      signupResult = await result.current.signup('testuser', 'b@c.com', 'pass');
     });
 
     expect(signupResult).toBeNull();
@@ -81,7 +81,7 @@ describe('useAuth', () => {
 
     let signupResult: string | null = null;
     await act(async () => {
-      signupResult = await result.current.signup('b@c.com', 'pass');
+      signupResult = await result.current.signup('testuser', 'b@c.com', 'pass');
     });
 
     expect(signupResult).toBe('Email taken');

--- a/apps/client/test/features/auth/hooks/use-user-stats.test.ts
+++ b/apps/client/test/features/auth/hooks/use-user-stats.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserStats } from '@/features/auth/hooks/use-user-stats';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 500,
+  } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
+}
+
+describe('useUserStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_access_token', 'test-token');
+  });
+
+  it('fetches stats on mount', async () => {
+    const statsBody = {
+      streak: 5,
+      totalEntries: 42,
+      totalChars: 125000,
+      totalFermentations: 15,
+      weeklyChars: 3500,
+      monthlyChars: 12000,
+      entriesByQuestion: [],
+      monthlyTrend: [],
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse(true, statsBody));
+
+    const { result } = renderHook(() => useUserStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats?.streak).toBe(5);
+    expect(result.current.stats?.totalEntries).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on failure', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(false, {}));
+
+    const { result } = renderHook(() => useUserStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('統計データの取得に失敗しました');
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -19,6 +19,7 @@ import { adminDashboard } from './contexts/shared/presentation/routes/admin-dash
 import { adminObservability } from './contexts/shared/presentation/routes/admin-observability.js';
 import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
 import { adminUsers } from './contexts/user/presentation/routes/admin-users.js';
+import { userStats } from './contexts/user/presentation/routes/user-stats.js';
 
 const app = new Hono()
   .onError(errorHandler)
@@ -35,6 +36,7 @@ const app = new Hono()
   .use('/api/v1/*', authMiddleware)
   .use('/api/v1/fermentations', rateLimitFermentation())
   .use('/api/v1/*', rateLimitGeneral())
+  .route('/api/v1/users/me', userStats)
   .route('/api/v1/board', board)
   .route('/api/v1/entries', entries)
   .route('/api/v1/questions', questions)

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -1,7 +1,8 @@
-import { credentialsSchema } from '@oryzae/shared';
+import { loginSchema, profileUpdateSchema, signupSchema } from '@oryzae/shared';
 import { createClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { getSupabaseClient } from '../../infrastructure/supabase-client.js';
 
 function getSupabaseAuthClient() {
   const url = process.env.SUPABASE_URL;
@@ -10,30 +11,33 @@ function getSupabaseAuthClient() {
   return createClient(url, anonKey);
 }
 
-function extractUserProfile(user: {
-  id: string;
-  email?: string;
-  user_metadata?: Record<string, unknown>;
-}) {
-  const meta = user.user_metadata ?? {};
-  return {
-    id: user.id,
-    email: user.email,
-    avatarUrl: typeof meta.avatar_url === 'string' ? meta.avatar_url : null,
-    name:
-      typeof meta.full_name === 'string'
-        ? meta.full_name
-        : typeof meta.name === 'string'
-          ? meta.name
-          : null,
-  };
+function createUserSupabase(authHeader: string) {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) throw new Error('Supabase env vars not set');
+  return createClient(url, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
 }
 
 export const authRoutes = new Hono()
   .post('/signup', async (c) => {
-    const body = credentialsSchema.parse(await c.req.json());
-    const supabase = getSupabaseAuthClient();
+    const body = signupSchema.parse(await c.req.json());
+    const serviceSupabase = getSupabaseClient();
 
+    // Check nickname uniqueness
+    const { data: existing } = await serviceSupabase
+      .from('profiles')
+      .select('id')
+      .ilike('nickname', body.nickname)
+      .single();
+
+    if (existing) {
+      return c.json({ error: 'このニックネームは既に使用されています' }, 400);
+    }
+
+    // Create auth user
+    const supabase = getSupabaseAuthClient();
     const { data, error } = await supabase.auth.signUp({
       email: body.email,
       password: body.password,
@@ -43,11 +47,19 @@ export const authRoutes = new Hono()
       return c.json({ error: error.message }, 400);
     }
 
+    // Create profile
+    if (data.user) {
+      await serviceSupabase.from('profiles').insert({
+        id: data.user.id,
+        nickname: body.nickname,
+      });
+    }
+
     return c.json(
       {
         user: data.user
-          ? extractUserProfile(data.user)
-          : { id: undefined, email: undefined, avatarUrl: null, name: null },
+          ? { id: data.user.id, email: data.user.email, nickname: body.nickname, avatarUrl: null }
+          : null,
         session: data.session
           ? {
               accessToken: data.session.access_token,
@@ -60,11 +72,35 @@ export const authRoutes = new Hono()
     );
   })
   .post('/login', async (c) => {
-    const body = credentialsSchema.parse(await c.req.json());
-    const supabase = getSupabaseAuthClient();
+    const body = loginSchema.parse(await c.req.json());
+    const isEmail = body.identifier.includes('@');
 
+    let email = body.identifier;
+
+    // Resolve nickname to email
+    if (!isEmail) {
+      const serviceSupabase = getSupabaseClient();
+      const { data: profile } = await serviceSupabase
+        .from('profiles')
+        .select('id')
+        .ilike('nickname', body.identifier)
+        .single();
+
+      if (!profile) {
+        return c.json({ error: 'ニックネームが見つかりません' }, 401);
+      }
+
+      // Get email from auth.users via admin API
+      const { data: userData } = await serviceSupabase.auth.admin.getUserById(profile.id);
+      if (!userData?.user?.email) {
+        return c.json({ error: 'ユーザー情報の取得に失敗しました' }, 401);
+      }
+      email = userData.user.email;
+    }
+
+    const supabase = getSupabaseAuthClient();
     const { data, error } = await supabase.auth.signInWithPassword({
-      email: body.email,
+      email,
       password: body.password,
     });
 
@@ -72,8 +108,21 @@ export const authRoutes = new Hono()
       return c.json({ error: error.message }, 401);
     }
 
+    // Fetch profile
+    const serviceSupabase = getSupabaseClient();
+    const { data: profile } = await serviceSupabase
+      .from('profiles')
+      .select('nickname, avatar_url')
+      .eq('id', data.user.id)
+      .single();
+
     return c.json({
-      user: extractUserProfile(data.user),
+      user: {
+        id: data.user.id,
+        email: data.user.email,
+        nickname: profile?.nickname ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+      },
       session: {
         accessToken: data.session.access_token,
         refreshToken: data.session.refresh_token,
@@ -95,9 +144,10 @@ export const authRoutes = new Hono()
 
     return c.json({
       session: {
-        accessToken: data.session!.access_token,
-        refreshToken: data.session!.refresh_token,
-        expiresAt: data.session!.expires_at,
+        // @type-assertion-allowed: session is guaranteed non-null after successful refresh
+        accessToken: (data.session as NonNullable<typeof data.session>).access_token,
+        refreshToken: (data.session as NonNullable<typeof data.session>).refresh_token,
+        expiresAt: (data.session as NonNullable<typeof data.session>).expires_at,
       },
     });
   })
@@ -129,8 +179,46 @@ export const authRoutes = new Hono()
       return c.json({ error: error.message }, 400);
     }
 
+    // Ensure profile exists for OAuth users
+    const serviceSupabase = getSupabaseClient();
+    const { data: profile } = await serviceSupabase
+      .from('profiles')
+      .select('nickname, avatar_url')
+      .eq('id', data.user.id)
+      .single();
+
+    if (!profile) {
+      // Auto-create profile for OAuth users
+      const meta = data.user.user_metadata ?? {};
+      const nickname =
+        typeof meta.full_name === 'string'
+          ? meta.full_name.replace(/\s+/g, '_').slice(0, 30)
+          : `user_${data.user.id.slice(0, 8)}`;
+      const avatarUrl = typeof meta.avatar_url === 'string' ? meta.avatar_url : null;
+
+      await serviceSupabase.from('profiles').insert({
+        id: data.user.id,
+        nickname,
+        avatar_url: avatarUrl,
+      });
+
+      return c.json({
+        user: { id: data.user.id, email: data.user.email, nickname, avatarUrl },
+        session: {
+          accessToken: data.session.access_token,
+          refreshToken: data.session.refresh_token,
+          expiresAt: data.session.expires_at,
+        },
+      });
+    }
+
     return c.json({
-      user: extractUserProfile(data.user),
+      user: {
+        id: data.user.id,
+        email: data.user.email,
+        nickname: profile.nickname,
+        avatarUrl: profile.avatar_url,
+      },
       session: {
         accessToken: data.session.access_token,
         refreshToken: data.session.refresh_token,
@@ -157,14 +245,7 @@ export const authRoutes = new Hono()
       .object({ accessToken: z.string(), password: z.string().min(6) })
       .parse(await c.req.json());
 
-    const url = process.env.SUPABASE_URL;
-    const anonKey = process.env.SUPABASE_ANON_KEY;
-    if (!url || !anonKey) return c.json({ error: 'Server config error' }, 500);
-
-    const supabase = createClient(url, anonKey, {
-      global: { headers: { Authorization: `Bearer ${accessToken}` } },
-    });
-
+    const supabase = createUserSupabase(`Bearer ${accessToken}`);
     const { error } = await supabase.auth.updateUser({ password });
 
     if (error) {
@@ -179,14 +260,7 @@ export const authRoutes = new Hono()
       return c.json({ error: 'Missing token' }, 401);
     }
 
-    const url = process.env.SUPABASE_URL;
-    const anonKey = process.env.SUPABASE_ANON_KEY;
-    if (!url || !anonKey) return c.json({ error: 'Server config error' }, 500);
-
-    const supabase = createClient(url, anonKey, {
-      global: { headers: { Authorization: authHeader } },
-    });
-
+    const supabase = createUserSupabase(authHeader);
     const {
       data: { user },
       error,
@@ -196,5 +270,91 @@ export const authRoutes = new Hono()
       return c.json({ error: 'Invalid token' }, 401);
     }
 
-    return c.json({ user: extractUserProfile(user) });
+    // Fetch profile
+    const serviceSupabase = getSupabaseClient();
+    const { data: profile } = await serviceSupabase
+      .from('profiles')
+      .select('nickname, avatar_url')
+      .eq('id', user.id)
+      .single();
+
+    return c.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        nickname: profile?.nickname ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+      },
+    });
+  })
+  .patch('/profile', async (c) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return c.json({ error: 'Missing token' }, 401);
+    }
+
+    const supabase = createUserSupabase(authHeader);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    const body = profileUpdateSchema.parse(await c.req.json());
+    const serviceSupabase = getSupabaseClient();
+
+    // Check nickname uniqueness if changing
+    if (body.nickname) {
+      const { data: existing } = await serviceSupabase
+        .from('profiles')
+        .select('id')
+        .ilike('nickname', body.nickname)
+        .neq('id', user.id)
+        .single();
+
+      if (existing) {
+        return c.json({ error: 'このニックネームは既に使用されています' }, 400);
+      }
+    }
+
+    const updateData: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (body.nickname) updateData.nickname = body.nickname;
+    if (body.avatarUrl !== undefined) updateData.avatar_url = body.avatarUrl;
+
+    const { error } = await serviceSupabase.from('profiles').update(updateData).eq('id', user.id);
+
+    if (error) {
+      return c.json({ error: error.message }, 500);
+    }
+
+    const { data: profile } = await serviceSupabase
+      .from('profiles')
+      .select('nickname, avatar_url')
+      .eq('id', user.id)
+      .single();
+
+    return c.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        nickname: profile?.nickname ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+      },
+    });
+  })
+  .get('/nickname/check', async (c) => {
+    const nickname = c.req.query('nickname');
+    if (!nickname) return c.json({ available: false }, 400);
+
+    const serviceSupabase = getSupabaseClient();
+    const { data } = await serviceSupabase
+      .from('profiles')
+      .select('id')
+      .ilike('nickname', nickname)
+      .single();
+
+    return c.json({ available: !data });
   });

--- a/apps/server/src/contexts/user/presentation/routes/user-stats.ts
+++ b/apps/server/src/contexts/user/presentation/routes/user-stats.ts
@@ -1,0 +1,136 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { Hono } from 'hono';
+
+type Env = {
+  Variables: {
+    userId: string;
+    supabase: SupabaseClient;
+  };
+};
+
+export const userStats = new Hono<Env>().get('/stats', async (c) => {
+  const userId = c.get('userId');
+  const supabase = c.get('supabase');
+
+  const [entriesRes, fermentationsRes] = await Promise.all([
+    supabase
+      .from('entries')
+      .select('id, content, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false }),
+    supabase.from('fermentation_results').select('id, status').eq('user_id', userId),
+  ]);
+
+  const entries = entriesRes.data ?? [];
+  const fermentations = fermentationsRes.data ?? [];
+
+  // Total entries and chars
+  const totalEntries = entries.length;
+  const totalChars = entries.reduce((sum, e) => sum + (e.content?.length ?? 0), 0);
+
+  // Total fermentations
+  const totalFermentations = fermentations.filter((f) => f.status === 'completed').length;
+
+  // Streak calculation
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const entryDates = new Set(
+    entries.map((e) => {
+      const d = new Date(e.created_at);
+      d.setHours(0, 0, 0, 0);
+      return d.toISOString().slice(0, 10);
+    }),
+  );
+
+  let streak = 0;
+  const checkDate = new Date(today);
+  // Check if today has an entry, if not start from yesterday
+  if (!entryDates.has(checkDate.toISOString().slice(0, 10))) {
+    checkDate.setDate(checkDate.getDate() - 1);
+  }
+  while (entryDates.has(checkDate.toISOString().slice(0, 10))) {
+    streak++;
+    checkDate.setDate(checkDate.getDate() - 1);
+  }
+
+  // Weekly and monthly chars
+  const weekAgo = new Date(today);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  const monthAgo = new Date(today);
+  monthAgo.setMonth(monthAgo.getMonth() - 1);
+
+  const weeklyChars = entries
+    .filter((e) => new Date(e.created_at) >= weekAgo)
+    .reduce((sum, e) => sum + (e.content?.length ?? 0), 0);
+
+  const monthlyChars = entries
+    .filter((e) => new Date(e.created_at) >= monthAgo)
+    .reduce((sum, e) => sum + (e.content?.length ?? 0), 0);
+
+  // Monthly trend (last 12 months)
+  const monthlyTrend: { month: string; entries: number; chars: number }[] = [];
+  for (let i = 11; i >= 0; i--) {
+    const d = new Date(today);
+    d.setMonth(d.getMonth() - i);
+    const monthKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    const monthEntries = entries.filter((e) => e.created_at.startsWith(monthKey));
+    monthlyTrend.push({
+      month: monthKey,
+      entries: monthEntries.length,
+      chars: monthEntries.reduce((sum, e) => sum + (e.content?.length ?? 0), 0),
+    });
+  }
+
+  // Entries by question
+  const { data: links } = await supabase
+    .from('entry_question_links')
+    .select('question_id')
+    .in(
+      'entry_id',
+      entries.map((e) => e.id),
+    );
+
+  const questionCounts = new Map<string, number>();
+  for (const link of links ?? []) {
+    questionCounts.set(link.question_id, (questionCounts.get(link.question_id) ?? 0) + 1);
+  }
+
+  // Get question texts
+  const questionIds = [...questionCounts.keys()];
+  const entriesByQuestion: { questionId: string; questionText: string; count: number }[] = [];
+  if (questionIds.length > 0) {
+    const { data: transactions } = await supabase
+      .from('question_transactions')
+      .select('question_id, string')
+      .in('question_id', questionIds)
+      .eq('is_validated_by_user', true)
+      .order('question_version', { ascending: false });
+
+    const textMap = new Map<string, string>();
+    for (const t of transactions ?? []) {
+      if (!textMap.has(t.question_id)) {
+        textMap.set(t.question_id, t.string);
+      }
+    }
+
+    for (const [qId, count] of questionCounts) {
+      entriesByQuestion.push({
+        questionId: qId,
+        questionText: textMap.get(qId) ?? '',
+        count,
+      });
+    }
+    entriesByQuestion.sort((a, b) => b.count - a.count);
+  }
+
+  return c.json({
+    streak,
+    totalEntries,
+    totalChars,
+    totalFermentations,
+    weeklyChars,
+    monthlyChars,
+    entriesByQuestion,
+    monthlyTrend,
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,5 +14,8 @@ export {
   boardSnippetUpdateSchema,
   createEntrySchema,
   credentialsSchema,
+  loginSchema,
+  profileUpdateSchema,
   questionStringSchema,
+  signupSchema,
 } from './schemas.js';

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -17,6 +17,31 @@ export const credentialsSchema = z.object({
   password: z.string().min(6),
 });
 
+export const signupSchema = z.object({
+  nickname: z
+    .string()
+    .min(2, 'ニックネームは2文字以上')
+    .max(30, 'ニックネームは30文字以下')
+    .regex(/^[a-zA-Z0-9_-]+$/, '英数字、ハイフン、アンダースコアのみ使用可能'),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export const loginSchema = z.object({
+  identifier: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export const profileUpdateSchema = z.object({
+  nickname: z
+    .string()
+    .min(2)
+    .max(30)
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .optional(),
+  avatarUrl: z.string().nullable().optional(),
+});
+
 // Board schemas
 export const boardQuerySchema = z.object({
   dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),

--- a/supabase/migrations/00009_create_profiles.sql
+++ b/supabase/migrations/00009_create_profiles.sql
@@ -1,0 +1,49 @@
+-- Profiles table for nickname-based login and avatar
+CREATE TABLE public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  nickname text NOT NULL,
+  avatar_url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Unique nickname for login resolution
+CREATE UNIQUE INDEX idx_profiles_nickname ON public.profiles (lower(nickname));
+
+-- RLS
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own profile"
+  ON public.profiles FOR SELECT
+  USING (id = auth.uid());
+
+CREATE POLICY "Users can update own profile"
+  ON public.profiles FOR UPDATE
+  USING (id = auth.uid());
+
+-- Service role needs full access for signup (insert) and admin operations
+CREATE POLICY "Service role can manage all profiles"
+  ON public.profiles FOR ALL
+  USING (true);
+
+-- Avatar storage bucket
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('avatars', 'avatars', true)
+  ON CONFLICT (id) DO NOTHING;
+
+-- Storage policies for avatars
+CREATE POLICY "Users can upload own avatar"
+  ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Anyone can view avatars"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+CREATE POLICY "Users can update own avatar"
+  ON storage.objects FOR UPDATE
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can delete own avatar"
+  ON storage.objects FOR DELETE
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
## Summary

ユーザー登録フローをメールアドレスからニックネームベースに刷新し、
アカウントページにライティング統計を表示。

### Phase 1: DB + バックエンド
- `profiles` テーブル（nickname UNIQUE, avatar_url）+ RLS + avatars Storage バケット
- signup: nickname + email + password → profiles INSERT
- login: ニックネーム or メールアドレスで認証（nickname → email サーバーサイド解決）
- /me: profile 情報（nickname, avatarUrl）を返す
- PATCH /profile: ニックネーム・アバター更新
- GET /nickname/check: 重複チェック
- OAuth callback: 自動 profile 作成
- GET /users/me/stats: ストリーク, 累計エントリ/文字数, 発酵回数, 月別推移, 問い別エントリ数

### Phase 2: フロントエンド認証フロー
- Login: 「ニックネームまたはメールアドレス」で認証
- Signup: ニックネーム + メール + パスワード + パスワード確認

### Phase 3: /account + サイドバー + 統計
- /account ページ: プロフィール表示・インライン編集（ニックネーム, パスワード）
- ライティング統計: 連続記録, 累計エントリ/文字数, 発酵回数, 週次/月次文字数, 月別推移チャート, 問い別エントリ数
- サイドバー: アバターアイコン追加（クリックで /account）

## DB Migration
- `00009_create_profiles.sql`: profiles テーブル + avatars バケット + RLS

## Test plan
- [x] typecheck 全パス
- [x] 274 tests 全パス (server 177 + client 43 + admin 54)
- [x] dep-cruise 0 violations
- [x] 新規登録（ニックネーム）→ メール確認 → ログイン
- [x] ニックネームでログイン
- [x] /account ページで統計表示
- [x] Supabase migration 適用

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)