### PR TITLE
fix: 読み込み中テキストのフラッシュを除去

### DIFF
--- a/apps/client/src/app/(protected)/account/page.tsx
+++ b/apps/client/src/app/(protected)/account/page.tsx
@@ -8,16 +8,7 @@ export default function AccountRoute() {
   const { auth, loading, logout } = useAuth();
   const router = useRouter();
 
-  if (loading || !auth) {
-    return (
-      <div
-        className="flex h-full items-center justify-center text-xs"
-        style={{ color: 'var(--date-color)' }}
-      >
-        読み込み中...
-      </div>
-    );
-  }
+  if (loading || !auth) return null;
 
   function handleLogout() {
     logout();

--- a/apps/client/src/app/(protected)/board/page.tsx
+++ b/apps/client/src/app/(protected)/board/page.tsx
@@ -6,16 +6,7 @@ import { BoardView } from '@/features/board/components/board-view';
 export default function BoardPage() {
   const { api, loading: authLoading } = useAuth();
 
-  if (authLoading || !api) {
-    return (
-      <div
-        className="flex h-full items-center justify-center text-xs"
-        style={{ color: 'var(--date-color)' }}
-      >
-        Loading...
-      </div>
-    );
-  }
+  if (authLoading || !api) return null;
 
   return <BoardView api={api} />;
 }

--- a/apps/client/src/app/(protected)/entries/[id]/page.tsx
+++ b/apps/client/src/app/(protected)/entries/[id]/page.tsx
@@ -28,13 +28,7 @@ export default function EntryDetailPage() {
     [runTransition, router],
   );
 
-  if (entryLoading || authLoading) {
-    return (
-      <div className="flex min-h-full items-center justify-center">
-        <p className="text-sm text-[var(--date-color)]">読み込み中...</p>
-      </div>
-    );
-  }
+  if (entryLoading || authLoading) return null;
 
   if (!entry) {
     return (

--- a/apps/client/src/app/(protected)/layout.tsx
+++ b/apps/client/src/app/(protected)/layout.tsx
@@ -19,13 +19,7 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
     }
   }, [loading, auth, router]);
 
-  if (loading) {
-    return (
-      <div className="flex min-h-full items-center justify-center">
-        <p className="text-sm text-[var(--date-color)]">読み込み中...</p>
-      </div>
-    );
-  }
+  if (loading) return null;
 
   if (!auth) return null;
 

--- a/apps/client/src/app/(protected)/questions/page.tsx
+++ b/apps/client/src/app/(protected)/questions/page.tsx
@@ -23,9 +23,7 @@ export default function QuestionsPage() {
         <QuestionCreateForm onSubmit={createQuestion} />
 
         <div className="mt-6">
-          {loading ? (
-            <p className="text-sm text-[var(--date-color)]">読み込み中...</p>
-          ) : (
+          {loading ? null : (
             <QuestionTimeline
               questions={questions}
               onArchive={archiveQuestion}

--- a/apps/client/src/features/auth/components/writing-stats.tsx
+++ b/apps/client/src/features/auth/components/writing-stats.tsx
@@ -26,13 +26,7 @@ function StatCard({ label, value, sub }: { label: string; value: string | number
 export function WritingStats() {
   const { stats, loading } = useUserStats();
 
-  if (loading) {
-    return (
-      <p className="py-8 text-center text-sm" style={{ color: 'var(--date-color)' }}>
-        読み込み中...
-      </p>
-    );
-  }
+  if (loading) return null;
 
   if (!stats) return null;
 

--- a/apps/client/src/features/board/components/board-view.tsx
+++ b/apps/client/src/features/board/components/board-view.tsx
@@ -139,14 +139,7 @@ export function BoardView({ api }: BoardViewProps) {
 
       {/* Canvas */}
       <div className="relative min-h-full" style={{ minWidth: 1200, minHeight: 900 }}>
-        {loading && (
-          <div
-            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-xs"
-            style={{ color: 'var(--date-color)' }}
-          >
-            Loading...
-          </div>
-        )}
+        {loading && cards.length === 0 && null}
 
         {cards.map((card) => (
           <BoardCard

--- a/apps/client/src/features/entries/components/entry-list.tsx
+++ b/apps/client/src/features/entries/components/entry-list.tsx
@@ -125,9 +125,7 @@ export function EntryList({ api, authLoading }: EntryListProps) {
         )}
       </div>
 
-      {authLoading || (loading && entries.length === 0) ? (
-        <p className="text-center text-sm text-[var(--date-color)]">読み込み中...</p>
-      ) : entries.length === 0 ? (
+      {authLoading || (loading && entries.length === 0) ? null : entries.length === 0 ? (
         <p className="py-12 text-center text-sm text-[var(--date-color)]">
           {isSearching ? '検索結果はありません' : 'エントリーはまだありません'}
         </p>

--- a/apps/client/src/features/fermentation/components/jar-view.tsx
+++ b/apps/client/src/features/fermentation/components/jar-view.tsx
@@ -169,13 +169,7 @@ export function JarView({
     setZoomedId(null);
   }
 
-  if (authLoading) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-[var(--date-color)]">
-        読み込み中...
-      </div>
-    );
-  }
+  if (authLoading) return null;
 
   return (
     <div className="relative h-full w-full overflow-hidden bg-[var(--bg)]">


### PR DESCRIPTION
## 問題

認証チェック中に「読み込み中...」テキストが画面中央上に一瞬表示され、その後コンテンツに切り替わるのが視覚的に不快。

## 修正

全ページの loading 状態を `return null` に変更。認証チェックは一瞬なので、空フレームの方がテキストがチラつくよりマシ。

対象: layout, board, entries/[id], account, questions, jar-view, entry-list, board-view, writing-stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)