### PR TITLE
fix(server): 発酵分析で問いと紐づいたエントリーのみを対象に絞り込む

### DIFF
--- a/apps/admin/test/features/dashboard/hooks/use-health-trends.test.ts
+++ b/apps/admin/test/features/dashboard/hooks/use-health-trends.test.ts
@@ -13,9 +13,9 @@ function mockResponse(ok: boolean, body: unknown): Response {
   } as Response; // @type-assertion-allowed: テスト用の最小限 Response スタブ
 }
 
-const sampleDays = [
-  { date: '2026-04-06', successRate: 95, activeWriters: 10 },
-  { date: '2026-04-07', successRate: 80, activeWriters: 8 },
+const sampleResponseDays = [
+  { date: '2026-04-06', totalFermentations: 20, completedFermentations: 19, activeWriters: 10 },
+  { date: '2026-04-07', totalFermentations: 10, completedFermentations: 8, activeWriters: 8 },
 ];
 
 describe('useHealthTrends', () => {
@@ -25,7 +25,7 @@ describe('useHealthTrends', () => {
   });
 
   it('fetches trend data on mount', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse(true, sampleDays));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { days: sampleResponseDays }));
 
     const { result } = renderHook(() => useHealthTrends());
 
@@ -33,12 +33,27 @@ describe('useHealthTrends', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.days).toEqual(sampleDays);
+    expect(result.current.days).toEqual([
+      {
+        date: '2026-04-06',
+        totalFermentations: 20,
+        completedFermentations: 19,
+        activeWriters: 10,
+        successRate: 95,
+      },
+      {
+        date: '2026-04-07',
+        totalFermentations: 10,
+        completedFermentations: 8,
+        activeWriters: 8,
+        successRate: 80,
+      },
+    ]);
     expect(result.current.error).toBeNull();
   });
 
-  it('passes dateFrom and dateTo as query parameters', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse(true, sampleDays));
+  it('passes date_from and date_to as query parameters', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { days: sampleResponseDays }));
 
     renderHook(() => useHealthTrends('2026-04-01', '2026-04-12'));
 
@@ -47,8 +62,8 @@ describe('useHealthTrends', () => {
     });
 
     const calledUrl = mockFetch.mock.calls[0][0];
