### PR TITLE
feat(client): エディタにフォーカスモードを追加 (#184)

### DIFF
--- a/apps/client/src/features/auth/components/sidebar.tsx
+++ b/apps/client/src/features/auth/components/sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/features/auth/hooks/use-auth';
+import { useSidebarVisibility } from '@/lib/sidebar-context';
 import { useTheme } from '@/lib/theme-context';
 import { useUnread } from '@/lib/unread-context';
 
@@ -47,10 +48,13 @@ export function Sidebar() {
   const { auth } = useAuth();
   const { theme } = useTheme();
   const { unreadCount } = useUnread();
+  const { hidden } = useSidebarVisibility();
 
   return (
     <nav
-      className="fixed left-0 top-0 bottom-0 z-30 flex w-20 flex-col items-center py-10 transition-all duration-500"
+      className={`fixed left-0 top-0 bottom-0 z-30 flex w-20 flex-col items-center py-10 transition-all duration-500 ${
+        hidden ? 'pointer-events-none opacity-0' : 'opacity-100'
+      }`}
       style={{
         background: theme === 'dark' ? 'rgba(8, 8, 14, 0.8)' : 'rgba(253, 251, 247, 0.4)',
         backdropFilter: 'blur(12px)',

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -19,12 +19,13 @@ import { useBrowserNavGuard } from '@/features/entries/hooks/use-browser-nav-gua
 import { useEditorSettings } from '@/features/entries/hooks/use-editor-settings';
 import { useSaveEntry } from '@/features/entries/hooks/use-entry';
 import { useEraserTrace } from '@/features/entries/hooks/use-eraser-trace';
+import { useFocusMode } from '@/features/entries/hooks/use-focus-mode';
 import { useGhostEffect } from '@/features/entries/hooks/use-ghost-effect';
 import { usePressureBleed } from '@/features/entries/hooks/use-pressure-bleed';
 import { useTimeInscription } from '@/features/entries/hooks/use-time-inscription';
 import { useVoiceDynamics } from '@/features/entries/hooks/use-voice-dynamics';
 import type { ApiClient } from '@/lib/api';
-import { SIDEBAR_WIDTH } from '@/lib/sidebar-context';
+import { SIDEBAR_WIDTH, useSidebarVisibility } from '@/lib/sidebar-context';
 
 interface AuthState {
   accessToken: string;
@@ -128,6 +129,28 @@ export function EntryEditor({
     cancel: cancelLeaveConfirm,
     confirm: confirmLeaveConfirm,
   } = useBrowserNavGuard(hasUnsavedChanges);
+
+  const anyOverlayOpen =
+    settingsOpen ||
+    saveModalOpen ||
+    isEditingTitle ||
+    statsOpen ||
+    pendingNavPath !== null ||
+    leaveConfirmOpen;
+  const uiVisible = useFocusMode({
+    enabled: settings.focusModeEnabled,
+    forceVisible: anyOverlayOpen,
+    editorRef,
+  });
+  const fadeClass = `transition-opacity duration-300 ${
+    uiVisible ? 'opacity-100' : 'pointer-events-none opacity-0'
+  }`;
+
+  const { setHidden: setSidebarHidden } = useSidebarVisibility();
+  useEffect(() => {
+    setSidebarHidden(!uiVisible);
+    return () => setSidebarHidden(false);
+  }, [uiVisible, setSidebarHidden]);
 
   useGhostEffect(editorRef, ghostLayerRef, settings);
   useAmpEffect(settings.ampEnabled);
@@ -432,7 +455,9 @@ export function EntryEditor({
       style={{ left: sidebarWidth }}
     >
       {/* Top toolbar */}
-      <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-2">
+      <div
+        className={`flex items-center justify-between border-b border-[var(--border-subtle)] px-4 py-2 ${fadeClass}`}
+      >
         <div className="flex items-center gap-2">
           {/* New entry */}
           <button
@@ -711,7 +736,7 @@ export function EntryEditor({
       </div>
 
       {/* Question linker */}
-      <div className="border-b border-[var(--border-subtle)] px-4 py-2">
+      <div className={`border-b border-[var(--border-subtle)] px-4 py-2 ${fadeClass}`}>
         <QuestionLinker
           activeQuestions={activeQuestions}
           linkedQuestionIds={linkedIds}
@@ -803,7 +828,7 @@ export function EntryEditor({
                     left: '6%',
                     top: '4%',
                     width: '79%',
-                    height: '92%',
+                    height: '86%',
                     position: 'absolute',
                     overflowX: 'auto',
                   }
@@ -830,7 +855,9 @@ export function EntryEditor({
       />
 
       {/* Status bar */}
-      <EditorStatusBar status={status} charCount={charCount} />
+      <div className={fadeClass}>
+        <EditorStatusBar status={status} charCount={charCount} />
+      </div>
 
       {/* Save title modal — shared between 保存する and 漬け込む */}
       <SaveTitleModal

--- a/apps/client/src/features/entries/components/settings-drawer.tsx
+++ b/apps/client/src/features/entries/components/settings-drawer.tsx
@@ -10,6 +10,7 @@ export interface EditorSettings {
   fontFamily: FontFamily;
   fontSize: number;
   lineHeight: number;
+  focusModeEnabled: boolean;
   timeInscriptionEnabled: boolean;
   timeInscriptionMode: TimeInscriptionMode;
   eraserTraceEnabled: boolean;
@@ -29,6 +30,7 @@ export const DEFAULT_SETTINGS: EditorSettings = {
   fontFamily: 'serif',
   fontSize: 32,
   lineHeight: 1.625,
+  focusModeEnabled: true,
   timeInscriptionEnabled: false,
   timeInscriptionMode: 'fontSize',
   eraserTraceEnabled: false,
@@ -185,6 +187,12 @@ export function SettingsDrawer({ open, settings, onChange, onClose }: SettingsDr
               step={0.05}
               display={settings.lineHeight.toFixed(2)}
               onChange={(v) => onChange({ lineHeight: v })}
+            />
+            <Toggle
+              id="focus-mode"
+              label="フォーカスモード"
+              checked={settings.focusModeEnabled}
+              onChange={(v) => onChange({ focusModeEnabled: v })}
             />
           </div>
 

--- a/apps/client/src/features/entries/hooks/use-editor-settings.ts
+++ b/apps/client/src/features/entries/hooks/use-editor-settings.ts
@@ -14,6 +14,8 @@ const LINE_HEIGHT_STORAGE_KEY = 'oryzae-editor-line-height';
 const LINE_HEIGHT_MIN = 1.0;
 const LINE_HEIGHT_MAX = 2.5;
 
+const FOCUS_MODE_STORAGE_KEY = 'oryzae-editor-focus-mode';
+
 function readStoredFontSize(): number | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -60,12 +62,35 @@ function writeStoredLineHeight(value: number): void {
   }
 }
 
+function readStoredFocusMode(): boolean | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(FOCUS_MODE_STORAGE_KEY);
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredFocusMode(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(FOCUS_MODE_STORAGE_KEY, String(value));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
 function getInitialSettings(): EditorSettings {
   const next: EditorSettings = { ...DEFAULT_SETTINGS };
   const fontSize = readStoredFontSize();
   if (fontSize !== null) next.fontSize = fontSize;
   const lineHeight = readStoredLineHeight();
   if (lineHeight !== null) next.lineHeight = lineHeight;
+  const focusMode = readStoredFocusMode();
+  if (focusMode !== null) next.focusModeEnabled = focusMode;
   return next;
 }
 
@@ -78,6 +103,9 @@ export function useEditorSettings(): [EditorSettings, (patch: Partial<EditorSett
     }
     if (typeof patch.lineHeight === 'number') {
       writeStoredLineHeight(patch.lineHeight);
+    }
+    if (typeof patch.focusModeEnabled === 'boolean') {
+      writeStoredFocusMode(patch.focusModeEnabled);
     }
     setSettings((prev) => ({ ...prev, ...patch }));
   }, []);

--- a/apps/client/src/features/entries/hooks/use-focus-mode.ts
+++ b/apps/client/src/features/entries/hooks/use-focus-mode.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { type RefObject, useEffect, useState } from 'react';
+
+const FADE_DELAY_MS = 2000;
+
+interface FocusModeOptions {
+  enabled: boolean;
+  forceVisible: boolean;
+  editorRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Hide non-editor UI while the user types, reveal it when the mouse moves.
+ * After the mouse stops, remaining input starts a 2s grace period before hiding.
+ */
+export function useFocusMode({ enabled, forceVisible, editorRef }: FocusModeOptions): boolean {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (!enabled || forceVisible) {
+      setVisible(true);
+      return;
+    }
+
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    let lastMouseMove = 0;
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function clearHideTimer() {
+      if (hideTimer !== null) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    }
+
+    function onMouseMove() {
+      lastMouseMove = Date.now();
+      clearHideTimer();
+      setVisible(true);
+    }
+
+    function onInput() {
+      const elapsed = Date.now() - lastMouseMove;
+      if (elapsed >= FADE_DELAY_MS) {
+        setVisible(false);
+        return;
+      }
+      clearHideTimer();
+      hideTimer = setTimeout(() => {
+        setVisible(false);
+        hideTimer = null;
+      }, FADE_DELAY_MS - elapsed);
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    editor.addEventListener('input', onInput);
+
+    return () => {
+      clearHideTimer();
+      document.removeEventListener('mousemove', onMouseMove);
+      editor.removeEventListener('input', onInput);
+    };
+  }, [enabled, forceVisible, editorRef]);
+
+  return visible;
+}

--- a/apps/client/src/lib/sidebar-context.tsx
+++ b/apps/client/src/lib/sidebar-context.tsx
@@ -1,8 +1,29 @@
 'use client';
 
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
 /** Fixed glass-morphism sidebar width (px) */
 export const SIDEBAR_WIDTH = 80;
 
+interface SidebarVisibilityContextValue {
+  hidden: boolean;
+  setHidden: (hidden: boolean) => void;
+}
+
+const SidebarVisibilityContext = createContext<SidebarVisibilityContextValue>({
+  hidden: false,
+  setHidden: () => {},
+});
+
 export function SidebarProvider({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  const [hidden, setHiddenState] = useState(false);
+  const setHidden = useCallback((next: boolean) => setHiddenState(next), []);
+  const value = useMemo(() => ({ hidden, setHidden }), [hidden, setHidden]);
+  return (
+    <SidebarVisibilityContext.Provider value={value}>{children}</SidebarVisibilityContext.Provider>
+  );
+}
+
+export function useSidebarVisibility(): SidebarVisibilityContextValue {
+  return useContext(SidebarVisibilityContext);
 }

--- a/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
+++ b/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
@@ -5,6 +5,7 @@ import { useEditorSettings } from '@/features/entries/hooks/use-editor-settings'
 
 const FONT_SIZE_KEY = 'oryzae-editor-font-size';
 const LINE_HEIGHT_KEY = 'oryzae-editor-line-height';
+const FOCUS_MODE_KEY = 'oryzae-editor-focus-mode';
 
 describe('useEditorSettings', () => {
   beforeEach(() => {
@@ -95,6 +96,34 @@ describe('useEditorSettings', () => {
     expect(result.current[0].writingMode).toBe('horizontal');
     expect(window.localStorage.getItem(FONT_SIZE_KEY)).toBeNull();
     expect(window.localStorage.getItem(LINE_HEIGHT_KEY)).toBeNull();
+    expect(window.localStorage.getItem(FOCUS_MODE_KEY)).toBeNull();
+  });
+
+  it('initializes focusModeEnabled from localStorage when stored (false)', () => {
+    window.localStorage.setItem(FOCUS_MODE_KEY, 'false');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].focusModeEnabled).toBe(false);
+  });
+
+  it('initializes focusModeEnabled from localStorage when stored (true)', () => {
+    window.localStorage.setItem(FOCUS_MODE_KEY, 'true');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].focusModeEnabled).toBe(true);
+  });
+
+  it('defaults focusModeEnabled to true when storage value is invalid', () => {
+    window.localStorage.setItem(FOCUS_MODE_KEY, 'maybe');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].focusModeEnabled).toBe(DEFAULT_SETTINGS.focusModeEnabled);
+  });
+
+  it('persists focusModeEnabled to localStorage when updated', () => {
+    const { result } = renderHook(() => useEditorSettings());
+    act(() => {
+      result.current[1]({ focusModeEnabled: false });
+    });
+    expect(result.current[0].focusModeEnabled).toBe(false);
+    expect(window.localStorage.getItem(FOCUS_MODE_KEY)).toBe('false');
   });
 
   it('applies multi-field patches and persists fontSize + lineHeight', () => {

--- a/apps/client/test/features/entries/hooks/use-focus-mode.test.ts
+++ b/apps/client/test/features/entries/hooks/use-focus-mode.test.ts
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFocusMode } from '@/features/entries/hooks/use-focus-mode';
+
+function dispatchMouseMove() {
+  document.dispatchEvent(new MouseEvent('mousemove'));
+}
+
+function dispatchInput(target: HTMLElement) {
+  target.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('useFocusMode', () => {
+  let editorEl: HTMLDivElement;
+  let editorRef: { current: HTMLDivElement | null };
+
+  beforeEach(() => {
+    editorEl = document.createElement('div');
+    document.body.appendChild(editorEl);
+    editorRef = { current: editorEl };
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    editorEl.remove();
+  });
+
+  it('starts visible', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    expect(result.current).toBe(true);
+  });
+
+  it('stays visible when disabled even on input', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: false, forceVisible: false, editorRef }),
+    );
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('stays visible when forceVisible is true', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: true, editorRef }),
+    );
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('hides immediately on input when no recent mouse movement', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('shows on mousemove', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(false);
+    act(() => {
+      dispatchMouseMove();
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('delays hide by 2s after recent mouse movement', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    act(() => {
+      dispatchMouseMove();
+    });
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('mousemove during grace period resets visibility and cancels hide', () => {
+    const { result } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    act(() => {
+      dispatchMouseMove();
+    });
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    act(() => {
+      dispatchMouseMove();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('removes listeners on cleanup', () => {
+    const removeDocSpy = vi.spyOn(document, 'removeEventListener');
+    const removeEditorSpy = vi.spyOn(editorEl, 'removeEventListener');
+    const { unmount } = renderHook(() =>
+      useFocusMode({ enabled: true, forceVisible: false, editorRef }),
+    );
+    unmount();
+    expect(removeDocSpy.mock.calls.map((c) => c[0])).toContain('mousemove');
+    expect(removeEditorSpy.mock.calls.map((c) => c[0])).toContain('input');
+  });
+
+  it('forces visible again when forceVisible toggles on', () => {
+    const { result, rerender } = renderHook(
+      ({ forceVisible }: { forceVisible: boolean }) =>
+        useFocusMode({ enabled: true, forceVisible, editorRef }),
+      { initialProps: { forceVisible: false } },
+    );
+    act(() => {
+      dispatchInput(editorEl);
+    });
+    expect(result.current).toBe(false);
+    rerender({ forceVisible: true });
+    expect(result.current).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Notion 風フォーカスモード: テキスト入力で上部ツールバー・質問リンカー・ステータスバー・サイドバーがフェードアウト、マウス移動で復帰
- 設定ドロワーからトグル可能（デフォルト ON、`oryzae-editor-focus-mode` キーで永続化）
- 縦書き時の本文エリア下側マージンを広げて上下バランスを改善（height 92% → 86%）

Closes #184

## 実装詳細
- `useFocusMode` フック: `input` / `mousemove` を監視、直近マウス移動から 2 秒の猶予後に fade-out
- `SidebarVisibilityContext`: サイドバー（`features/auth`）とエディタ（`features/entries`）間の feature 依存を避けつつ可視性を共有
- フェード除外条件: 設定ドロワー / 保存モーダル / インラインタイトル編集 / 統計ポップアップ / 離脱確認モーダルのいずれかが開いている間は常時表示

## Test plan
- [x] `pnpm typecheck` ✅
- [x] `pnpm test` ✅ (89 tests, 13 追加)
- [x] `pnpm dep-cruise` ✅
- [ ] ブラウザ動作確認
  - [ ] 入力開始で全 UI がフェードアウト
  - [ ] マウス移動でフェードイン
  - [ ] 設定ドロワーで「フォーカスモード」トグル→ OFF でフェードしなくなる
  - [ ] リロードしても設定が維持される
  - [ ] 各モーダル／ドロワー／タイトル編集中はフェードしない
  - [ ] 縦書き時に本文の上下バランスが整っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)