### PR TITLE
fix: リトライアイコンを PlayCircle に変更して更新アイコンと区別

### DIFF
--- a/apps/admin/src/features/fermentations/components/fermentation-detail-header.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-detail-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RotateCcw } from 'lucide-react';
+import { PlayCircle } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import type { FermentationDetailResponse } from '../hooks/use-fermentation-detail';
@@ -56,7 +56,7 @@ export function FermentationDetailHeader({ data, onRetry }: FermentationDetailHe
         </span>
         {data.status === 'failed' && onRetry && (
           <Button variant="ghost" size="xs" disabled={retrying} onClick={handleRetry}>
-            <RotateCcw className={`h-3 w-3 ${retrying ? 'animate-spin' : ''}`} />
+            <PlayCircle className={`h-3.5 w-3.5 ${retrying ? 'animate-pulse' : ''}`} />
             Retry
           </Button>
         )}

--- a/apps/admin/src/features/fermentations/components/fermentation-table.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowDown, ArrowUp, ArrowUpDown, RotateCcw } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, PlayCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -168,14 +168,15 @@ export function FermentationTable({ items, onRetry, onRowClick }: FermentationTa
                 <Button
                   variant="ghost"
                   size="icon-xs"
+                  title="再実行"
                   disabled={retryingId === item.id}
                   onClick={(e) => {
                     e.stopPropagation();
                     handleRetry(item.id);
                   }}
                 >
-                  <RotateCcw
-                    className={`h-3 w-3 ${retryingId === item.id ? 'animate-spin' : ''}`}
+                  <PlayCircle
+                    className={`h-3.5 w-3.5 ${retryingId === item.id ? 'animate-pulse' : ''}`}
                   />
                 </Button>
               )}


### PR DESCRIPTION
## Summary
Fermentation の再実行（リトライ）アイコンを `RotateCcw` から `PlayCircle` に変更。
`RefreshCw`（データ更新）と `RotateCcw`（リトライ）が酷似していてわかりにくかったため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)