### PR TITLE
fix: dashboard 重複カード削除 + 日付フィルタ連動

### DIFF
--- a/apps/admin/src/app/(protected)/dashboard/page.tsx
+++ b/apps/admin/src/app/(protected)/dashboard/page.tsx
@@ -22,7 +22,7 @@ export default function DashboardPage() {
     loading: statsLoading,
     error: statsError,
     refresh: refreshStats,
-  } = useDashboardStats();
+  } = useDashboardStats({ dateFrom, dateTo });
   const {
     groups,
     loading: failuresLoading,
@@ -99,17 +99,15 @@ export default function DashboardPage() {
         <HealthSparklines days={days} />
       </div>
 
-      {/* Row 4: Summary cards — cost + activity + stats */}
+      {/* Row 4: Summary cards */}
       <div className="grid gap-4 lg:grid-cols-5">
+        {stats ? (
+          <StatsCards stats={stats} />
+        ) : statsLoading ? (
+          <p className="text-xs text-muted-foreground">Loading...</p>
+        ) : null}
         <CostSummaryCard summary={summary} />
         <UserActivityCard activeWriters={activeWriters} totalUsers={totalUsers} />
-        <div className="lg:col-span-3">
-          {stats ? (
-            <StatsCards stats={stats} />
-          ) : statsLoading ? (
-            <p className="text-xs text-muted-foreground">Loading...</p>
-          ) : null}
-        </div>
       </div>
     </div>
   );

--- a/apps/admin/src/features/dashboard/components/stats-cards.tsx
+++ b/apps/admin/src/features/dashboard/components/stats-cards.tsx
@@ -6,16 +6,12 @@ interface StatCardProps {
   label: string;
   value: string | number;
   subtitle?: string;
-  warning?: boolean;
 }
 
-function StatCard({ label, value, subtitle, warning }: StatCardProps) {
+function StatCard({ label, value, subtitle }: StatCardProps) {
   return (
     <div className="rounded-lg border border-border/50 bg-card p-4">
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs uppercase tracking-wider text-muted-foreground">{label}</span>
-        {warning && <span className="size-1.5 rounded-full bg-red-500" />}
-      </div>
+      <span className="text-xs uppercase tracking-wider text-muted-foreground">{label}</span>
       <div className="text-3xl font-semibold tracking-tight mt-0.5">
         {typeof value === 'number' ? value.toLocaleString() : value}
       </div>
@@ -25,11 +21,6 @@ function StatCard({ label, value, subtitle, warning }: StatCardProps) {
 }
 
 export function StatsCards({ stats }: { stats: DashboardStats }) {
-  const successRate =
-    stats.totalFermentations > 0
-      ? Math.round((stats.completedFermentations / stats.totalFermentations) * 100)
-      : 0;
-
   return (
     <div className="grid gap-4 grid-cols-3">
       <StatCard label="Users" value={stats.totalUsers} />
@@ -38,17 +29,6 @@ export function StatsCards({ stats }: { stats: DashboardStats }) {
         label="Fermentations"
         value={stats.totalFermentations}
         subtitle={`${stats.completedFermentations} done / ${stats.failedFermentations} failed`}
-      />
-      <StatCard
-        label="Success Rate"
-        value={`${successRate}%`}
-        subtitle={successRate < 80 ? 'Below target (80%)' : undefined}
-        warning={successRate < 80}
-      />
-      <StatCard
-        label="Cost Tracked"
-        value={stats.fermentationsWithCostTracking}
-        subtitle="With Gateway data"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- 重複していた「Success Rate」カードを削除（チャートで表示済み）
- 意味不明だった「Cost Tracked」カードを削除
- StatsCards: Users / Entries / Fermentations の3つに整理
- useDashboardStats を日付セレクタに連動（全期間固定→選択期間）

🤖 Generated with [Claude Code](https://claude.com/claude-code)