### PR TITLE
fix: admin に @oryzae/shared の transpilePackages を追加

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -2,7 +2,7 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@oryzae/server'],
+  transpilePackages: ['@oryzae/shared', '@oryzae/server'],
   turbopack: {},
 };
 


### PR DESCRIPTION
## 問題

admin の `next.config.ts` に `@oryzae/shared` が `transpilePackages` に含まれていなかった。
client では含まれている。これにより admin が shared の古い dist を参照し、スキーマの不一致が起きる可能性があった。

## 修正

`transpilePackages: ['@oryzae/server']` → `transpilePackages: ['@oryzae/shared', '@oryzae/server']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)