### PR TITLE
feat: dashboard recharts — 日付連動トレンドチャート

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -24,6 +24,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/apps/admin/src/app/(protected)/dashboard/page.tsx
+++ b/apps/admin/src/app/(protected)/dashboard/page.tsx
@@ -94,14 +94,14 @@ export default function DashboardPage() {
       {/* Row 2: Failure alerts (full width) */}
       <FailureAlerts groups={groups} retryFermentation={retryFermentation} />
 
-      {/* Row 3: Health sparklines (2 cards) + cost summary (1 card) — 3 columns */}
+      {/* Row 3: Charts — 3 columns */}
       <div className="grid gap-4 lg:grid-cols-3">
         <HealthSparklines days={days} />
-        <CostSummaryCard summary={summary} />
       </div>
 
-      {/* Row 4: User activity (1/4) + stats grid (3/4) */}
-      <div className="grid gap-4 lg:grid-cols-4">
+      {/* Row 4: Summary cards — cost + activity + stats */}
+      <div className="grid gap-4 lg:grid-cols-5">
+        <CostSummaryCard summary={summary} />
         <UserActivityCard activeWriters={activeWriters} totalUsers={totalUsers} />
         <div className="lg:col-span-3">
           {stats ? (

--- a/apps/admin/src/features/dashboard/components/health-sparklines.tsx
+++ b/apps/admin/src/features/dashboard/components/health-sparklines.tsx
@@ -1,127 +1,175 @@
 'use client';
 
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import type { TrendDay } from '../hooks/use-health-trends';
 
-function formatDayLabel(iso: string): string {
+function formatDateLabel(iso: string): string {
   const d = new Date(iso);
-  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  return days[d.getDay()] ?? '';
+  return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-const PLACEHOLDER_DAYS = 7;
-const BAR_WIDTH = 3;
-const BAR_GAP = 4;
-const BAR_MAX_HEIGHT = 48;
-
-function SparkBars({ values, colorFn }: { values: number[]; colorFn: (value: number) => string }) {
-  if (values.length === 0) {
-    return (
-      <div className="flex items-end" style={{ gap: `${BAR_GAP}px` }}>
-        {Array.from({ length: PLACEHOLDER_DAYS }).map((_, i) => (
-          <div
-            key={`placeholder-${
-              // biome-ignore lint/suspicious/noArrayIndexKey: placeholder bars have no stable id
-              i
-            }`}
-            className="rounded-full bg-muted"
-            style={{
-              width: `${BAR_WIDTH}px`,
-              height: `${BAR_MAX_HEIGHT * 0.2}px`,
-            }}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  const max = Math.max(...values, 1);
-
-  return (
-    <div className="flex items-end" style={{ gap: `${BAR_GAP}px` }}>
-      {values.map((v, i) => {
-        const height = Math.max((v / max) * BAR_MAX_HEIGHT, 2);
-        return (
-          <div
-            key={`bar-${
-              // biome-ignore lint/suspicious/noArrayIndexKey: bar index is stable within render
-              i
-            }`}
-            className={`rounded-full ${colorFn(v)}`}
-            style={{
-              width: `${BAR_WIDTH}px`,
-              height: `${height}px`,
-            }}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function SuccessRateCard({ days }: { days: TrendDay[] }) {
+function SuccessRateChart({ days }: { days: TrendDay[] }) {
   const latest = days.length > 0 ? days[days.length - 1] : null;
   const currentValue = latest ? `${Math.round(latest.successRate)}%` : '--';
+  const data = days.map((d) => ({
+    name: formatDateLabel(d.date),
+    rate: Math.round(d.successRate),
+  }));
 
   return (
-    <div className="flex flex-col justify-between rounded-lg border border-border/50 bg-card p-4">
-      <div>
+    <div className="rounded-lg border border-border/50 bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
         <span className="text-xs uppercase tracking-wider text-muted-foreground">Success Rate</span>
-        <div className="text-3xl font-semibold tracking-tight mt-0.5">{currentValue}</div>
+        <span className="text-2xl font-semibold tracking-tight">{currentValue}</span>
       </div>
-      <div className="mt-3 flex items-end gap-0">
-        <div className="flex-1">
-          <SparkBars
-            values={days.map((d) => d.successRate)}
-            colorFn={(v) => (v > 80 ? 'bg-green-500' : 'bg-red-500')}
-          />
-          {days.length > 0 && (
-            <div className="flex mt-1" style={{ gap: `${BAR_GAP}px` }}>
-              {days.map((d) => (
-                <span
-                  key={d.date}
-                  className="text-[8px] text-muted-foreground/60 text-center"
-                  style={{ width: `${BAR_WIDTH}px` }}
-                >
-                  {formatDayLabel(d.date).charAt(0)}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="h-[140px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data}>
+            <defs>
+              <linearGradient id="successGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 10 }} stroke="hsl(var(--muted-foreground))" />
+            <YAxis
+              domain={[0, 100]}
+              tick={{ fontSize: 10 }}
+              stroke="hsl(var(--muted-foreground))"
+              tickFormatter={(v: number) => `${v}%`}
+            />
+            <Tooltip
+              contentStyle={{
+                fontSize: 12,
+                borderRadius: 8,
+                border: '1px solid hsl(var(--border))',
+              }}
+              formatter={(value) => [`${value}%`, 'Success Rate']}
+            />
+            <Area
+              type="monotone"
+              dataKey="rate"
+              stroke="#22c55e"
+              fill="url(#successGrad)"
+              strokeWidth={2}
+            />
+            {/* 80% target line */}
+            <Line
+              type="monotone"
+              dataKey={() => 80}
+              stroke="#ef4444"
+              strokeDasharray="4 4"
+              strokeWidth={1}
+              dot={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );
 }
 
-function ActiveWritersCard({ days }: { days: TrendDay[] }) {
-  const latest = days.length > 0 ? days[days.length - 1] : null;
-  const currentValue = latest ? String(latest.activeWriters) : '--';
+function FermentationsChart({ days }: { days: TrendDay[] }) {
+  const totalForPeriod = days.reduce((sum, d) => sum + d.totalFermentations, 0);
+  const data = days.map((d) => ({
+    name: formatDateLabel(d.date),
+    completed: d.completedFermentations,
+    failed: d.totalFermentations - d.completedFermentations,
+  }));
 
   return (
-    <div className="flex flex-col justify-between rounded-lg border border-border/50 bg-card p-4">
-      <div>
+    <div className="rounded-lg border border-border/50 bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs uppercase tracking-wider text-muted-foreground">
+          Fermentations
+        </span>
+        <span className="text-2xl font-semibold tracking-tight">{totalForPeriod}</span>
+      </div>
+      <div className="h-[140px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 10 }} stroke="hsl(var(--muted-foreground))" />
+            <YAxis
+              tick={{ fontSize: 10 }}
+              stroke="hsl(var(--muted-foreground))"
+              allowDecimals={false}
+            />
+            <Tooltip
+              contentStyle={{
+                fontSize: 12,
+                borderRadius: 8,
+                border: '1px solid hsl(var(--border))',
+              }}
+            />
+            <Bar
+              dataKey="completed"
+              stackId="a"
+              fill="#22c55e"
+              radius={[0, 0, 0, 0]}
+              name="Completed"
+            />
+            <Bar dataKey="failed" stackId="a" fill="#ef4444" radius={[2, 2, 0, 0]} name="Failed" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function ActiveWritersChart({ days }: { days: TrendDay[] }) {
+  const latest = days.length > 0 ? days[days.length - 1] : null;
+  const currentValue = latest ? String(latest.activeWriters) : '--';
+  const data = days.map((d) => ({ name: formatDateLabel(d.date), writers: d.activeWriters }));
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
         <span className="text-xs uppercase tracking-wider text-muted-foreground">
           Active Writers
         </span>
-        <div className="text-3xl font-semibold tracking-tight mt-0.5">{currentValue}</div>
+        <span className="text-2xl font-semibold tracking-tight">{currentValue}</span>
       </div>
-      <div className="mt-3 flex items-end gap-0">
-        <div className="flex-1">
-          <SparkBars values={days.map((d) => d.activeWriters)} colorFn={() => 'bg-primary'} />
-          {days.length > 0 && (
-            <div className="flex mt-1" style={{ gap: `${BAR_GAP}px` }}>
-              {days.map((d) => (
-                <span
-                  key={d.date}
-                  className="text-[8px] text-muted-foreground/60 text-center"
-                  style={{ width: `${BAR_WIDTH}px` }}
-                >
-                  {formatDayLabel(d.date).charAt(0)}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="h-[140px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 10 }} stroke="hsl(var(--muted-foreground))" />
+            <YAxis
+              tick={{ fontSize: 10 }}
+              stroke="hsl(var(--muted-foreground))"
+              allowDecimals={false}
+            />
+            <Tooltip
+              contentStyle={{
+                fontSize: 12,
+                borderRadius: 8,
+                border: '1px solid hsl(var(--border))',
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="writers"
+              stroke="hsl(var(--primary))"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              name="Writers"
+            />
+          </LineChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );
@@ -130,8 +178,9 @@ function ActiveWritersCard({ days }: { days: TrendDay[] }) {
 export function HealthSparklines({ days }: { days: TrendDay[] }) {
   return (
     <>
-      <SuccessRateCard days={days} />
-      <ActiveWritersCard days={days} />
+      <SuccessRateChart days={days} />
+      <FermentationsChart days={days} />
+      <ActiveWritersChart days={days} />
     </>
   );
 }

--- a/apps/admin/src/features/dashboard/hooks/use-health-trends.ts
+++ b/apps/admin/src/features/dashboard/hooks/use-health-trends.ts
@@ -6,6 +6,8 @@ import { getAccessToken } from '@/lib/auth';
 
 export interface TrendDay {
   date: string;
+  totalFermentations: number;
+  completedFermentations: number;
   successRate: number;
   activeWriters: number;
 }
@@ -23,17 +25,28 @@ export function useHealthTrends(dateFrom?: string, dateTo?: string) {
     setError(null);
 
     const params = new URLSearchParams();
-    if (dateFrom) params.set('dateFrom', dateFrom);
-    if (dateTo) params.set('dateTo', dateTo);
+    if (dateFrom) params.set('date_from', dateFrom);
+    if (dateTo) params.set('date_to', dateTo);
     const qs = params.toString();
 
     const api = createApiClient(token);
     const res = await api.fetch(`/api/v1/admin/dashboard/trends${qs ? `?${qs}` : ''}`);
     if (res.ok) {
-      const data: unknown = await res.json();
-      if (Array.isArray(data)) {
-        setDays(data as TrendDay[]); // @type-assertion-allowed: APIレスポンスの型をバリデーション後にキャスト
-      }
+      const body = (await res.json()) as {
+        days: {
+          date: string;
+          totalFermentations: number;
+          completedFermentations: number;
+          activeWriters: number;
+        }[];
+      };
+      setDays(
+        (body.days ?? []).map((d) => ({
+          ...d,
+          successRate:
+            d.totalFermentations > 0 ? (d.completedFermentations / d.totalFermentations) * 100 : 0,
+        })),
+      );
     } else {
       setError('トレンドデータの取得に失敗しました');
     }

--- a/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
@@ -117,49 +117,58 @@ export const adminDashboard = new Hono<Env>()
   })
   .get('/trends', async (c) => {
     const supabase = c.get('adminSupabase');
+    const dateFromParam = c.req.query('date_from');
+    const dateToParam = c.req.query('date_to');
 
-    const days: {
-      date: string;
-      totalFermentations: number;
-      completedFermentations: number;
-      activeWriters: number;
-    }[] = [];
+    // Determine date range
+    const endDate = dateToParam ? new Date(dateToParam) : new Date();
+    const startDate = dateFromParam
+      ? new Date(dateFromParam)
+      : new Date(endDate.getTime() - 6 * 24 * 60 * 60 * 1000);
 
-    for (let i = 6; i >= 0; i--) {
-      const d = new Date();
-      d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().slice(0, 10);
-      const dayStart = `${dateStr}T00:00:00.000Z`;
-      const dayEnd = `${dateStr}T23:59:59.999Z`;
-
-      const [totalRes, completedRes, writersRes] = await Promise.all([
-        supabase
-          .from('fermentation_results')
-          .select('id', { count: 'exact', head: true })
-          .gte('created_at', dayStart)
-          .lte('created_at', dayEnd),
-        supabase
-          .from('fermentation_results')
-          .select('id', { count: 'exact', head: true })
-          .eq('status', 'completed')
-          .gte('created_at', dayStart)
-          .lte('created_at', dayEnd),
-        supabase
-          .from('entries')
-          .select('user_id')
-          .gte('created_at', dayStart)
-          .lte('created_at', dayEnd),
-      ]);
-
-      const uniqueWriters = new Set((writersRes.data ?? []).map((r) => r.user_id));
-
-      days.push({
-        date: dateStr,
-        totalFermentations: totalRes.count ?? 0,
-        completedFermentations: completedRes.count ?? 0,
-        activeWriters: uniqueWriters.size,
-      });
+    // Build list of dates
+    const dates: string[] = [];
+    const cursor = new Date(startDate);
+    while (cursor <= endDate) {
+      dates.push(cursor.toISOString().slice(0, 10));
+      cursor.setDate(cursor.getDate() + 1);
     }
+
+    // Fetch all data in the range at once (much faster than per-day queries)
+    const rangeStart = `${dates[0]}T00:00:00.000Z`;
+    const rangeEnd = `${dates[dates.length - 1]}T23:59:59.999Z`;
+
+    const [fermRes, entriesRes] = await Promise.all([
+      supabase
+        .from('fermentation_results')
+        .select('status, created_at')
+        .gte('created_at', rangeStart)
+        .lte('created_at', rangeEnd),
+      supabase
+        .from('entries')
+        .select('user_id, created_at')
+        .gte('created_at', rangeStart)
+        .lte('created_at', rangeEnd),
+    ]);
+
+    const fermentations = fermRes.data ?? [];
+    const entries = entriesRes.data ?? [];
+
+    // Group by date
+    const days = dates.map((dateStr) => {
+      const dayFerms = fermentations.filter((f) => f.created_at.slice(0, 10) === dateStr);
+      const dayEntries = entries.filter((e) => e.created_at.slice(0, 10) === dateStr);
+      const total = dayFerms.length;
+      const completed = dayFerms.filter((f) => f.status === 'completed').length;
+      const uniqueWriters = new Set(dayEntries.map((e) => e.user_id));
+
+      return {
+        date: dateStr,
+        totalFermentations: total,
+        completedFermentations: completed,
+        activeWriters: uniqueWriters.size,
+      };
+    });
 
     return c.json({ days });
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -2019,6 +2022,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -2315,6 +2329,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@supabase/auth-js@2.103.0':
     resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
     engines: {node: '>=20.0.0'}
@@ -2464,6 +2481,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2507,6 +2551,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2806,6 +2853,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2818,6 +2909,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2875,6 +2969,9 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -3055,6 +3152,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-in-the-middle@2.0.6:
     resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
@@ -3065,6 +3168,10 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -3517,6 +3624,18 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -3551,9 +3670,25 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -3566,6 +3701,9 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3760,6 +3898,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3876,6 +4017,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -5808,6 +5952,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.5
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
+
   '@rollup/plugin-commonjs@28.0.1(rollup@4.59.0)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -6136,6 +6292,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@supabase/auth-js@2.103.0':
     dependencies:
       tslib: 2.8.1
@@ -6286,6 +6444,30 @@ snapshots:
     dependencies:
       '@types/node': 20.19.39
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -6338,6 +6520,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -6657,6 +6841,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -6665,6 +6887,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -6721,6 +6945,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -6906,6 +7132,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-in-the-middle@2.0.6:
     dependencies:
       acorn: 8.16.0
@@ -6921,6 +7151,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   ini@4.1.1: {}
+
+  internmap@2.0.3: {}
 
   interpret@3.1.1: {}
 
@@ -7480,6 +7712,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -7509,9 +7750,35 @@ snapshots:
 
   react@19.2.5: {}
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.11
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   regexp-tree@0.1.27: {}
 
@@ -7523,6 +7790,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -7735,6 +8004,8 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -7830,6 +8101,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary
- **recharts 導入**: 本格的なチャートライブラリを admin に追加
- **3つのチャート**:
  - Success Rate: エリアチャート（緑グラデーション + 80%目標線）
  - Fermentations: 積み上げ棒グラフ（completed/failed）
  - Active Writers: 折れ線グラフ
- **日付セレクタ連動**: /trends エンドポイントが date_from/date_to を受け取り、選択期間のデータを返す（固定7日→可変）
- **パフォーマンス改善**: N+1 per-day クエリを一括取得 + クライアント側グルーピングに最適化
- Dashboard レイアウト調整（3列チャート行 + 5列サマリー行）

## Test plan
- [x] 全ガードレール通過
- [ ] Dashboard で Today/7d/30d/Custom 切替 → チャート更新確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)