### PR TITLE
fix: 認証チェック中もサイドバーを表示する

### DIFF
--- a/apps/client/src/app/(protected)/layout.tsx
+++ b/apps/client/src/app/(protected)/layout.tsx
@@ -19,9 +19,8 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
     }
   }, [loading, auth, router]);
 
-  if (loading) return null;
-
-  if (!auth) return null;
+  // Not authenticated and not loading → redirect in progress
+  if (!loading && !auth) return null;
 
   return (
     <ThemeProvider>
@@ -38,7 +37,7 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
                 } as React.CSSProperties
               }
             >
-              <div className="relative flex-1 overflow-auto">{children}</div>
+              <div className="relative flex-1 overflow-auto">{loading ? null : children}</div>
               <PageFooter />
             </main>
           </div>


### PR DESCRIPTION
## 問題

前回の修正 (#162) で loading 中に `return null` にしたが、ネットワークが遅い時に完全に空白になる。

## 修正

loading 中もサイドバー + フッター付きのフルレイアウトを表示し、コンテンツエリアだけ空にする。

Before: 空白 → サイドバーがバンと出る
After: サイドバー最初から見える → コンテンツがスッと表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)