### PR TITLE
fix: signup フロー改善 — 確認メッセージ + メール認証後の自動ログイン

### DIFF
--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -2,12 +2,39 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { getAccessToken } from '@/lib/auth';
+import { getAccessToken, setTokens } from '@/lib/auth';
+
+function parseHashParams(hash: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  const stripped = hash.startsWith('#') ? hash.slice(1) : hash;
+  for (const pair of stripped.split('&')) {
+    const [key, value] = pair.split('=');
+    if (key && value) {
+      params[decodeURIComponent(key)] = decodeURIComponent(value);
+    }
+  }
+  return params;
+}
 
 export default function HomePage() {
   const router = useRouter();
 
   useEffect(() => {
+    const hash = window.location.hash;
+
+    // Handle Supabase email confirmation redirect (tokens in hash fragment)
+    if (hash) {
+      const params = parseHashParams(hash);
+      const accessToken = params.access_token;
+      const refreshToken = params.refresh_token;
+
+      if (accessToken && refreshToken) {
+        setTokens(accessToken, refreshToken);
+        router.replace('/entries');
+        return;
+      }
+    }
+
     if (getAccessToken()) {
       router.replace('/entries');
     } else {

--- a/apps/client/src/features/auth/components/signup-form.tsx
+++ b/apps/client/src/features/auth/components/signup-form.tsx
@@ -14,8 +14,9 @@ export function SignupForm() {
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [emailSent, setEmailSent] = useState(false);
   const router = useRouter();
-  const { signup } = useAuth();
+  const { signup, auth } = useAuth();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -35,7 +36,34 @@ export function SignupForm() {
       return;
     }
 
-    router.push('/entries');
+    // If session was returned (email confirmation disabled), go to entries
+    if (auth) {
+      router.push('/entries');
+      return;
+    }
+
+    // Otherwise show email confirmation message
+    setEmailSent(true);
+    setLoading(false);
+  }
+
+  if (emailSent) {
+    return (
+      <div className="flex flex-col gap-4 text-center">
+        <h1 className="text-2xl font-bold">Oryzae</h1>
+        <p className="text-sm text-zinc-500">確認メールを送信しました</p>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          <span className="font-medium">{email}</span>{' '}
+          に確認メールを送信しました。メール内のリンクをクリックして、アカウントを有効化してください。
+        </p>
+        <Link
+          href="/login"
+          className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          ログインに戻る
+        </Link>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- **signup 後**: 確認メール送信メッセージを表示（/entries へのリダイレクトではなく）
- **メール確認後**: Supabase の確認リンクからリダイレクトされた際、ルートページ（/）でハッシュフラグメントのトークンを検出して自動ログイン → /entries へ直行
- ユーザーは確認リンクをクリックするだけでログイン完了、追加の操作不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)