### PR TITLE
feat: admin costs ページ統合 — 単一テーブル + フィルタ + 合計

### DIFF
--- a/apps/admin/src/app/(protected)/costs/page.tsx
+++ b/apps/admin/src/app/(protected)/costs/page.tsx
@@ -1,109 +1,197 @@
 'use client';
 
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Search, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { DateRangeSelector } from '@/components/ui/date-range-selector';
 import { CostTable } from '@/features/cost-tracking/components/cost-table';
-import { UserCostTable } from '@/features/cost-tracking/components/user-cost-table';
 import { useCostData } from '@/features/cost-tracking/hooks/use-cost-data';
-import { useUserCostSummary } from '@/features/cost-tracking/hooks/use-user-cost-summary';
+import { useUsers } from '@/features/users/hooks/use-users';
+import { useDateRange } from '@/lib/use-date-range';
 
-function formatCost(cost: number): string {
-  return `$${cost.toFixed(4)}`;
+function UserSearchCombobox({
+  users,
+  onSelect,
+  onClear,
+  selectedLabel,
+}: {
+  users: { id: string; email: string }[];
+  onSelect: (userId: string, label: string) => void;
+  onClear: () => void;
+  selectedLabel: string;
+}) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!query) return [];
+    const q = query.toLowerCase();
+    return users.filter((u) => u.email.toLowerCase().includes(q) || u.id.includes(q)).slice(0, 8);
+  }, [users, query]);
+
+  function handleSelect(user: { id: string; email: string }) {
+    onSelect(user.id, user.email);
+    setQuery('');
+    setOpen(false);
+  }
+
+  if (selectedLabel) {
+    return (
+      <div className="flex h-7 items-center gap-1.5 rounded-md border border-border bg-transparent px-2 text-xs">
+        <Search className="h-3 w-3 text-muted-foreground" />
+        <span className="max-w-48 truncate">{selectedLabel}</span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="ml-1 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => query && setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="ユーザーを検索..."
+        className="h-7 w-56 rounded-md border border-border bg-transparent pl-7 pr-2 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      {open && filtered.length > 0 && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border border-border bg-background shadow-lg">
+          {filtered.map((user) => (
+            <button
+              key={user.id}
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => handleSelect(user)}
+              className="flex w-full flex-col px-3 py-1.5 text-left text-xs hover:bg-muted"
+            >
+              <span className="truncate">{user.email}</span>
+              <span className="truncate font-mono text-[10px] text-muted-foreground">
+                {user.id.slice(0, 12)}...
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function CostsPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
-  const { data, pagination, loading, error, refresh } = useCostData({ page });
-  const {
-    data: userCosts,
-    loading: userCostsLoading,
-    error: userCostsError,
-    refresh: refreshUserCosts,
-  } = useUserCostSummary();
+  const [appliedUser, setAppliedUser] = useState('');
+  const [appliedUserLabel, setAppliedUserLabel] = useState('');
+  const { preset, dateFrom, dateTo, selectPreset, setCustomRange } = useDateRange('30d');
+  const { users } = useUsers();
+  const { data, pagination, loading, error, refresh } = useCostData({
+    page,
+    dateFrom,
+    dateTo,
+    userId: appliedUser || undefined,
+  });
 
   const totalPages = Math.ceil(pagination.total / pagination.limit);
-  const grandTotal = userCosts.reduce((sum, item) => sum + item.totalCostUsd, 0);
+  const grandTotal = data.reduce((sum, item) => sum + (item.cost?.totalCost ?? 0), 0);
 
-  function handleRefresh() {
-    refresh();
-    refreshUserCosts();
+  function handleUserSelect(userId: string, label: string) {
+    setAppliedUser(userId);
+    setAppliedUserLabel(label);
+    setPage(1);
+  }
+
+  function clearUserFilter() {
+    setAppliedUser('');
+    setAppliedUserLabel('');
+    setPage(1);
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-medium">Cost Tracking</h1>
           <span className="text-sm text-muted-foreground">
-            Total: <span className="font-mono text-foreground">{formatCost(grandTotal)}</span>
+            {pagination.total} tracked
+            <span className="mx-1.5 text-border">|</span>
+            Total: <span className="font-mono text-foreground">${grandTotal.toFixed(4)}</span>
           </span>
         </div>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          onClick={handleRefresh}
-          disabled={loading || userCostsLoading}
-        >
-          <RefreshCw className={`h-3 w-3 ${loading || userCostsLoading ? 'animate-spin' : ''}`} />
-        </Button>
+        <div className="flex items-center gap-2">
+          <DateRangeSelector
+            preset={preset}
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onPresetChange={selectPreset}
+            onCustomChange={setCustomRange}
+          />
+          <Button variant="ghost" size="icon-xs" onClick={refresh} disabled={loading}>
+            <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
       </div>
 
-      {(error || userCostsError) && (
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <UserSearchCombobox
+          users={users}
+          onSelect={handleUserSelect}
+          onClear={clearUserFilter}
+          selectedLabel={appliedUserLabel}
+        />
+      </div>
+
+      {error && (
         <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error || userCostsError}
+          {error}
         </div>
       )}
 
-      <div>
-        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
-          Per User
-        </h2>
-        {userCostsLoading && userCosts.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-8 text-center">Loading...</p>
-        ) : (
-          <UserCostTable items={userCosts} onUserClick={(id) => router.push(`/users/${id}`)} />
-        )}
-      </div>
+      {loading && data.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">Loading...</p>
+      ) : (
+        <>
+          <CostTable items={data} onRowClick={(id) => router.push(`/fermentations/${id}`)} />
 
-      <div>
-        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
-          Request Log
-        </h2>
-        {loading && data.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-8 text-center">Loading...</p>
-        ) : (
-          <>
-            <CostTable items={data} onRowClick={(id) => router.push(`/fermentations/${id}`)} />
-
-            {totalPages > 1 && (
-              <div className="flex items-center justify-center gap-2 pt-2">
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page <= 1}
-                >
-                  Previous
-                </Button>
-                <span className="text-xs text-muted-foreground font-mono">
-                  {page} / {totalPages}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                  disabled={page >= totalPages}
-                >
-                  Next
-                </Button>
-              </div>
-            )}
-          </>
-        )}
-      </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 pt-2">
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-xs text-muted-foreground font-mono">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/components/ui/table.tsx
+++ b/apps/admin/src/components/ui/table.tsx
@@ -75,4 +75,17 @@ function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   );
 }
 
-export { Table, TableBody, TableCell, TableHead, TableHeader, TableRow };
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'border-t border-border bg-muted/50 font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/apps/admin/src/features/cost-tracking/components/cost-table.tsx
+++ b/apps/admin/src/features/cost-tracking/components/cost-table.tsx
@@ -4,6 +4,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -36,6 +37,10 @@ interface CostTableProps {
 }
 
 export function CostTable({ items, onRowClick }: CostTableProps) {
+  const totalCost = items.reduce((sum, item) => sum + (item.cost?.totalCost ?? 0), 0);
+  const totalInput = items.reduce((sum, item) => sum + (item.cost?.promptTokens ?? 0), 0);
+  const totalOutput = items.reduce((sum, item) => sum + (item.cost?.completionTokens ?? 0), 0);
+
   return (
     <Table>
       <TableHeader>
@@ -59,8 +64,8 @@ export function CostTable({ items, onRowClick }: CostTableProps) {
             <TableCell className="whitespace-nowrap font-mono text-xs">
               {formatDate(item.created_at)}
             </TableCell>
-            <TableCell className="font-mono text-xs text-muted-foreground">
-              {item.user_id.slice(0, 8)}
+            <TableCell className="text-xs text-muted-foreground">
+              {item.user_email || item.user_id.slice(0, 8)}
             </TableCell>
             <TableCell>
               <span className="inline-flex items-center gap-1.5 text-sm">
@@ -92,6 +97,25 @@ export function CostTable({ items, onRowClick }: CostTableProps) {
           </TableRow>
         )}
       </TableBody>
+      {items.length > 0 && (
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3} className="text-xs font-medium">
+              Page Total ({items.length} requests)
+            </TableCell>
+            <TableCell className="text-right font-mono text-xs font-medium">
+              {totalInput.toLocaleString()}
+            </TableCell>
+            <TableCell className="text-right font-mono text-xs font-medium">
+              {totalOutput.toLocaleString()}
+            </TableCell>
+            <TableCell className="text-right font-mono text-sm font-medium">
+              {formatCost(totalCost)}
+            </TableCell>
+            <TableCell />
+          </TableRow>
+        </TableFooter>
+      )}
     </Table>
   );
 }

--- a/apps/admin/src/features/cost-tracking/hooks/use-cost-data.ts
+++ b/apps/admin/src/features/cost-tracking/hooks/use-cost-data.ts
@@ -7,6 +7,7 @@ import { getAccessToken } from '@/lib/auth';
 export interface CostItem {
   id: string;
   user_id: string;
+  user_email: string;
   status: string;
   generation_id: string | null;
   created_at: string;
@@ -28,15 +29,17 @@ interface UseCostDataParams {
   limit?: number;
   dateFrom?: string;
   dateTo?: string;
+  userId?: string;
 }
 
 export function useCostData(params?: UseCostDataParams) {
   const page = params?.page ?? 1;
-  const limit = params?.limit ?? 20;
+  const limit = params?.limit ?? 30;
   const dateFrom = params?.dateFrom;
   const dateTo = params?.dateTo;
+  const userId = params?.userId;
   const [data, setData] = useState<CostItem[]>([]);
-  const [pagination, setPagination] = useState({ page: 1, limit: 20, total: 0 });
+  const [pagination, setPagination] = useState({ page: 1, limit: 30, total: 0 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,6 +56,7 @@ export function useCostData(params?: UseCostDataParams) {
     searchParams.set('limit', String(limit));
     if (dateFrom) searchParams.set('date_from', dateFrom);
     if (dateTo) searchParams.set('date_to', dateTo);
+    if (userId) searchParams.set('user_id', userId);
 
     const res = await api.fetch(`/api/v1/admin/fermentations/costs?${searchParams.toString()}`);
     if (res.ok) {
@@ -63,7 +67,7 @@ export function useCostData(params?: UseCostDataParams) {
       setError('コストデータの取得に失敗しました');
     }
     setLoading(false);
-  }, [page, limit, dateFrom, dateTo]);
+  }, [page, limit, dateFrom, dateTo, userId]);
 
   useEffect(() => {
     fetchCosts();

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -133,15 +133,27 @@ export const adminFermentations = new Hono<Env>()
   .get('/costs', async (c) => {
     const supabase = c.get('adminSupabase');
     const page = Number(c.req.query('page') ?? '1');
-    const limit = Number(c.req.query('limit') ?? '10');
+    const limit = Number(c.req.query('limit') ?? '30');
     const offset = (page - 1) * limit;
     const dateFrom = c.req.query('date_from');
     const dateTo = c.req.query('date_to');
+    const userParam = c.req.query('user_id');
+
+    // Resolve email to user ID if needed
+    let resolvedUserId = userParam;
+    if (userParam && userParam.includes('@')) {
+      const { data: usersLookup } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 });
+      const matchedUser = (usersLookup?.users ?? []).find(
+        (u) => u.email?.toLowerCase() === userParam.toLowerCase(),
+      );
+      resolvedUserId = matchedUser?.id ?? 'no-match';
+    }
 
     let costsQuery = supabase
       .from('fermentation_results')
       .select('id, user_id, status, generation_id, created_at', { count: 'exact' })
       .not('generation_id', 'is', null);
+    if (resolvedUserId) costsQuery = costsQuery.eq('user_id', resolvedUserId);
     if (dateFrom) costsQuery = costsQuery.gte('created_at', dateFrom);
     if (dateTo) costsQuery = costsQuery.lte('created_at', `${dateTo}T23:59:59.999Z`);
 
@@ -151,13 +163,20 @@ export const adminFermentations = new Hono<Env>()
 
     if (error) return c.json({ error: error.message }, 500);
 
+    // Resolve user emails
+    const { data: usersData } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 });
+    const emailMap = new Map<string, string>();
+    for (const u of usersData?.users ?? []) {
+      emailMap.set(u.id, u.email ?? '');
+    }
+
     const items = await Promise.all(
       (data ?? []).map(async (row) => {
         try {
           const info = await gateway.getGenerationInfo({ id: row.generation_id });
-          return { ...row, cost: info };
+          return { ...row, user_email: emailMap.get(row.user_id) ?? '', cost: info };
         } catch {
-          return { ...row, cost: null };
+          return { ...row, user_email: emailMap.get(row.user_id) ?? '', cost: null };
         }
       }),
     );


### PR DESCRIPTION
## Summary
- PER USER と REQUEST LOG の2テーブルを1つの統合テーブルに集約
- ユーザー検索オートコンプリート追加（fermentations と統一 UIUX）
- 日付フィルタ（DateRangeSelector）追加
- テーブルフッターにページ合計（Input/Output トークン、Cost）を表示
- shadcn Table に `TableFooter` コンポーネント追加
- サーバー `/costs`: `user_id` フィルタ + メール解決 + `user_email` 返却
- User 列にメールアドレスを表示

## Test plan
- [x] 全ガードレール通過（typecheck, test, dep-cruise, knip）
- [ ] admin /costs でユーザー検索 → フィルタ → 合計確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)