### PR TITLE
feat: Discord 通知 — 新規登録・発酵失敗・日次コストアラート

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,13 @@ UPSTASH_REDIS_REST_TOKEN=
 # Personal Token — https://vercel.com/account/tokens
 VERCEL_TOKEN=
 
+# ── Discord ──
+# Webhook URL — https://discord.com/api/webhooks/xxx/yyy
+DISCORD_WEBHOOK_URL=
+
+# ── Cron ──
+# Secret for Vercel Cron job authentication
+CRON_SECRET=
+
 # ── Server ──
 PORT=3000

--- a/apps/client/src/app/api/cron/cost-alert/route.ts
+++ b/apps/client/src/app/api/cron/cost-alert/route.ts
@@ -1,0 +1,15 @@
+import app from '@oryzae/server';
+
+export const maxDuration = 120;
+
+export async function GET(req: Request) {
+  // Vercel Cron sends GET with Authorization: Bearer <CRON_SECRET>
+  // Forward as POST to the Hono cron route, preserving the auth header
+  const url = new URL('/api/v1/cron/cost-alert', req.url);
+  const internalReq = new Request(url.toString(), {
+    method: 'POST',
+    headers: req.headers,
+  });
+
+  return app.fetch(internalReq);
+}

--- a/apps/client/vercel.json
+++ b/apps/client/vercel.json
@@ -6,6 +6,10 @@
     {
       "path": "/api/cron/fermentation",
       "schedule": "0 18 * * *"
+    },
+    {
+      "path": "/api/cron/cost-alert",
+      "schedule": "0 1 * * *"
     }
   ]
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -18,6 +18,7 @@ import {
 import { adminDashboard } from './contexts/shared/presentation/routes/admin-dashboard.js';
 import { adminObservability } from './contexts/shared/presentation/routes/admin-observability.js';
 import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
+import { cronCostAlert } from './contexts/shared/presentation/routes/cron-cost-alert.js';
 import { adminUsers } from './contexts/user/presentation/routes/admin-users.js';
 import { userStats } from './contexts/user/presentation/routes/user-stats.js';
 
@@ -25,6 +26,7 @@ const app = new Hono()
   .onError(errorHandler)
   .get('/health', (c) => c.json({ status: 'ok' }))
   .route('/api/v1/cron/fermentation', cronFermentation)
+  .route('/api/v1/cron/cost-alert', cronCostAlert)
   .use('/api/v1/auth/*', rateLimitAuth())
   .route('/api/v1/auth', authRoutes)
   .use('/api/v1/admin/*', adminAuthMiddleware)

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
 import { SupabaseQuestionRepository } from '../../../question/infrastructure/repositories/supabase-question.repository.js';
 import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
+import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
 import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
@@ -369,6 +370,27 @@ export const adminFermentations = new Hono<Env>()
     );
 
     const result = await usecase.execute(dateKey);
+
+    // Notify Discord if there were failures
+    if (result.failed > 0) {
+      notifyDiscord({
+        title: 'スケジュール発酵 — 失敗あり',
+        color: COLORS.WARNING,
+        fields: [
+          { name: '対象日', value: dateKey, inline: true },
+          { name: '成功', value: String(result.succeeded), inline: true },
+          { name: '失敗', value: String(result.failed), inline: true },
+          {
+            name: 'エラー詳細',
+            value:
+              result.errors
+                .slice(0, 3)
+                .map((e) => `${e.userId.slice(0, 8)}: ${e.error.slice(0, 80)}`)
+                .join('\n') || '-',
+          },
+        ],
+      });
+    }
 
     return c.json({ dateKey, ...result });
   })

--- a/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
 import { GetFermentationResultUsecase } from '../../application/usecases/get-fermentation-result.usecase.js';
 import { ListFermentationResultsUsecase } from '../../application/usecases/list-fermentation-results.usecase.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
@@ -30,15 +31,32 @@ export const fermentations = new Hono<Env>()
     const llmGateway = new VercelAiAnalysisGateway();
     const usecase = new RunFermentationUsecase(repo, llmGateway, generateId);
 
