### PR TITLE
fix: admin ログインの Internal Server Error を修正

### DIFF
--- a/apps/admin/src/features/auth/hooks/use-admin-auth.ts
+++ b/apps/admin/src/features/auth/hooks/use-admin-auth.ts
@@ -81,7 +81,7 @@ export function useAdminAuth() {
     const client = createApiClient();
     const res = await client.fetch('/api/v1/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ identifier: email, password }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error: string };


### PR DESCRIPTION
## 原因

admin のログインフォームが `{ email, password }` で API を呼んでいたが、`loginSchema` は `{ identifier, password }` を期待していた。Zod バリデーションエラーが Internal Server Error として返っていた。

## 修正

`use-admin-auth.ts` の login 関数で `email` → `identifier` にフィールド名を修正。

## Test plan

- [x] typecheck パス
- [x] 55テスト 全パス
- [ ] https://oryzae-admin.vercel.app/login でログインできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)