### PR TITLE
feat: admin テーブル統一 — ソート・合計・発火モーダル

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@oryzae/server": "workspace:*",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@sentry/nextjs": "^10.48.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/admin/src/app/(protected)/fermentations/page.tsx
+++ b/apps/admin/src/app/(protected)/fermentations/page.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { RefreshCw, Search, X } from 'lucide-react';
+import { Play, RefreshCw, Search, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { DateRangeSelector } from '@/components/ui/date-range-selector';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { FermentationTable } from '@/features/fermentations/components/fermentation-table';
 import { TriggerScheduledFermentationPanel } from '@/features/fermentations/components/trigger-scheduled-fermentation-panel';
 import { useFermentations } from '@/features/fermentations/hooks/use-fermentations';
@@ -152,6 +160,23 @@ export default function FermentationsPage() {
             onPresetChange={selectPreset}
             onCustomChange={setCustomRange}
           />
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="ghost" size="xs">
+                <Play className="mr-1 h-3 w-3" />
+                手動発火
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>手動で発酵プロセスを発火</DialogTitle>
+                <DialogDescription>
+                  指定日 (JST) のエントリに対して ScheduledFermentation を実行します
+                </DialogDescription>
+              </DialogHeader>
+              <TriggerScheduledFermentationPanel onCompleted={refresh} />
+            </DialogContent>
+          </Dialog>
           <Button variant="ghost" size="icon-xs" onClick={refresh} disabled={loading}>
             <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
           </Button>
@@ -183,8 +208,6 @@ export default function FermentationsPage() {
           ))}
         </div>
       </div>
-
-      <TriggerScheduledFermentationPanel onCompleted={refresh} />
 
       {error && (
         <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">

--- a/apps/admin/src/components/ui/dialog.tsx
+++ b/apps/admin/src/components/ui/dialog.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import type * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+const DialogPortal = DialogPrimitive.Portal;
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/apps/admin/src/features/cost-tracking/components/cost-table.tsx
+++ b/apps/admin/src/features/cost-tracking/components/cost-table.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import {
   Table,
   TableBody,
@@ -31,31 +33,106 @@ function statusDotColor(status: string): string {
   return 'bg-muted-foreground/40';
 }
 
+type SortKey =
+  | 'created_at'
+  | 'user_email'
+  | 'status'
+  | 'promptTokens'
+  | 'completionTokens'
+  | 'totalCost'
+  | 'latency';
+type SortDir = 'asc' | 'desc';
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-30" />;
+  return dir === 'asc' ? (
+    <ArrowUp className="ml-1 inline h-3 w-3" />
+  ) : (
+    <ArrowDown className="ml-1 inline h-3 w-3" />
+  );
+}
+
 interface CostTableProps {
   items: CostItem[];
   onRowClick?: (id: string) => void;
 }
 
 export function CostTable({ items, onRowClick }: CostTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('created_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  }
+
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const mul = sortDir === 'asc' ? 1 : -1;
+      switch (sortKey) {
+        case 'created_at':
+          return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+        case 'user_email':
+          return mul * (a.user_email || '').localeCompare(b.user_email || '');
+        case 'status':
+          return mul * a.status.localeCompare(b.status);
+        case 'promptTokens':
+          return mul * ((a.cost?.promptTokens ?? 0) - (b.cost?.promptTokens ?? 0));
+        case 'completionTokens':
+          return mul * ((a.cost?.completionTokens ?? 0) - (b.cost?.completionTokens ?? 0));
+        case 'totalCost':
+          return mul * ((a.cost?.totalCost ?? 0) - (b.cost?.totalCost ?? 0));
+        case 'latency':
+          return mul * ((a.cost?.latency ?? 0) - (b.cost?.latency ?? 0));
+        default:
+          return 0;
+      }
+    });
+  }, [items, sortKey, sortDir]);
+
   const totalCost = items.reduce((sum, item) => sum + (item.cost?.totalCost ?? 0), 0);
   const totalInput = items.reduce((sum, item) => sum + (item.cost?.promptTokens ?? 0), 0);
   const totalOutput = items.reduce((sum, item) => sum + (item.cost?.completionTokens ?? 0), 0);
