### PR TITLE
feat: アカウントページ構造化、テーマ/ログアウトをサイドバーから移動

### DIFF
--- a/apps/client/src/app/(protected)/account/page.tsx
+++ b/apps/client/src/app/(protected)/account/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { AccountPage } from '@/features/auth/components/account-page';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 
 export default function AccountRoute() {
-  const { auth, loading } = useAuth();
+  const { auth, loading, logout } = useAuth();
+  const router = useRouter();
 
   if (loading || !auth) {
     return (
@@ -17,5 +19,10 @@ export default function AccountRoute() {
     );
   }
 
-  return <AccountPage user={auth.user} />;
+  function handleLogout() {
+    logout();
+    router.push('/login');
+  }
+
+  return <AccountPage user={auth.user} onLogout={handleLogout} />;
 }

--- a/apps/client/src/features/auth/components/account-page.tsx
+++ b/apps/client/src/features/auth/components/account-page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { translateAuthError } from '@/features/auth/utils/error-messages';
 import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
+import { useTheme } from '@/lib/theme-context';
 import { WritingStats } from './writing-stats';
 
 interface AccountPageProps {
@@ -15,6 +16,7 @@ interface AccountPageProps {
     name: string | null;
     providers: string[];
   };
+  onLogout: () => void;
 }
 
 const labelClass = 'mb-1 text-[10px] font-medium uppercase tracking-[0.1em]';
@@ -25,6 +27,37 @@ const inputStyle = {
   backgroundColor: 'var(--bg)',
   color: 'var(--fg)',
 };
+const sectionHeadingClass = 'mb-6 text-xs font-semibold uppercase tracking-[0.2em]';
+const sectionHeadingStyle = { color: 'var(--accent)', fontFamily: 'Inter, sans-serif' };
+
+const SECTIONS = [
+  { id: 'profile', label: 'プロフィール' },
+  { id: 'security', label: 'セキュリティ' },
+  { id: 'stats', label: '統計' },
+  { id: 'settings', label: '設定' },
+];
+
+function SectionNav() {
+  function handleClick(id: string) {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+  }
+
+  return (
+    <nav className="mb-10 flex flex-wrap gap-4">
+      {SECTIONS.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          onClick={() => handleClick(s.id)}
+          className="text-[10px] font-medium uppercase tracking-[0.1em] transition-colors hover:text-[var(--accent)]"
+          style={{ color: 'var(--date-color)', fontFamily: 'Inter, sans-serif' }}
+        >
+          {s.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
 
 function EditableField({
   label,
@@ -362,7 +395,74 @@ function PasswordChangeSection({ isOAuthOnly }: { isOAuthOnly: boolean }) {
   );
 }
 
-export function AccountPage({ user }: AccountPageProps) {
+function ThemeToggleSection() {
+  const { theme, toggle } = useTheme();
+
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className={labelClass} style={labelStyle}>
+          テーマ
+        </p>
+        <p className="text-sm" style={{ color: 'var(--fg)' }}>
+          {theme === 'light' ? 'ライトモード' : 'ダークモード'}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
+        style={{
+          color: 'var(--accent)',
+          border: '1px solid var(--border-subtle)',
+        }}
+      >
+        {theme === 'light' ? (
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-3.5 w-3.5"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        ) : (
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-3.5 w-3.5"
+          >
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </svg>
+        )}
+        切り替え
+      </button>
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="my-8 h-px" style={{ backgroundColor: 'var(--border-subtle)' }} />;
+}
+
+export function AccountPage({ user, onLogout }: AccountPageProps) {
   const displayName = user.nickname ?? user.name ?? user.email.split('@')[0];
   const initials = displayName.charAt(0).toUpperCase();
   const isOAuthOnly = user.providers.length > 0 && !user.providers.includes('email');
@@ -385,71 +485,111 @@ export function AccountPage({ user }: AccountPageProps) {
 
   return (
     <div className="mx-auto max-w-md px-6 py-12">
-      <h1
-        className="mb-8 text-xs font-semibold uppercase tracking-[0.2em]"
-        style={{ color: 'var(--accent)', fontFamily: 'Inter, sans-serif' }}
-      >
+      {/* Page title */}
+      <h1 className={sectionHeadingClass} style={sectionHeadingStyle}>
         Account
       </h1>
 
-      {/* Avatar + Name */}
-      <div className="mb-8 flex items-center gap-4">
-        {user.avatarUrl ? (
-          // biome-ignore lint/performance/noImgElement: external avatar URL
-          <img
-            src={user.avatarUrl}
-            alt=""
-            className="h-16 w-16 rounded-full object-cover"
-            referrerPolicy="no-referrer"
+      {/* Section index nav */}
+      <SectionNav />
+
+      {/* ── Profile ── */}
+      <section id="profile">
+        <h2 className={sectionHeadingClass} style={sectionHeadingStyle}>
+          プロフィール
+        </h2>
+
+        <div className="mb-6 flex items-center gap-4">
+          {user.avatarUrl ? (
+            // biome-ignore lint/performance/noImgElement: external avatar URL
+            <img
+              src={user.avatarUrl}
+              alt=""
+              className="h-16 w-16 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <span
+              className="flex h-16 w-16 items-center justify-center rounded-full text-xl font-bold text-white"
+              style={{ backgroundColor: 'var(--accent)' }}
+            >
+              {initials}
+            </span>
+          )}
+          <div>
+            <p className="text-sm font-medium" style={{ color: 'var(--fg)' }}>
+              {displayName}
+            </p>
+            <p className="text-xs" style={{ color: 'var(--date-color)' }}>
+              {user.email}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-5">
+          <EditableField
+            label="ニックネーム"
+            value={user.nickname ?? ''}
+            onSave={(val) => updateProfile('nickname', val)}
           />
-        ) : (
-          <span
-            className="flex h-16 w-16 items-center justify-center rounded-full text-xl font-bold text-white"
-            style={{ backgroundColor: 'var(--accent)' }}
-          >
-            {initials}
-          </span>
-        )}
-        <div>
-          <p className="text-sm font-medium" style={{ color: 'var(--fg)' }}>
-            {displayName}
-          </p>
-          <p className="text-xs" style={{ color: 'var(--date-color)' }}>
-            {user.email}
-          </p>
+          <div>
+            <p className={labelClass} style={labelStyle}>
+              ユーザーID
+            </p>
+            <p className="font-mono text-xs" style={{ color: 'var(--date-color)' }}>
+              {user.id}
+            </p>
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Profile fields */}
-      <div className="flex flex-col gap-5">
-        <EditableField
-          label="ニックネーム"
-          value={user.nickname ?? ''}
-          onSave={(val) => updateProfile('nickname', val)}
-        />
-        <EmailChangeSection email={user.email} isOAuthOnly={isOAuthOnly} />
-        <PasswordChangeSection isOAuthOnly={isOAuthOnly} />
-        <div>
-          <p className={labelClass} style={labelStyle}>
-            ユーザーID
-          </p>
-          <p className="font-mono text-xs" style={{ color: 'var(--date-color)' }}>
-            {user.id}
-          </p>
+      <Divider />
+
+      {/* ── Security ── */}
+      <section id="security">
+        <h2 className={sectionHeadingClass} style={sectionHeadingStyle}>
+          セキュリティ
+        </h2>
+        <div className="flex flex-col gap-5">
+          <EmailChangeSection email={user.email} isOAuthOnly={isOAuthOnly} />
+          <PasswordChangeSection isOAuthOnly={isOAuthOnly} />
         </div>
-      </div>
+      </section>
 
-      {/* Divider */}
-      <div className="my-8 h-px" style={{ backgroundColor: 'var(--border-subtle)' }} />
+      <Divider />
 
-      {/* Writing Statistics */}
-      <h2
-        className="mb-6 text-xs font-semibold uppercase tracking-[0.2em]"
-        style={{ color: 'var(--accent)', fontFamily: 'Inter, sans-serif' }}
-      >
-        Writing Stats
-      </h2>
-      <WritingStats />
+      {/* ── Stats ── */}
+      <section id="stats">
+        <h2 className={sectionHeadingClass} style={sectionHeadingStyle}>
+          統計
+        </h2>
+        <WritingStats />
+      </section>
+
+      <Divider />
+
+      {/* ── Settings ── */}
+      <section id="settings">
+        <h2 className={sectionHeadingClass} style={sectionHeadingStyle}>
+          設定
+        </h2>
+        <div className="flex flex-col gap-6">
+          <ThemeToggleSection />
+
+          <div>
+            <p className={labelClass} style={labelStyle}>
+              ログアウト
+            </p>
+            <button
+              type="button"
+              onClick={onLogout}
+              className="mt-1 text-sm font-medium text-red-500 transition-colors hover:text-red-600"
+            >
+              ログアウトする
+            </button>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { useTheme } from '@/lib/theme-context';
 import { useUnread } from '@/lib/unread-context';
@@ -44,15 +44,9 @@ const NAV_ITEMS: NavItem[] = [
 
 export function Sidebar() {
   const pathname = usePathname();
-  const router = useRouter();
-  const { auth, logout } = useAuth();
-  const { theme, toggle: toggleTheme } = useTheme();
+  const { auth } = useAuth();
+  const { theme } = useTheme();
   const { unreadCount } = useUnread();
-
-  function handleLogout() {
-    logout();
-    router.push('/login');
-  }
 
   return (
     <nav
@@ -147,50 +141,6 @@ export function Sidebar() {
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Dark mode toggle */}
-      <button
-        type="button"
-        onClick={toggleTheme}
-        title={theme === 'light' ? 'ダークモードに切り替え' : 'ライトモードに切り替え'}
-        className="group mb-4 flex h-12 w-12 items-center justify-center rounded-[20px] text-[#8C857E] transition-all duration-300 hover:bg-[rgba(140,133,126,0.1)] hover:text-[#4A4541]"
-      >
-        {theme === 'light' ? (
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-4 w-4 transition-transform duration-300 group-hover:scale-110"
-          >
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-          </svg>
-        ) : (
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-4 w-4 transition-transform duration-300 group-hover:scale-110"
-          >
-            <circle cx="12" cy="12" r="5" />
-            <line x1="12" y1="1" x2="12" y2="3" />
-            <line x1="12" y1="21" x2="12" y2="23" />
-            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-            <line x1="1" y1="12" x2="3" y2="12" />
-            <line x1="21" y1="12" x2="23" y2="12" />
-            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-          </svg>
-        )}
-      </button>
-
       {/* Account avatar */}
       <Link
         href="/account"
@@ -216,27 +166,6 @@ export function Sidebar() {
           </span>
         )}
       </Link>
-
-      {/* Logout */}
-      <button
-        type="button"
-        onClick={handleLogout}
-        title="ログアウト"
-        className="group flex h-12 w-12 items-center justify-center rounded-[20px] text-[#8C857E] transition-all duration-300 hover:bg-[rgba(140,133,126,0.1)] hover:text-[#4A4541]"
-      >
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4 transition-transform duration-300 group-hover:scale-110"
-        >
-          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
-        </svg>
-      </button>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- アカウントページを4セクション（プロフィール/セキュリティ/統計/設定）に構造化
- ページ上部にセクションインデックスナビ（スムーズスクロール付き）
- **設定セクション**: テーマ切り替え（Light/Dark）とログアウトを配置
- **サイドバー簡素化**: ダークモードトグルとログアウトボタンを削除、ナビ + アバターのみに

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全 196 テスト通過
- [x] `pnpm dep-cruise` 依存違反なし
- [x] `pnpm knip` デッドコードなし
- [ ] ブラウザ: インデックスからセクションスクロール、テーマ切替、ログアウト動作確認
- [ ] ブラウザ: サイドバーからダークモード/ログアウトが消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)