### PR TITLE
feat: エントリ全文検索機能 (#81)

### DIFF
--- a/apps/client/src/features/entries/components/entry-card.tsx
+++ b/apps/client/src/features/entries/components/entry-card.tsx
@@ -1,14 +1,37 @@
 'use client';
 
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 
 interface EntryCardProps {
   id: string;
   content: string;
   createdAt: string;
+  searchQuery?: string;
 }
 
-export function EntryCard({ id, content, createdAt }: EntryCardProps) {
+function highlightText(text: string, query: string): ReactNode {
+  if (!query) return text;
+
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(regex);
+
+  if (parts.length === 1) return text;
+
+  return parts.map((part, i) => {
+    const key = `${part}-${i}`;
+    return regex.test(part) ? (
+      <mark key={key} className="bg-[rgba(200,180,100,0.3)] text-[var(--fg)]">
+        {part}
+      </mark>
+    ) : (
+      <span key={key}>{part}</span>
+    );
+  });
+}
+
+export function EntryCard({ id, content, createdAt, searchQuery }: EntryCardProps) {
   const lines = content.split('\n').filter((l) => l.trim().length > 0);
   const title = lines[0]?.substring(0, 100) ?? '';
   const preview =
@@ -37,7 +60,7 @@ export function EntryCard({ id, content, createdAt }: EntryCardProps) {
         className="mb-1.5 text-[15px] font-medium text-[var(--fg)]"
         style={{ fontFamily: "'Noto Serif JP', serif" }}
       >
-        {title}
+        {searchQuery ? highlightText(title, searchQuery) : title}
       </h3>
 
       {/* Preview */}
@@ -51,7 +74,7 @@ export function EntryCard({ id, content, createdAt }: EntryCardProps) {
             overflow: 'hidden',
           }}
         >
-          {preview}
+          {searchQuery ? highlightText(preview, searchQuery) : preview}
         </p>
       )}
 

--- a/apps/client/src/features/entries/components/entry-list.tsx
+++ b/apps/client/src/features/entries/components/entry-list.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { useDebounce } from '@/features/entries/hooks/use-debounce';
 import { useEntries } from '@/features/entries/hooks/use-entries';
 import type { ApiClient } from '@/lib/api';
 import { EntryCard } from './entry-card';
@@ -65,50 +67,111 @@ function groupEntries(entries: EntryItem[]): MonthGroup[] {
 }
 
 export function EntryList({ api, authLoading }: EntryListProps) {
-  const { entries, loading, hasMore, loadMore } = useEntries(api, authLoading);
+  const [searchInput, setSearchInput] = useState('');
+  const debouncedSearch = useDebounce(searchInput, 300);
+  const search = debouncedSearch.trim() || undefined;
+  const { entries, loading, hasMore, loadMore } = useEntries(api, authLoading, search);
 
-  if (authLoading || (loading && entries.length === 0)) {
-    return <p className="text-center text-sm text-[var(--date-color)]">読み込み中...</p>;
-  }
-
-  if (entries.length === 0) {
-    return (
-      <p className="py-12 text-center text-sm text-[var(--date-color)]">
-        エントリーはまだありません
-      </p>
-    );
-  }
-
-  const monthGroups = groupEntries(entries);
+  const isSearching = !!search;
 
   return (
     <div className="flex flex-col">
-      {monthGroups.map((month) => (
-        <div key={month.label}>
-          {/* Month header */}
-          <div className="border-b border-[var(--border-subtle)] pb-2 pt-6 text-sm font-medium text-[var(--fg)]">
-            {month.label}
-          </div>
+      {/* Search bar */}
+      <div className="relative mb-4">
+        <input
+          type="text"
+          placeholder="エントリーを検索..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--bg)] px-4 py-2.5 pl-10 text-sm text-[var(--fg)] placeholder:text-[var(--date-color)] focus:border-[var(--accent)] focus:outline-none"
+        />
+        <svg
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--date-color)]"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-label="検索"
+          role="img"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        {searchInput && (
+          <button
+            type="button"
+            onClick={() => setSearchInput('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--date-color)] hover:text-[var(--fg)]"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-label="検索をクリア"
+              role="img"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
 
-          {month.weeks.map((week) => (
-            <div key={week.label}>
-              {/* Week label */}
-              <div className="pt-4 pb-2 text-xs text-[var(--date-color)]">{week.label}</div>
-
-              {week.entries.map((entry) => (
-                <EntryCard
-                  key={entry.id}
-                  id={entry.id}
-                  content={entry.content}
-                  createdAt={entry.createdAt}
-                />
-              ))}
-            </div>
+      {authLoading || (loading && entries.length === 0) ? (
+        <p className="text-center text-sm text-[var(--date-color)]">読み込み中...</p>
+      ) : entries.length === 0 ? (
+        <p className="py-12 text-center text-sm text-[var(--date-color)]">
+          {isSearching ? '検索結果はありません' : 'エントリーはまだありません'}
+        </p>
+      ) : isSearching ? (
+        /* Flat list for search results (no month/week grouping) */
+        <div className="flex flex-col">
+          <div className="pb-2 text-xs text-[var(--date-color)]">{entries.length}件の結果</div>
+          {entries.map((entry) => (
+            <EntryCard
+              key={entry.id}
+              id={entry.id}
+              content={entry.content}
+              createdAt={entry.createdAt}
+              searchQuery={search}
+            />
           ))}
         </div>
-      ))}
+      ) : (
+        /* Grouped list for normal browsing */
+        groupEntries(entries).map((month) => (
+          <div key={month.label}>
+            <div className="border-b border-[var(--border-subtle)] pb-2 pt-6 text-sm font-medium text-[var(--fg)]">
+              {month.label}
+            </div>
 
-      {hasMore && (
+            {month.weeks.map((week) => (
+              <div key={week.label}>
+                <div className="pt-4 pb-2 text-xs text-[var(--date-color)]">{week.label}</div>
+
+                {week.entries.map((entry) => (
+                  <EntryCard
+                    key={entry.id}
+                    id={entry.id}
+                    content={entry.content}
+                    createdAt={entry.createdAt}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        ))
+      )}
+
+      {hasMore && entries.length > 0 && (
         <button
           type="button"
           onClick={loadMore}

--- a/apps/client/src/features/entries/hooks/use-debounce.ts
+++ b/apps/client/src/features/entries/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/apps/client/src/features/entries/hooks/use-entries.ts
+++ b/apps/client/src/features/entries/hooks/use-entries.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ApiClient } from '@/lib/api';
 
 interface Entry {
@@ -14,11 +14,12 @@ interface Entry {
 
 const PAGE_SIZE = 20;
 
-export function useEntries(api: ApiClient | null, authLoading: boolean) {
+export function useEntries(api: ApiClient | null, authLoading: boolean, search?: string) {
   const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(true);
   const [cursor, setCursor] = useState<string | undefined>();
   const [hasMore, setHasMore] = useState(true);
+  const prevSearchRef = useRef(search);
 
   const fetchEntries = useCallback(
     async (nextCursor?: string) => {
@@ -27,6 +28,7 @@ export function useEntries(api: ApiClient | null, authLoading: boolean) {
 
       const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
       if (nextCursor) params.set('cursor', nextCursor);
+      if (search) params.set('q', search);
 
       const res = await api.fetch(`/api/v1/entries?${params}`);
 
@@ -42,8 +44,17 @@ export function useEntries(api: ApiClient | null, authLoading: boolean) {
 
       setLoading(false);
     },
-    [api],
+    [api, search],
   );
+
+  useEffect(() => {
+    if (prevSearchRef.current !== search) {
+      prevSearchRef.current = search;
+      setEntries([]);
+      setCursor(undefined);
+      setHasMore(true);
+    }
+  }, [search]);
 
   useEffect(() => {
     if (!authLoading && api) {

--- a/apps/client/test/features/entries/hooks/use-entries.test.ts
+++ b/apps/client/test/features/entries/hooks/use-entries.test.ts
@@ -106,4 +106,76 @@ describe('useEntries', () => {
     expect(result.current.hasMore).toBe(false);
     expect(apiFetch.mock.calls[1][0]).toContain('cursor=e19');
   });
+
+  it('sends q param when search is provided', async () => {
+    apiFetch.mockResolvedValueOnce(
+      mockResponse(true, [
+        {
+          id: '1',
+          userId: 'u1',
+          content: '天気が良い',
+          mediaUrls: [],
+          createdAt: '',
+          updatedAt: '',
+        },
+      ]),
+    );
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useEntries(api, false, '天気'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(apiFetch.mock.calls[0][0]).toContain('q=%E5%A4%A9%E6%B0%97');
+    expect(result.current.entries).toHaveLength(1);
+  });
+
+  it('resets entries when search changes', async () => {
+    apiFetch.mockResolvedValueOnce(
+      mockResponse(true, [
+        { id: '1', userId: 'u1', content: 'first', mediaUrls: [], createdAt: '', updatedAt: '' },
+      ]),
+    );
+    const api = createMockApi(apiFetch);
+
+    const { result, rerender } = renderHook(({ search }) => useEntries(api, false, search), {
+      initialProps: { search: 'first' },
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.entries).toHaveLength(1);
+
+    apiFetch.mockResolvedValueOnce(
+      mockResponse(true, [
+        { id: '2', userId: 'u1', content: 'second', mediaUrls: [], createdAt: '', updatedAt: '' },
+      ]),
+    );
+
+    rerender({ search: 'second' });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].id).toBe('2');
+  });
+
+  it('does not send q param when search is empty', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(true, []));
+    const api = createMockApi(apiFetch);
+
+    renderHook(() => useEntries(api, false, ''));
+
+    await waitFor(() => {
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(apiFetch.mock.calls[0][0]).not.toContain('q=');
+  });
 });

--- a/apps/server/src/contexts/entry/application/usecases/search-entries.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/search-entries.usecase.ts
@@ -1,0 +1,16 @@
+import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
+import type { EntryProps } from '../../domain/models/entry.js';
+
+export class SearchEntriesUsecase {
+  constructor(private entryRepo: EntryRepositoryGateway) {}
+
+  async execute(
+    userId: string,
+    query: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<EntryProps[]> {
+    const entries = await this.entryRepo.searchByUserId(userId, query, cursor, limit);
+    return entries.map((entry) => entry.toProps());
+  }
+}

--- a/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
+++ b/apps/server/src/contexts/entry/domain/gateways/entry-repository.gateway.ts
@@ -6,6 +6,7 @@ export interface EntryRepositoryGateway {
   listByUserId(userId: string, cursor?: string, limit?: number): Promise<Entry[]>;
   listByUserIdAndDate(userId: string, dateKey: string): Promise<Entry[]>;
   listByUserIdAndWeek(userId: string, dateKey: string): Promise<Entry[]>;
+  searchByUserId(userId: string, query: string, cursor?: string, limit?: number): Promise<Entry[]>;
   save(entry: Entry): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -75,6 +75,29 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
     return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
   }
 
+  async searchByUserId(
+    userId: string,
+    query: string,
+    cursor?: string,
+    limit = 20,
+  ): Promise<Entry[]> {
+    let q = this.supabase
+      .from('entries')
+      .select('*')
+      .eq('user_id', userId)
+      .ilike('content', `%${query}%`)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (cursor) {
+      q = q.lt('created_at', cursor);
+    }
+
+    const { data, error } = await q;
+    if (error) throw error;
+    return (data ?? []).map((row: Record<string, unknown>) => this.toDomain(row));
+  }
+
   async save(entry: Entry): Promise<void> {
     const props = entry.toProps();
     const { error } = await this.supabase.from('entries').upsert({

--- a/apps/server/src/contexts/entry/presentation/routes/entries.ts
+++ b/apps/server/src/contexts/entry/presentation/routes/entries.ts
@@ -4,6 +4,7 @@ import { CreateEntryUsecase } from '../../application/usecases/create-entry.usec
 import { DeleteEntryUsecase } from '../../application/usecases/delete-entry.usecase.js';
 import { GetEntryUsecase } from '../../application/usecases/get-entry.usecase.js';
 import { ListEntriesUsecase } from '../../application/usecases/list-entries.usecase.js';
+import { SearchEntriesUsecase } from '../../application/usecases/search-entries.usecase.js';
 import { UpdateEntryUsecase } from '../../application/usecases/update-entry.usecase.js';
 import { SupabaseEntryRepository } from '../../infrastructure/repositories/supabase-entry.repository.js';
 import { SupabaseEntrySnapshotRepository } from '../../infrastructure/repositories/supabase-entry-snapshot.repository.js';
@@ -31,15 +32,19 @@ export const entries = new Hono<Env>()
   .get('/', async (c) => {
     const cursor = c.req.query('cursor');
     const limit = c.req.query('limit');
+    const q = c.req.query('q');
     const supabase = c.get('supabase');
     const entryRepo = new SupabaseEntryRepository(supabase);
-    const usecase = new ListEntriesUsecase(entryRepo);
+    const parsedLimit = limit ? Number(limit) : undefined;
 
-    const result = await usecase.execute(
-      c.get('userId'),
-      cursor,
-      limit ? Number(limit) : undefined,
-    );
+    if (q) {
+      const searchUsecase = new SearchEntriesUsecase(entryRepo);
+      const result = await searchUsecase.execute(c.get('userId'), q, cursor, parsedLimit);
+      return c.json(result);
+    }
+
+    const listUsecase = new ListEntriesUsecase(entryRepo);
+    const result = await listUsecase.execute(c.get('userId'), cursor, parsedLimit);
     return c.json(result);
   })
   .get('/:id', async (c) => {

--- a/apps/server/test/contexts/entry/application/usecases/search-entries.usecase.test.ts
+++ b/apps/server/test/contexts/entry/application/usecases/search-entries.usecase.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SearchEntriesUsecase } from '@/contexts/entry/application/usecases/search-entries.usecase';
+import type { EntryRepositoryGateway } from '@/contexts/entry/domain/gateways/entry-repository.gateway';
+import { Entry } from '@/contexts/entry/domain/models/entry';
+
+describe('SearchEntriesUsecase', () => {
+  let entryRepo: EntryRepositoryGateway;
+  let usecase: SearchEntriesUsecase;
+
+  const entryProps1 = {
+    id: 'entry-1',
+    userId: 'user-1',
+    content: '今日は良い天気でした',
+    mediaUrls: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const entryProps2 = {
+    id: 'entry-2',
+    userId: 'user-1',
+    content: '天気が悪くて外に出られなかった',
+    mediaUrls: [],
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    entryRepo = {
+      findById: vi.fn().mockResolvedValue(null),
+      findByIds: vi.fn().mockResolvedValue([]),
+      listByUserId: vi.fn().mockResolvedValue([]),
+      listByUserIdAndDate: vi.fn().mockResolvedValue([]),
+      listByUserIdAndWeek: vi.fn().mockResolvedValue([]),
+      searchByUserId: vi.fn().mockResolvedValue([]),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    usecase = new SearchEntriesUsecase(entryRepo);
+  });
+
+  it('検索クエリに一致する Entry の Props 配列を返す', async () => {
+    vi.mocked(entryRepo.searchByUserId).mockResolvedValue([
+      Entry.fromProps(entryProps1),
+      Entry.fromProps(entryProps2),
+    ]);
+
+    const result = await usecase.execute('user-1', '天気');
+
+    expect(result).toEqual([entryProps1, entryProps2]);
+    expect(entryRepo.searchByUserId).toHaveBeenCalledWith('user-1', '天気', undefined, undefined);
+  });
+
+  it('一致するエントリがない場合は空配列を返す', async () => {
+    vi.mocked(entryRepo.searchByUserId).mockResolvedValue([]);
+
+    const result = await usecase.execute('user-1', '存在しないキーワード');
+
+    expect(result).toEqual([]);
+  });
+
+  it('cursor と limit を repo に渡す', async () => {
+    vi.mocked(entryRepo.searchByUserId).mockResolvedValue([Entry.fromProps(entryProps2)]);
+
+    await usecase.execute('user-1', '天気', '2026-01-01T00:00:00.000Z', 10);
+
+    expect(entryRepo.searchByUserId).toHaveBeenCalledWith(
+      'user-1',
+      '天気',
+      '2026-01-01T00:00:00.000Z',
+      10,
+    );
+  });
+});

--- a/supabase/migrations/00010_add_entry_search_index.sql
+++ b/supabase/migrations/00010_add_entry_search_index.sql
@@ -1,0 +1,5 @@
+-- pg_trgm 拡張によるエントリ全文検索（日本語トライグラム対応）
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ILIKE '%keyword%' を高速化する GIN インデックス
+CREATE INDEX idx_entries_content_trgm ON public.entries USING gin (content gin_trgm_ops);


### PR DESCRIPTION
## Summary
- `pg_trgm` + GIN インデックスによる日本語対応の全文検索を実装
- `GET /api/v1/entries` に `q` クエリパラメータを追加（検索なしは既存動作と同一）
- フロントエンドに検索バー（300ms デバウンス）、検索結果ハイライト表示を追加

## Changes
| レイヤー | ファイル | 変更 |
|---------|---------|------|
| DB | `00010_add_entry_search_index.sql` | pg_trgm 有効化 + GIN index |
| Domain | `entry-repository.gateway.ts` | `searchByUserId` 追加 |
| Infra | `supabase-entry.repository.ts` | ILIKE 検索実装 |
| App | `search-entries.usecase.ts` | 新規 usecase |
| Pres | `entries.ts` routes | `q` パラメータ分岐 |
| Frontend | `use-entries.ts` | search 引数追加 |
| Frontend | `use-debounce.ts` | 新規 hook |
| Frontend | `entry-list.tsx` | 検索バー UI |
| Frontend | `entry-card.tsx` | ハイライト表示 |

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全 281 テスト通過（新規 6 件含む）
- [x] `pnpm dep-cruise` アーキテクチャ違反なし
- [x] `pnpm lint` 自変更にエラーなし
- [ ] ブラウザで `/entries` を開き検索バーに日本語入力 → 結果が絞り込まれる
- [ ] ハイライト表示される
- [ ] 検索クリアで全件表示に戻る
- [ ] ページネーション（もっと見る）が検索中も動作する

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)