+
+  function SortableHead({
+    label,
+    sortKeyName,
+    className,
+  }: {
+    label: string;
+    sortKeyName: SortKey;
+    className?: string;
+  }) {
+    return (
+      <TableHead
+        className={`cursor-pointer select-none ${className ?? ''}`}
+        onClick={() => handleSort(sortKeyName)}
+      >
+        {label}
+        <SortIcon active={sortKey === sortKeyName} dir={sortDir} />
+      </TableHead>
+    );
+  }
 
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Date</TableHead>
-          <TableHead>User</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead className="text-right">Input</TableHead>
-          <TableHead className="text-right">Output</TableHead>
-          <TableHead className="text-right">Cost</TableHead>
-          <TableHead className="text-right">Latency</TableHead>
+          <SortableHead label="Date" sortKeyName="created_at" />
+          <SortableHead label="User" sortKeyName="user_email" />
+          <SortableHead label="Status" sortKeyName="status" />
+          <SortableHead label="Input" sortKeyName="promptTokens" className="text-right" />
+          <SortableHead label="Output" sortKeyName="completionTokens" className="text-right" />
+          <SortableHead label="Cost" sortKeyName="totalCost" className="text-right" />
+          <SortableHead label="Latency" sortKeyName="latency" className="text-right" />
         </TableRow>
       </TableHeader>
       <TableBody>