-    const result = await usecase.execute({
-      userId: c.get('userId'),
-      questionId: body.questionId,
-      questionText: body.questionText,
-      entryId: body.entryId,
-      entryContent: body.entryContent,
-    });
+    try {
+      const result = await usecase.execute({
+        userId: c.get('userId'),
+        questionId: body.questionId,
+        questionText: body.questionText,
+        entryId: body.entryId,
+        entryContent: body.entryContent,
+      });
 
-    return c.json(result, 201);
+      return c.json(result, 201);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // Notify Discord about fermentation failure (fire-and-forget)
+      notifyDiscord({
+        title: '発酵プロセス失敗',
+        color: COLORS.ERROR,
+        fields: [
+          { name: 'User', value: c.get('userId').slice(0, 8), inline: true },
+          { name: 'Question', value: body.questionId.slice(0, 8), inline: true },
+          { name: 'Error', value: errorMessage.slice(0, 200) },
+        ],
+      });
+
+      throw error;
+    }
   })
   .get('/', async (c) => {
     const questionId = c.req.query('questionId');

--- a/apps/server/src/contexts/shared/infrastructure/discord-notify.ts
+++ b/apps/server/src/contexts/shared/infrastructure/discord-notify.ts
@@ -1,0 +1,43 @@
+/**
+ * Discord Webhook notification utility.
+ *
+ * Sends embed messages to Discord via webhook URL.
+ * Silently fails if DISCORD_WEBHOOK_URL is not set (no-op in dev).
+ */
+
+interface DiscordEmbed {
+  title: string;
+  description?: string;
+  color?: number;
+  fields?: { name: string; value: string; inline?: boolean }[];
+  timestamp?: string;
+}
+
+const COLOR_SUCCESS = 0x22c55e; // green
+const COLOR_WARNING = 0xeab308; // yellow
+const COLOR_ERROR = 0xef4444; // red
+const COLOR_INFO = 0x3b82f6; // blue
+
+export const COLORS = {
+  SUCCESS: COLOR_SUCCESS,
+  WARNING: COLOR_WARNING,
+  ERROR: COLOR_ERROR,
+  INFO: COLOR_INFO,
+};
+
+export async function notifyDiscord(embed: DiscordEmbed): Promise<void> {
+  const url = process.env.DISCORD_WEBHOOK_URL;
+  if (!url) return;
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [{ ...embed, timestamp: embed.timestamp ?? new Date().toISOString() }],
+      }),
+    });
+  } catch {
+    // Silently ignore — notification failure should never break the app
+  }
+}

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -8,6 +8,7 @@ import {
 import { createClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { COLORS, notifyDiscord } from '../../infrastructure/discord-notify.js';
 import { getSupabaseClient } from '../../infrastructure/supabase-client.js';
 
 function getSupabaseAuthClient() {
@@ -64,6 +65,16 @@ export const authRoutes = new Hono()
       await serviceSupabase.from('profiles').insert({
         id: data.user.id,
         nickname: body.nickname,
+      });
+
+      // Notify Discord (fire-and-forget)
+      notifyDiscord({
+        title: '新規ユーザー登録',
+        color: COLORS.SUCCESS,
+        fields: [
+          { name: 'ニックネーム', value: body.nickname, inline: true },
+          { name: 'メール', value: body.email, inline: true },
+        ],
       });
     }
 

--- a/apps/server/src/contexts/shared/presentation/routes/cron-cost-alert.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/cron-cost-alert.ts
@@ -1,0 +1,92 @@
+import { gateway } from 'ai';
+import { Hono } from 'hono';
+import { COLORS, notifyDiscord } from '../../infrastructure/discord-notify.js';
+import { getSupabaseClient } from '../../infrastructure/supabase-client.js';
+
+const DAILY_COST_THRESHOLD_USD = 1.0;
+
+export const cronCostAlert = new Hono()
+  .use('*', async (c, next) => {
+    const authHeader = c.req.header('Authorization');
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (!cronSecret) {
+      return c.json({ error: 'CRON_SECRET not configured' }, 500);
+    }
+
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    await next();
+  })
+  .post('/', async (c) => {
+    const supabase = getSupabaseClient();
+
+    // Get yesterday's date range (UTC)
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const dayStart = `${yesterday.toISOString().slice(0, 10)}T00:00:00.000Z`;
+    const dayEnd = `${yesterday.toISOString().slice(0, 10)}T23:59:59.999Z`;
+
+    // Fetch fermentations with cost tracking from yesterday
+    const { data, error } = await supabase
+      .from('fermentation_results')
+      .select('generation_id')
+      .not('generation_id', 'is', null)
+      .gte('created_at', dayStart)
+      .lte('created_at', dayEnd);
+
+    if (error) {
+      return c.json({ error: error.message }, 500);
+    }
+
+    // Sum costs
+    let totalCost = 0;
+    let trackedCount = 0;
+    for (const row of data ?? []) {
+      try {
+        const info = await gateway.getGenerationInfo({ id: row.generation_id });
+        if (typeof info?.totalCost === 'number') {
+          totalCost += info.totalCost;
+          trackedCount++;
+        }
+      } catch {
+        // skip failed lookups
+      }
+    }
+
+    const dateLabel = yesterday.toISOString().slice(0, 10);
+
+    // Always send a daily summary
+    if (totalCost >= DAILY_COST_THRESHOLD_USD) {
+      await notifyDiscord({
+        title: 'AI コスト警告 — 閾値超過',
+        color: COLORS.ERROR,
+        fields: [
+          { name: '日付', value: dateLabel, inline: true },
+          { name: '合計コスト', value: `$${totalCost.toFixed(4)}`, inline: true },
+          { name: '閾値', value: `$${DAILY_COST_THRESHOLD_USD.toFixed(2)}`, inline: true },
+          { name: 'トラッキング数', value: String(trackedCount) },
+        ],
+      });
+    } else {
+      await notifyDiscord({
+        title: 'AI コスト日次レポート',
+        color: COLORS.INFO,
+        fields: [
+          { name: '日付', value: dateLabel, inline: true },
+          { name: '合計コスト', value: `$${totalCost.toFixed(4)}`, inline: true },
+          { name: 'トラッキング数', value: String(trackedCount), inline: true },
+        ],
+      });
+    }
+
+    return c.json({
+      message: 'Cost alert check completed',
+      date: dateLabel,
+      totalCost: Math.round(totalCost * 1000000) / 1000000,
+      trackedCount,
+      thresholdExceeded: totalCost >= DAILY_COST_THRESHOLD_USD,
+    });
+  });


### PR DESCRIPTION
## Summary

### コードで実装（このPR）
| イベント | トリガー | 通知内容 |
|---------|---------|---------|
| 新規ユーザー登録 | signup 成功時 | ニックネーム + メール |
| Fermentation 失敗 | usecase throw 時 | User ID + Question ID + エラー |
| スケジュール発酵失敗 | trigger-scheduled に失敗あり | 対象日 + 成功/失敗数 + エラー詳細 |
| AI コスト日次レポート | Vercel Cron 毎日 01:00 UTC | 前日のコスト合計、閾値超過時は警告 |

### 手動設定が必要（コード不要）
- **Sentry → Discord**: Sentry Dashboard で Discord integration を有効化
- **Vercel デプロイ → Discord**: Vercel Dashboard で Discord integration を有効化

### 新規ファイル
- `apps/server/src/contexts/shared/infrastructure/discord-notify.ts` — Discord Webhook ユーティリティ
- `apps/server/src/contexts/shared/presentation/routes/cron-cost-alert.ts` — コスト監視 cron
- `apps/client/src/app/api/cron/cost-alert/route.ts` — Vercel Cron ルート転送

### 環境変数（Vercel に設定が必要）
- `DISCORD_WEBHOOK_URL` — Discord チャンネルの Webhook URL
- `CRON_SECRET` — Vercel Cron 認証用シークレット（既存の fermentation cron と共有）

## Test plan
- [x] 全ガードレール通過
- [ ] `DISCORD_WEBHOOK_URL` なしでも全機能が正常動作する（no-op）
- [ ] Webhook URL 設定後に signup → Discord に通知が届く

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)