### PR TITLE
feat: Vercel デプロイ通知 → Discord Webhook 受信

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -19,6 +19,7 @@ import { adminDashboard } from './contexts/shared/presentation/routes/admin-dash
 import { adminObservability } from './contexts/shared/presentation/routes/admin-observability.js';
 import { authRoutes } from './contexts/shared/presentation/routes/auth.js';
 import { cronCostAlert } from './contexts/shared/presentation/routes/cron-cost-alert.js';
+import { webhookVercel } from './contexts/shared/presentation/routes/webhook-vercel.js';
 import { adminUsers } from './contexts/user/presentation/routes/admin-users.js';
 import { userStats } from './contexts/user/presentation/routes/user-stats.js';
 
@@ -27,6 +28,7 @@ const app = new Hono()
   .get('/health', (c) => c.json({ status: 'ok' }))
   .route('/api/v1/cron/fermentation', cronFermentation)
   .route('/api/v1/cron/cost-alert', cronCostAlert)
+  .route('/api/v1/webhooks/vercel', webhookVercel)
   .use('/api/v1/auth/*', rateLimitAuth())
   .route('/api/v1/auth', authRoutes)
   .use('/api/v1/admin/*', adminAuthMiddleware)

--- a/apps/server/src/contexts/shared/presentation/routes/webhook-vercel.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/webhook-vercel.ts
@@ -1,0 +1,59 @@
+import { Hono } from 'hono';
+import { COLORS, notifyDiscord } from '../../infrastructure/discord-notify.js';
+
+/**
+ * Vercel Deploy Webhook receiver.
+ *
+ * Vercel sends POST with a JSON body when deployment events occur.
+ * We forward relevant events to Discord.
+ *
+ * Setup: Vercel Dashboard → Project → Settings → Webhooks
+ *   URL: https://oryzae.vercel.app/api/v1/webhooks/vercel
+ *   Events: deployment.created, deployment.succeeded, deployment.error
+ */
+export const webhookVercel = new Hono().post('/', async (c) => {
+  const body = (await c.req.json()) as Record<string, unknown>;
+  const type = typeof body.type === 'string' ? body.type : '';
+  const payload =
+    typeof body.payload === 'object' && body.payload !== null
+      ? (body.payload as Record<string, unknown>)
+      : {};
+
+  const deployment =
+    typeof payload.deployment === 'object' && payload.deployment !== null
+      ? (payload.deployment as Record<string, unknown>)
+      : payload;
+
+  const name = typeof deployment.name === 'string' ? deployment.name : 'unknown';
+  const url = typeof deployment.url === 'string' ? deployment.url : '';
+  const meta =
+    typeof deployment.meta === 'object' && deployment.meta !== null
+      ? (deployment.meta as Record<string, unknown>)
+      : {};
+  const commitMessage =
+    typeof meta.githubCommitMessage === 'string' ? meta.githubCommitMessage.slice(0, 100) : '';
+
+  if (type === 'deployment.error' || type === 'deployment.failed') {
+    await notifyDiscord({
+      title: 'Vercel デプロイ失敗',
+      color: COLORS.ERROR,
+      fields: [
+        { name: 'Project', value: name, inline: true },
+        { name: 'URL', value: url ? `https://${url}` : '-', inline: true },
+        ...(commitMessage ? [{ name: 'Commit', value: commitMessage }] : []),
+      ],
+    });
+  } else if (type === 'deployment.succeeded' || type === 'deployment.ready') {
+    await notifyDiscord({
+      title: 'Vercel デプロイ成功',
+      color: COLORS.SUCCESS,
+      fields: [
+        { name: 'Project', value: name, inline: true },
+        { name: 'URL', value: url ? `https://${url}` : '-', inline: true },
+        ...(commitMessage ? [{ name: 'Commit', value: commitMessage }] : []),
+      ],
+    });
+  }
+
+  return c.json({ ok: true });
+});


### PR DESCRIPTION
## Summary
Vercel の Webhook を受信して Discord に転送する `POST /api/v1/webhooks/vercel` エンドポイントを追加。

デプロイ成功時は緑、失敗時は赤の embed でプロジェクト名・URL・コミットメッセージを通知。

## Setup
Vercel Dashboard → Project → Settings → Webhooks で:
- URL: `https://oryzae.vercel.app/api/v1/webhooks/vercel`
- Events: `deployment.succeeded`, `deployment.error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)