-    expect(calledUrl).toContain('dateFrom=2026-04-01');
-    expect(calledUrl).toContain('dateTo=2026-04-12');
+    expect(calledUrl).toContain('date_from=2026-04-01');
+    expect(calledUrl).toContain('date_to=2026-04-12');
   });
 
   it('sets error on fetch failure', async () => {

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -1,14 +1,11 @@
 import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway.js';
+import type { Entry } from '../../../entry/domain/models/entry.js';
+import type { EntryQuestionLinkRepositoryGateway } from '../../../question/domain/gateways/entry-question-link-repository.gateway.js';
 import type { QuestionRepositoryGateway } from '../../../question/domain/gateways/question-repository.gateway.js';
 import type { QuestionTransactionRepositoryGateway } from '../../../question/domain/gateways/question-transaction-repository.gateway.js';
 import type { FermentationRepositoryGateway } from '../../domain/gateways/fermentation-repository.gateway.js';
 import type { LlmAnalysisGateway } from '../../domain/gateways/llm-analysis.gateway.js';
 import { RunFermentationUsecase } from './run-fermentation.usecase.js';
-
-interface UserWithEntries {
-  userId: string;
-  entryIds: string[];
-}
 
 interface ScheduledFermentationResult {
   totalUsers: number;
@@ -23,6 +20,7 @@ export class ScheduledFermentationUsecase {
     private entryRepo: EntryRepositoryGateway,
     private questionRepo: QuestionRepositoryGateway,
     private questionTransactionRepo: QuestionTransactionRepositoryGateway,
+    private entryQuestionLinkRepo: EntryQuestionLinkRepositoryGateway,
     private fermentationRepo: FermentationRepositoryGateway,
     private llmGateway: LlmAnalysisGateway,
     private generateId: () => string,
@@ -40,47 +38,44 @@ export class ScheduledFermentationUsecase {
 
     // 1. Find users who wrote entries on the given date
     const userIds = await this.listActiveUserIds();
-    const usersWithEntries: UserWithEntries[] = [];
+    const usersWithEntries: Array<{ userId: string; entries: Entry[] }> = [];
 
     for (const userId of userIds) {
       const entries = await this.entryRepo.listByUserIdAndDate(userId, dateKey);
       if (entries.length > 0) {
-        usersWithEntries.push({
-          userId,
-          entryIds: entries.map((e) => e.toProps().id),
-        });
+        usersWithEntries.push({ userId, entries });
       }
     }
 
     result.totalUsers = usersWithEntries.length;
 
-    // 2. For each user, get active questions and run fermentation
+    // 2. For each user, run fermentation per active question using only entries linked to that question
     const runUsecase = new RunFermentationUsecase(
       this.fermentationRepo,
       this.llmGateway,
       this.generateId,
     );
 
-    for (const { userId, entryIds } of usersWithEntries) {
+    for (const { userId, entries } of usersWithEntries) {
       const activeQuestions = await this.questionRepo.listActiveByUserId(userId);
       if (activeQuestions.length === 0) continue;
 
-      // Get all entries for the day to combine content
-      const entries = await this.entryRepo.listByUserIdAndDate(userId, dateKey);
-      const combinedContent = entries.map((e) => e.toProps().content).join('\n\n---\n\n');
-
-      // Use the first entry as the representative entry ID
-      const entryId = entryIds[0];
-
       for (const question of activeQuestions) {
+        const linkedEntryIds = new Set(
+          await this.entryQuestionLinkRepo.listEntryIdsByQuestionId(question.id),
+        );
+        const questionEntries = entries.filter((e) => linkedEntryIds.has(e.toProps().id));
+        if (questionEntries.length === 0) continue;
+
         result.totalFermentations++;
 
-        // Get latest validated question text
         const latestTransaction =
           await this.questionTransactionRepo.findLatestValidatedByQuestionId(question.id);
         if (!latestTransaction) continue;
 
         const questionText = latestTransaction.toProps().string;
+        const combinedContent = questionEntries.map((e) => e.toProps().content).join('\n\n---\n\n');
+        const entryId = questionEntries[0].toProps().id;
 
         try {
           await runUsecase.execute({

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -3,6 +3,7 @@ import { gateway } from 'ai';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
+import { SupabaseEntryQuestionLinkRepository } from '../../../question/infrastructure/repositories/supabase-entry-question-link.repository.js';
 import { SupabaseQuestionRepository } from '../../../question/infrastructure/repositories/supabase-question.repository.js';
 import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
 import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
@@ -350,6 +351,7 @@ export const adminFermentations = new Hono<Env>()
     const entryRepo = new SupabaseEntryRepository(supabase);
     const questionRepo = new SupabaseQuestionRepository(supabase);
     const questionTransactionRepo = new SupabaseQuestionTransactionRepository(supabase);
+    const entryQuestionLinkRepo = new SupabaseEntryQuestionLinkRepository(supabase);
     const fermentationRepo = new SupabaseFermentationRepository(supabase);
     const llmGateway = new VercelAiAnalysisGateway();
 
@@ -363,6 +365,7 @@ export const adminFermentations = new Hono<Env>()
       entryRepo,
       questionRepo,
       questionTransactionRepo,
+      entryQuestionLinkRepo,
       fermentationRepo,
       llmGateway,
       () => crypto.randomUUID(),

--- a/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { SupabaseEntryRepository } from '../../../entry/infrastructure/repositories/supabase-entry.repository.js';
+import { SupabaseEntryQuestionLinkRepository } from '../../../question/infrastructure/repositories/supabase-entry-question-link.repository.js';
 import { SupabaseQuestionRepository } from '../../../question/infrastructure/repositories/supabase-question.repository.js';
 import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
 import { getSupabaseClient } from '../../../shared/infrastructure/supabase-client.js';
@@ -31,6 +32,7 @@ export const cronFermentation = new Hono()
     const entryRepo = new SupabaseEntryRepository(supabase);
     const questionRepo = new SupabaseQuestionRepository(supabase);
     const questionTransactionRepo = new SupabaseQuestionTransactionRepository(supabase);
+    const entryQuestionLinkRepo = new SupabaseEntryQuestionLinkRepository(supabase);
     const fermentationRepo = new SupabaseFermentationRepository(supabase);
     const llmGateway = new VercelAiAnalysisGateway();
 
@@ -50,6 +52,7 @@ export const cronFermentation = new Hono()
       entryRepo,
       questionRepo,
       questionTransactionRepo,
+      entryQuestionLinkRepo,
       fermentationRepo,
       llmGateway,
       generateId,

--- a/apps/server/src/contexts/question/domain/gateways/entry-question-link-repository.gateway.ts
+++ b/apps/server/src/contexts/question/domain/gateways/entry-question-link-repository.gateway.ts
@@ -2,4 +2,5 @@ export interface EntryQuestionLinkRepositoryGateway {
   link(entryId: string, questionId: string): Promise<void>;
   unlink(entryId: string, questionId: string): Promise<void>;
   listQuestionIdsByEntryId(entryId: string): Promise<string[]>;
+  listEntryIdsByQuestionId(questionId: string): Promise<string[]>;
 }

--- a/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
+++ b/apps/server/src/contexts/question/infrastructure/repositories/supabase-entry-question-link.repository.ts
@@ -34,4 +34,16 @@ export class SupabaseEntryQuestionLinkRepository implements EntryQuestionLinkRep
       (row: Record<string, unknown>) => (row as Record<string, unknown>).question_id as string,
     );
   }
+
+  async listEntryIdsByQuestionId(questionId: string): Promise<string[]> {
+    const { data, error } = await this.supabase
+      .from('entry_question_links')
+      .select('entry_id')
+      .eq('question_id', questionId);
+
+    if (error) throw error;
+    return (data ?? []).map(
+      (row: Record<string, unknown>) => (row as Record<string, unknown>).entry_id as string,
+    );
+  }
 }

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -4,6 +4,7 @@ import { Entry } from '@/contexts/entry/domain/models/entry.js';
 import { ScheduledFermentationUsecase } from '@/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.js';
 import type { FermentationRepositoryGateway } from '@/contexts/fermentation/domain/gateways/fermentation-repository.gateway.js';
 import type { LlmAnalysisGateway } from '@/contexts/fermentation/domain/gateways/llm-analysis.gateway.js';
+import type { EntryQuestionLinkRepositoryGateway } from '@/contexts/question/domain/gateways/entry-question-link-repository.gateway.js';
 import type { QuestionRepositoryGateway } from '@/contexts/question/domain/gateways/question-repository.gateway.js';
 import type { QuestionTransactionRepositoryGateway } from '@/contexts/question/domain/gateways/question-transaction-repository.gateway.js';
 import { Question } from '@/contexts/question/domain/models/question.js';
@@ -83,6 +84,15 @@ function mockQuestionTransactionRepo(): QuestionTransactionRepositoryGateway {
   };
 }
 
+function mockLinkRepo(): EntryQuestionLinkRepositoryGateway {
+  return {
+    link: vi.fn(),
+    unlink: vi.fn(),
+    listQuestionIdsByEntryId: vi.fn(),
+    listEntryIdsByQuestionId: vi.fn().mockResolvedValue([]),
+  };
+}
+
 function mockFermentationRepo(): FermentationRepositoryGateway {
   return {
     save: vi.fn(),
@@ -125,6 +135,7 @@ describe('ScheduledFermentationUsecase', () => {
       entryRepo,
       questionRepo,
       mockQuestionTransactionRepo(),
+      mockLinkRepo(),
       mockFermentationRepo(),
       mockLlm(),
       generateId,
@@ -152,6 +163,9 @@ describe('ScheduledFermentationUsecase', () => {
     const qtRepo = mockQuestionTransactionRepo();
     vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
 
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
     const fermentationRepo = mockFermentationRepo();
     const llm = mockLlm();
 
@@ -159,6 +173,7 @@ describe('ScheduledFermentationUsecase', () => {
       entryRepo,
       questionRepo,
       qtRepo,
+      linkRepo,
       fermentationRepo,
       llm,
       generateId,
@@ -187,12 +202,16 @@ describe('ScheduledFermentationUsecase', () => {
     const qtRepo = mockQuestionTransactionRepo();
     // findLatestValidatedByQuestionId returns null (default mock)
 
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
     const llm = mockLlm();
 
     const usecase = new ScheduledFermentationUsecase(
       entryRepo,
       questionRepo,
       qtRepo,
+      linkRepo,
       mockFermentationRepo(),
       llm,
       generateId,
@@ -226,6 +245,9 @@ describe('ScheduledFermentationUsecase', () => {
       return t2;
     });
 
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
     const fermentationRepo = mockFermentationRepo();
     // Make save fail on first call (simulating RunFermentationUsecase failure)
     let callCount = 0;
@@ -240,6 +262,7 @@ describe('ScheduledFermentationUsecase', () => {
       entryRepo,
       questionRepo,
       qtRepo,
+      linkRepo,
       fermentationRepo,
       llm,
       generateId,
@@ -260,6 +283,7 @@ describe('ScheduledFermentationUsecase', () => {
       mockEntryRepo(),
       mockQuestionRepo(),
       mockQuestionTransactionRepo(),
+      mockLinkRepo(),
       mockFermentationRepo(),
       mockLlm(),
       generateId,
@@ -289,6 +313,9 @@ describe('ScheduledFermentationUsecase', () => {
     const qtRepo = mockQuestionTransactionRepo();
     vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
 
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1', 'e2']);
+
     const llm = mockLlm();
     const fermentationRepo = mockFermentationRepo();
 
@@ -296,6 +323,7 @@ describe('ScheduledFermentationUsecase', () => {
       entryRepo,
       questionRepo,
       qtRepo,
+      linkRepo,
       fermentationRepo,
       llm,
       generateId,
@@ -311,5 +339,95 @@ describe('ScheduledFermentationUsecase', () => {
         entryContent: expect.stringContaining('---'),
       }),
     );
+  });
+
+  it('only includes entries linked to each question (does not leak other-question entries)', async () => {
+    const e1 = makeEntry('user-1', 'e1');
+    const e2 = makeEntry('user-1', 'e2');
+    const q1 = makeQuestion('user-1', 'q1');
+    const q2 = makeQuestion('user-1', 'q2');
+    const t1 = makeQuestionTransaction('q1', 'Q1');
+    const t2 = makeQuestionTransaction('q2', 'Q2');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([e1, e2]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1, q2]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockImplementation(async (id) =>
+      id === 'q1' ? t1 : t2,
+    );
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockImplementation(async (id) =>
+      id === 'q1' ? ['e1'] : ['e2'],
+    );
+
+    const llm = mockLlm();
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      mockFermentationRepo(),
+      llm,
+      generateId,
+      vi.fn().mockResolvedValue(['user-1']),
+    );
+
+    const result = await usecase.execute(dateKey);
+
+    expect(result.totalFermentations).toBe(2);
+    expect(result.succeeded).toBe(2);
+    expect(llm.analyze).toHaveBeenCalledTimes(2);
+    expect(llm.analyze).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ question: 'Q1', entryContent: 'Entry content for e1' }),
+    );
+    expect(llm.analyze).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ question: 'Q2', entryContent: 'Entry content for e2' }),
+    );
+  });
+
+  it('skips a question when no entries of the day are linked to it', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const question = makeQuestion('user-1', 'q1');
+    const transaction = makeQuestionTransaction('q1', 'Q');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.listByUserIdAndDate).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([question]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
+
+    const linkRepo = mockLinkRepo();
+    // Question is linked to a different entry not written today
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['other-entry']);
+
+    const llm = mockLlm();
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      mockFermentationRepo(),
+      llm,
+      generateId,
+      vi.fn().mockResolvedValue(['user-1']),
+    );
+
+    const result = await usecase.execute(dateKey);
+
+    expect(result.totalUsers).toBe(1);
+    expect(result.totalFermentations).toBe(0);
+    expect(llm.analyze).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- 発酵分析の対象エントリー選択のバグを修正：問いに紐づいていないエントリーまで結合されて LLM 分析対象になっていた
- `EntryQuestionLinkRepositoryGateway` に `listEntryIdsByQuestionId` を追加し、`ScheduledFermentationUsecase` で問いごとに `entry_question_links` を参照して当日のエントリーを絞り込む
- 絞り込み結果が空の問いは発酵分析をスキップ

Fixes #200

## Test plan
- [x] `pnpm typecheck` (server / client / admin / shared)
- [x] `pnpm --filter @oryzae/server test` — 179 tests passing（新規2ケース追加：他問いのエントリー混入がないこと、当日紐づきがない問いはスキップ）
- [x] `pnpm dep-cruise`
- [x] ステージングで cron / admin の手動発火を実行し、各問いの発酵結果に他問いのエントリーが混ざらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)