### PR TITLE
feat: セキュアなパスワード変更・メールアドレス変更・OAuth検出

### DIFF
--- a/apps/client/src/features/auth/components/account-page.tsx
+++ b/apps/client/src/features/auth/components/account-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { translateAuthError } from '@/features/auth/utils/error-messages';
 import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
 import { WritingStats } from './writing-stats';
@@ -12,8 +13,18 @@ interface AccountPageProps {
     nickname: string | null;
     avatarUrl: string | null;
     name: string | null;
+    providers: string[];
   };
 }
+
+const labelClass = 'mb-1 text-[10px] font-medium uppercase tracking-[0.1em]';
+const labelStyle = { color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' };
+const inputClass = 'w-full rounded-md border px-2 py-1 text-sm focus:outline-none focus:ring-1';
+const inputStyle = {
+  borderColor: 'var(--border-subtle)',
+  backgroundColor: 'var(--bg)',
+  color: 'var(--fg)',
+};
 
 function EditableField({
   label,
@@ -49,10 +60,7 @@ function EditableField({
 
   return (
     <div>
-      <p
-        className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em]"
-        style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
-      >
+      <p className={labelClass} style={labelStyle}>
         {label}
       </p>
       {editing ? (
@@ -61,12 +69,8 @@ function EditableField({
             type={type}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            className="flex-1 rounded-md border px-2 py-1 text-sm focus:outline-none focus:ring-1"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              backgroundColor: 'var(--bg)',
-              color: 'var(--fg)',
-            }}
+            className={`flex-1 ${inputClass}`}
+            style={inputStyle}
           />
           <button
             type="button"
@@ -110,9 +114,258 @@ function EditableField({
   );
 }
 
+function EmailChangeSection({ email, isOAuthOnly }: { email: string; isOAuthOnly: boolean }) {
+  const [editing, setEditing] = useState(false);
+  const [newEmail, setNewEmail] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const token = getAccessToken();
+    if (!token) {
+      setError('ログインが必要です');
+      setSaving(false);
+      return;
+    }
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/auth/change-email', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail }),
+    });
+
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      setError(translateAuthError(data.error));
+      setSaving(false);
+      return;
+    }
+
+    setSuccess(true);
+    setSaving(false);
+  }
+
+  return (
+    <div>
+      <p className={labelClass} style={labelStyle}>
+        メールアドレス
+      </p>
+      {isOAuthOnly ? (
+        <div>
+          <p className="text-sm" style={{ color: 'var(--fg)' }}>
+            {email}
+          </p>
+          <p className="mt-1 text-xs" style={{ color: 'var(--date-color)' }}>
+            Google アカウントに紐づいたメールアドレスです
+          </p>
+        </div>
+      ) : success ? (
+        <div>
+          <p className="text-sm" style={{ color: 'var(--fg)' }}>
+            {email}
+          </p>
+          <p className="mt-1 text-xs" style={{ color: 'var(--accent)' }}>
+            確認メールを送信しました。新しいメールアドレスに届いたメールのリンクをクリックしてください。
+          </p>
+        </div>
+      ) : editing ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <input
+            type="email"
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.target.value)}
+            required
+            placeholder="新しいメールアドレス"
+            className={inputClass}
+            style={inputStyle}
+          />
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="text-xs font-medium"
+              style={{ color: 'var(--accent)' }}
+            >
+              {saving ? '...' : '送信'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(false);
+                setNewEmail('');
+                setError(null);
+              }}
+              className="text-xs"
+              style={{ color: 'var(--date-color)' }}
+            >
+              取消
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="flex items-center gap-2">
+          <p className="text-sm" style={{ color: 'var(--fg)' }}>
+            {email}
+          </p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-xs"
+            style={{ color: 'var(--date-color)' }}
+          >
+            変更
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PasswordChangeSection({ isOAuthOnly }: { isOAuthOnly: boolean }) {
+  const [editing, setEditing] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  if (isOAuthOnly) return null;
+
+  function resetForm() {
+    setEditing(false);
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setError(null);
+    setSuccess(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (newPassword !== confirmPassword) {
+      setError('新しいパスワードが一致しません');
+      return;
+    }
+
+    setSaving(true);
+
+    const token = getAccessToken();
+    if (!token) {
+      setError('ログインが必要です');
+      setSaving(false);
+      return;
+    }
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/auth/change-password', {
+      method: 'POST',
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+
+    if (!res.ok) {
+      const data = (await res.json()) as { error: string };
+      setError(translateAuthError(data.error));
+      setSaving(false);
+      return;
+    }
+
+    setSuccess(true);
+    setSaving(false);
+    setTimeout(() => resetForm(), 2000);
+  }
+
+  return (
+    <div>
+      <p className={labelClass} style={labelStyle}>
+        パスワード
+      </p>
+      {success ? (
+        <p className="text-xs" style={{ color: 'var(--accent)' }}>
+          パスワードを更新しました
+        </p>
+      ) : editing ? (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            required
+            placeholder="現在のパスワード"
+            className={inputClass}
+            style={inputStyle}
+          />
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            required
+            minLength={6}
+            placeholder="新しいパスワード（6文字以上）"
+            className={inputClass}
+            style={inputStyle}
+          />
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            minLength={6}
+            placeholder="新しいパスワード（確認）"
+            className={inputClass}
+            style={inputStyle}
+          />
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="text-xs font-medium"
+              style={{ color: 'var(--accent)' }}
+            >
+              {saving ? '...' : '更新'}
+            </button>
+            <button
+              type="button"
+              onClick={resetForm}
+              className="text-xs"
+              style={{ color: 'var(--date-color)' }}
+            >
+              取消
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="flex items-center gap-2">
+          <p className="text-sm" style={{ color: 'var(--fg)' }}>
+            ••••••••
+          </p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-xs"
+            style={{ color: 'var(--date-color)' }}
+          >
+            変更
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function AccountPage({ user }: AccountPageProps) {
   const displayName = user.nickname ?? user.name ?? user.email.split('@')[0];
   const initials = displayName.charAt(0).toUpperCase();
+  const isOAuthOnly = user.providers.length > 0 && !user.providers.includes('email');
 
   async function updateProfile(field: string, value: string): Promise<string | null> {
     const token = getAccessToken();
@@ -122,22 +375,6 @@ export function AccountPage({ user }: AccountPageProps) {
     const res = await api.fetch('/api/v1/auth/profile', {
       method: 'PATCH',
       body: JSON.stringify({ [field]: value }),
-    });
-    if (!res.ok) {
-      const data = (await res.json()) as { error: string };
-      return data.error;
-    }
-    return null;
-  }
-
-  async function updatePassword(newPassword: string): Promise<string | null> {
-    const token = getAccessToken();
-    if (!token) return 'ログインが必要です';
-
-    const api = createApiClient(token);
-    const res = await api.fetch('/api/v1/auth/update-password', {
-      method: 'POST',
-      body: JSON.stringify({ accessToken: token, password: newPassword }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error: string };
@@ -190,23 +427,10 @@ export function AccountPage({ user }: AccountPageProps) {
           value={user.nickname ?? ''}
           onSave={(val) => updateProfile('nickname', val)}
         />
-        <EditableField
-          label="メールアドレス"
-          value={user.email}
-          type="email"
-          onSave={() => Promise.resolve('メールアドレスの変更はサポートに連絡してください')}
-        />
-        <EditableField
-          label="パスワード"
-          value="••••••••"
-          type="password"
-          onSave={updatePassword}
-        />
+        <EmailChangeSection email={user.email} isOAuthOnly={isOAuthOnly} />
+        <PasswordChangeSection isOAuthOnly={isOAuthOnly} />
         <div>
-          <p
-            className="mb-1 text-[10px] font-medium uppercase tracking-[0.1em]"
-            style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
-          >
+          <p className={labelClass} style={labelStyle}>
             ユーザーID
           </p>
           <p className="font-mono text-xs" style={{ color: 'var(--date-color)' }}>

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -14,6 +14,7 @@ interface AuthState {
     nickname: string | null;
     avatarUrl: string | null;
     name: string | null;
+    providers: string[];
   };
 }
 
@@ -41,6 +42,7 @@ export function useAuth() {
             nickname: string | null;
             avatarUrl: string | null;
             name: string | null;
+            providers: string[];
           };
         };
         setAuth({ accessToken: token, refreshToken: getRefreshToken() ?? '', user: data.user });
@@ -85,6 +87,7 @@ export function useAuth() {
             nickname: string | null;
             avatarUrl: string | null;
             name: string | null;
+            providers: string[];
           };
         };
         setAuth({
@@ -121,6 +124,7 @@ export function useAuth() {
         nickname: string | null;
         avatarUrl: string | null;
         name: string | null;
+        providers: string[];
       };
       session: { accessToken: string; refreshToken: string };
     };
@@ -152,6 +156,7 @@ export function useAuth() {
         nickname: string | null;
         avatarUrl: string | null;
         name: string | null;
+        providers: string[];
       };
       session: { accessToken: string; refreshToken: string } | null;
     };

--- a/apps/client/src/features/auth/utils/error-messages.ts
+++ b/apps/client/src/features/auth/utils/error-messages.ts
@@ -12,6 +12,10 @@ const ERROR_MAP: Record<string, string> = {
   'New password should be different from the old password':
     '新しいパスワードは現在のパスワードと異なるものにしてください',
   'Auth session missing!': 'セッションが切れました。もう一度ログインしてください',
+  'A user with this email address has already been registered':
+    'このメールアドレスは既に登録されています',
+  'Email address not confirmed': 'メールアドレスの確認が完了していません',
+  'Same password': '新しいパスワードは現在のパスワードと異なるものにしてください',
 };
 
 export function translateAuthError(message: string): string {

--- a/apps/client/test/features/auth/hooks/use-auth.test.ts
+++ b/apps/client/test/features/auth/hooks/use-auth.test.ts
@@ -24,8 +24,10 @@ describe('useAuth', () => {
     const user = {
       id: 'u1',
       email: 'a@b.com',
+      nickname: 'testuser',
       avatarUrl: 'https://example.com/avatar.jpg',
       name: 'Test User',
+      providers: ['email'],
     };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
@@ -58,7 +60,14 @@ describe('useAuth', () => {
 
   it('signup returns null on success and stores tokens', async () => {
     const session = { accessToken: 'at2', refreshToken: 'rt2' };
-    const user = { id: 'u2', email: 'b@c.com', avatarUrl: null, name: null };
+    const user = {
+      id: 'u2',
+      email: 'b@c.com',
+      nickname: 'newuser',
+      avatarUrl: null,
+      name: null,
+      providers: ['email'],
+    };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
     const { result } = renderHook(() => useAuth());
@@ -93,8 +102,10 @@ describe('useAuth', () => {
     const user = {
       id: 'u1',
       email: 'a@b.com',
+      nickname: 'testuser',
       avatarUrl: 'https://example.com/avatar.jpg',
       name: 'Test User',
+      providers: ['email'],
     };
     mockFetch.mockResolvedValueOnce(mockResponse(true, { user, session }));
 
@@ -124,8 +135,10 @@ describe('useAuth', () => {
         user: {
           id: 'u1',
           email: 'a@b.com',
+          nickname: 'testuser',
           avatarUrl: 'https://example.com/avatar.jpg',
           name: 'Test User',
+          providers: ['email'],
         },
       }),
     );

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -1,4 +1,10 @@
-import { loginSchema, profileUpdateSchema, signupSchema } from '@oryzae/shared';
+import {
+  changeEmailSchema,
+  changePasswordSchema,
+  loginSchema,
+  profileUpdateSchema,
+  signupSchema,
+} from '@oryzae/shared';
 import { createClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
 import { z } from 'zod';
@@ -18,6 +24,12 @@ function createUserSupabase(authHeader: string) {
   return createClient(url, anonKey, {
     global: { headers: { Authorization: authHeader } },
   });
+}
+
+function getProviders(user: { app_metadata?: Record<string, unknown> }): string[] {
+  const providers = user.app_metadata?.providers;
+  // @type-assertion-allowed: Supabase types app_metadata values as unknown
+  return Array.isArray(providers) ? (providers as string[]) : [];
 }
 
 export const authRoutes = new Hono()
@@ -58,7 +70,13 @@ export const authRoutes = new Hono()
     return c.json(
       {
         user: data.user
-          ? { id: data.user.id, email: data.user.email, nickname: body.nickname, avatarUrl: null }
+          ? {
+              id: data.user.id,
+              email: data.user.email,
+              nickname: body.nickname,
+              avatarUrl: null,
+              providers: getProviders(data.user),
+            }
           : null,
         session: data.session
           ? {
@@ -122,6 +140,7 @@ export const authRoutes = new Hono()
         email: data.user.email,
         nickname: profile?.nickname ?? null,
         avatarUrl: profile?.avatar_url ?? null,
+        providers: getProviders(data.user),
       },
       session: {
         accessToken: data.session.access_token,
@@ -203,7 +222,13 @@ export const authRoutes = new Hono()
       });
 
       return c.json({
-        user: { id: data.user.id, email: data.user.email, nickname, avatarUrl },
+        user: {
+          id: data.user.id,
+          email: data.user.email,
+          nickname,
+          avatarUrl,
+          providers: getProviders(data.user),
+        },
         session: {
           accessToken: data.session.access_token,
           refreshToken: data.session.refresh_token,
@@ -218,6 +243,7 @@ export const authRoutes = new Hono()
         email: data.user.email,
         nickname: profile.nickname,
         avatarUrl: profile.avatar_url,
+        providers: getProviders(data.user),
       },
       session: {
         accessToken: data.session.access_token,
@@ -284,8 +310,75 @@ export const authRoutes = new Hono()
         email: user.email,
         nickname: profile?.nickname ?? null,
         avatarUrl: profile?.avatar_url ?? null,
+        providers: getProviders(user),
       },
     });
+  })
+  .post('/change-password', async (c) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return c.json({ error: 'Missing token' }, 401);
+    }
+
+    const supabase = createUserSupabase(authHeader);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user?.email) {
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    const body = changePasswordSchema.parse(await c.req.json());
+
+    // Verify current password
+    const authClient = getSupabaseAuthClient();
+    const { error: signInError } = await authClient.auth.signInWithPassword({
+      email: user.email,
+      password: body.currentPassword,
+    });
+
+    if (signInError) {
+      return c.json({ error: '現在のパスワードが正しくありません' }, 400);
+    }
+
+    // Update password
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: body.newPassword,
+    });
+
+    if (updateError) {
+      return c.json({ error: updateError.message }, 400);
+    }
+
+    return c.json({ message: 'Password updated' });
+  })
+  .post('/change-email', async (c) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return c.json({ error: 'Missing token' }, 401);
+    }
+
+    const supabase = createUserSupabase(authHeader);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    const body = changeEmailSchema.parse(await c.req.json());
+
+    const { error } = await supabase.auth.updateUser({ email: body.newEmail });
+
+    if (error) {
+      return c.json({ error: error.message }, 400);
+    }
+
+    return c.json({ message: '確認メールを送信しました' });
   })
   .patch('/profile', async (c) => {
     const authHeader = c.req.header('Authorization');

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,8 @@ export {
   boardQuerySchema,
   boardSnippetCreateSchema,
   boardSnippetUpdateSchema,
+  changeEmailSchema,
+  changePasswordSchema,
   createEntrySchema,
   credentialsSchema,
   loginSchema,

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -42,6 +42,15 @@ export const profileUpdateSchema = z.object({
   avatarUrl: z.string().nullable().optional(),
 });
 
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string().min(6),
+});
+
+export const changeEmailSchema = z.object({
+  newEmail: z.string().email(),
+});
+
 // Board schemas
 export const boardQuerySchema = z.object({
   dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),


### PR DESCRIPTION
## Summary
- **パスワード変更**: 現在のパスワードを `signInWithPassword` で検証してから更新（セキュリティ修正）
- **メールアドレス変更**: Supabase の確認メールフロー経由で安全に変更
- **OAuth 検出**: `/me`, `/login`, `/signup`, `/oauth/callback` が `providers[]` を返すように。Google OAuth ユーザーはパスワードセクション非表示、メアド読み取り専用
- 共有スキーマに `changePasswordSchema`, `changeEmailSchema` 追加

## 変更ファイル
- `packages/shared/src/schemas.ts` / `index.ts` — 新スキーマ追加
- `apps/server/.../routes/auth.ts` — `/change-password`, `/change-email` 新規、全レスポンスに `providers` 追加
- `apps/client/src/features/auth/hooks/use-auth.ts` — `providers: string[]` を型に追加
- `apps/client/src/features/auth/components/account-page.tsx` — `PasswordChangeSection`, `EmailChangeSection` に改修
- `apps/client/src/features/auth/utils/error-messages.ts` — エラー翻訳追加

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全 196 テスト通過
- [x] `pnpm dep-cruise` 依存違反なし
- [x] `pnpm knip` デッドコードなし
- [ ] email ユーザー: パスワード変更フロー（現パスワード誤り→エラー / 正しい→成功）
- [ ] email ユーザー: メアド変更→確認メール送信メッセージ表示
- [ ] Google OAuth ユーザー: パスワード非表示、メアド読み取り専用

🤖 Generated with [Claude Code](https://claude.com/claude-code)