-        {items.map((item) => (
+        {sorted.map((item) => (
           <TableRow
             key={item.id}
             className={onRowClick ? 'cursor-pointer hover:bg-muted/50' : undefined}

--- a/apps/admin/src/features/fermentations/components/fermentation-table.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-table.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { RotateCcw } from 'lucide-react';
-import { useState } from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown, RotateCcw } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -29,6 +30,18 @@ function statusDotColor(status: string): string {
   return 'bg-muted-foreground';
 }
 
+type SortKey = 'created_at' | 'user_email' | 'target_period' | 'status';
+type SortDir = 'asc' | 'desc';
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-30" />;
+  return dir === 'asc' ? (
+    <ArrowUp className="ml-1 inline h-3 w-3" />
+  ) : (
+    <ArrowDown className="ml-1 inline h-3 w-3" />
+  );
+}
+
 interface FermentationTableProps {
   items: FermentationItem[];
   onRetry?: (id: string) => Promise<boolean>;
@@ -37,6 +50,35 @@ interface FermentationTableProps {
 
 export function FermentationTable({ items, onRetry, onRowClick }: FermentationTableProps) {
   const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('created_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  }
+
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const mul = sortDir === 'asc' ? 1 : -1;
+      switch (sortKey) {
+        case 'created_at':
+          return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+        case 'user_email':
+          return mul * (a.user_email || '').localeCompare(b.user_email || '');
+        case 'target_period':
+          return mul * a.target_period.localeCompare(b.target_period);
+        case 'status':
+          return mul * a.status.localeCompare(b.status);
+        default:
+          return 0;
+      }
+    });
+  }, [items, sortKey, sortDir]);
 
   const handleRetry = async (id: string) => {
     if (!onRetry) return;
@@ -45,21 +87,45 @@ export function FermentationTable({ items, onRetry, onRowClick }: FermentationTa
     setRetryingId(null);
   };
 
+  const completed = items.filter((i) => i.status === 'completed').length;
+  const failed = items.filter((i) => i.status === 'failed').length;
+  const tracked = items.filter((i) => i.generation_id).length;
+
+  function SortableHead({
+    label,
+    sortKeyName,
+    className,
+  }: {
+    label: string;
+    sortKeyName: SortKey;
+    className?: string;
+  }) {
+    return (
+      <TableHead
+        className={`cursor-pointer select-none ${className ?? ''}`}
+        onClick={() => handleSort(sortKeyName)}
+      >
+        {label}
+        <SortIcon active={sortKey === sortKeyName} dir={sortDir} />
+      </TableHead>
+    );
+  }
+
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Date</TableHead>
-          <TableHead>User</TableHead>
-          <TableHead>Period</TableHead>
-          <TableHead>Status</TableHead>
+          <SortableHead label="Date" sortKeyName="created_at" />
+          <SortableHead label="User" sortKeyName="user_email" />
+          <SortableHead label="Period" sortKeyName="target_period" />
+          <SortableHead label="Status" sortKeyName="status" />
           <TableHead>Error</TableHead>
           <TableHead>Cost</TableHead>
           <TableHead className="w-[48px]" />
         </TableRow>
       </TableHeader>
       <TableBody>
-        {items.map((item) => (
+        {sorted.map((item) => (
           <TableRow
             key={item.id}
             className={onRowClick ? 'cursor-pointer hover:bg-muted/50' : undefined}
@@ -124,6 +190,21 @@ export function FermentationTable({ items, onRetry, onRowClick }: FermentationTa
           </TableRow>
         )}
       </TableBody>
+      {items.length > 0 && (
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3} className="text-xs font-medium">
+              Page Total ({items.length} items)
+            </TableCell>
+            <TableCell className="text-xs font-medium">
+              {completed} completed / {failed} failed
+            </TableCell>
+            <TableCell />
+            <TableCell className="text-xs font-medium">{tracked} tracked</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableFooter>
+      )}
     </Table>
   );
 }

--- a/apps/admin/src/features/fermentations/components/trigger-scheduled-fermentation-panel.tsx
+++ b/apps/admin/src/features/fermentations/components/trigger-scheduled-fermentation-panel.tsx
@@ -38,35 +38,27 @@ export function TriggerScheduledFermentationPanel({ onCompleted }: Props) {
   };
 
   return (
-    <div className="rounded-md border border-border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-medium">手動で発酵プロセスを発火</h2>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            指定日 (JST) のエントリに対して ScheduledFermentation を実行します
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Input
-            type="date"
-            value={dateKey}
-            onChange={(e) => {
-              setDateKey(e.target.value);
-              setConfirming(false);
-            }}
-            disabled={loading}
-            className="w-auto h-8 text-xs"
-          />
-          <Button
-            variant={confirming ? 'destructive' : 'default'}
-            size="sm"
-            onClick={handleRun}
-            disabled={loading || !dateKey}
-          >
-            <Play className={`h-3 w-3 mr-1.5 ${loading ? 'animate-pulse' : ''}`} />
-            {loading ? '実行中...' : confirming ? '本当に実行する' : '実行'}
-          </Button>
-        </div>
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Input
+          type="date"
+          value={dateKey}
+          onChange={(e) => {
+            setDateKey(e.target.value);
+            setConfirming(false);
+          }}
+          disabled={loading}
+          className="w-auto h-8 text-xs"
+        />
+        <Button
+          variant={confirming ? 'destructive' : 'default'}
+          size="sm"
+          onClick={handleRun}
+          disabled={loading || !dateKey}
+        >
+          <Play className={`h-3 w-3 mr-1.5 ${loading ? 'animate-pulse' : ''}`} />
+          {loading ? '実行中...' : confirming ? '本当に実行する' : '実行'}
+        </Button>
       </div>
 
       {error && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@oryzae/server':
         specifier: workspace:*
         version: link:../server
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^10.48.0
         version: 10.48.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.1)
@@ -6954,7 +6957,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -8091,4 +8094,3 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
-


### PR DESCRIPTION
## Summary

### Fermentations
- ソート可能なカラムヘッダー（Date, User, Period, Status）
- フッター合計行（completed/failed/tracked カウント）
- 手動発火パネルを shadcn Dialog モーダルに移動（ヘッダーの「手動発火」ボタンから開く）

### Costs
- ソート可能なカラムヘッダー（Date, User, Status, Input, Output, Cost, Latency）

### 共通
- shadcn Dialog コンポーネント追加（@radix-ui/react-dialog）
- shadcn Table に TableFooter 追加

## 統一状況
| 機能 | Users | Fermentations | Costs |
|------|-------|---------------|-------|
| 検索 | リアルタイム | オートコンプリート | オートコンプリート |
| フィルタ | active/inactive | status (5種) | - |
| ソート | カラムクリック | カラムクリック | カラムクリック |
| 合計行 | あり | あり | あり |
| 日付フィルタ | - | あり | あり |

## Test plan
- [x] 全ガードレール通過
- [ ] 3ページ全てでソート・合計動作確認
- [ ] Fermentations: 「手動発火」ボタン → モーダル表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)