### PR TITLE
fix: テーブルのホバーUX改善 — ソートヘッダーとクリック行を視覚的に区別

### DIFF
--- a/apps/admin/src/components/ui/table.tsx
+++ b/apps/admin/src/components/ui/table.tsx
@@ -41,7 +41,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
     <tr
       data-slot="table-row"
       className={cn(
-        'border-b border-border/50 transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted',
+        'border-b border-border/50 transition-colors has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted',
         className,
       )}
       {...props}

--- a/apps/admin/src/features/cost-tracking/components/cost-table.tsx
+++ b/apps/admin/src/features/cost-tracking/components/cost-table.tsx
@@ -109,7 +109,7 @@ export function CostTable({ items, onRowClick }: CostTableProps) {
   }) {
     return (
       <TableHead
-        className={`cursor-pointer select-none ${className ?? ''}`}
+        className={`cursor-pointer select-none hover:bg-muted/60 transition-colors ${className ?? ''}`}
         onClick={() => handleSort(sortKeyName)}
       >
         {label}

--- a/apps/admin/src/features/fermentations/components/fermentation-table.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-table.tsx
@@ -102,7 +102,7 @@ export function FermentationTable({ items, onRetry, onRowClick }: FermentationTa
   }) {
     return (
       <TableHead
-        className={`cursor-pointer select-none ${className ?? ''}`}
+        className={`cursor-pointer select-none hover:bg-muted/60 transition-colors ${className ?? ''}`}
         onClick={() => handleSort(sortKeyName)}
       >
         {label}

--- a/apps/admin/src/features/users/components/user-table.tsx
+++ b/apps/admin/src/features/users/components/user-table.tsx
@@ -113,7 +113,7 @@ export function UserTable({ users, onUserClick, searchQuery, statusFilter }: Use
   }) {
     return (
       <TableHead
-        className={`cursor-pointer select-none ${className ?? ''}`}
+        className={`cursor-pointer select-none hover:bg-muted/60 transition-colors ${className ?? ''}`}
         onClick={() => handleSort(sortKeyName)}
       >
         {label}


### PR DESCRIPTION
## Summary
- ソート可能なカラムヘッダーにホバー時の背景色変化を追加（`hover:bg-muted/60`）
- TableRow のデフォルトホバーを削除 — `onRowClick` がある行だけがホバースタイルを持つ
- クリッカブルなエリア（ソートヘッダー vs データ行）が視覚的に明確に

🤖 Generated with [Claude Code](https://claude.com/claude-code)