### PR TITLE
fix(client): 縦書きエディタの末尾に半画面分のスクロール余白を追加

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -727,7 +727,7 @@ export function EntryEditor({
               document.execCommand('insertText', false, text);
             }}
             data-placeholder="今日は何を感じましたか？"
-            className={`whitespace-pre-wrap bg-transparent leading-relaxed focus:outline-none empty:before:text-zinc-400 empty:before:content-[attr(data-placeholder)] ${settings.writingMode === 'vertical' ? 'absolute inset-0' : 'min-h-full px-[15%] py-6'}`}
+            className={`whitespace-pre-wrap bg-transparent leading-relaxed focus:outline-none empty:before:text-zinc-400 empty:before:content-[attr(data-placeholder)] ${settings.writingMode === 'vertical' ? `absolute inset-0 after:block after:content-[''] after:w-[50vw]` : 'min-h-full px-[15%] py-6'}`}
             style={{
               ...(settings.writingMode === 'vertical'
                 ? {


### PR DESCRIPTION
## Summary
- Closes #177
- 縦書きモードで長文を左端までスクロールした際、末尾の左側に約半画面分の空白領域が見えるよう、`::after` 疑似要素（`width: 50vw`）を追加
- 冒頭にカーソルがある時はテキストが従来どおりエディタ幅いっぱいに表示される

## Test plan
- [x] 横書きモード: レイアウト変化なし
- [x] 縦書きモード（短文）: スクロール不要、テキスト幅いっぱい
- [x] 縦書きモード（長文）: 冒頭表示時はテキスト幅いっぱい
- [x] 縦書きモード（長文）: 左端までスクロールすると末尾の左側に約半画面分の空白

🤖 Generated with [Claude Code](https://claude.com/claude-code)