### PR TITLE
feat(client): エントリ一覧から削除できる kebab メニュー (#208)

### DIFF
--- a/apps/client/src/features/entries/components/delete-confirm-modal.tsx
+++ b/apps/client/src/features/entries/components/delete-confirm-modal.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface DeleteConfirmModalProps {
+  open: boolean;
+  deleting?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteConfirmModal({
+  open,
+  deleting = false,
+  onCancel,
+  onConfirm,
+}: DeleteConfirmModalProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="削除確認ダイアログ"
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onCancel}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onCancel();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="w-[90%] max-w-[400px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '28px 32px' }}
+      >
+        <h3 className="mb-2 text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          本当に削除しますか？
+        </h3>
+        <p className="mb-6 text-xs" style={{ color: 'var(--date-color)' }}>
+          このエントリーは完全に削除され、元に戻すことはできません。
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            disabled={deleting}
+            className="rounded-md border px-4 py-2 text-xs disabled:opacity-50"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--fg)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={deleting}
+            className="rounded-md border px-4 py-2 text-xs text-white disabled:opacity-50"
+            style={{ backgroundColor: '#c0392b', borderColor: '#c0392b' }}
+          >
+            {deleting ? '削除中...' : '削除する'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/entry-card.tsx
+++ b/apps/client/src/features/entries/components/entry-card.tsx
@@ -2,12 +2,14 @@
 
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { EntryKebabMenu } from './entry-kebab-menu';
 
 interface EntryCardProps {
   id: string;
   content: string;
   createdAt: string;
   searchQuery?: string;
+  onDeleteClick?: (id: string) => void;
 }
 
 function highlightText(text: string, query: string): ReactNode {
@@ -31,7 +33,7 @@ function highlightText(text: string, query: string): ReactNode {
   });
 }
 
-export function EntryCard({ id, content, createdAt, searchQuery }: EntryCardProps) {
+export function EntryCard({ id, content, createdAt, searchQuery, onDeleteClick }: EntryCardProps) {
   const lines = content.split('\n').filter((l) => l.trim().length > 0);
   const title = lines[0]?.substring(0, 100) ?? '';
   const preview =
@@ -42,49 +44,55 @@ export function EntryCard({ id, content, createdAt, searchQuery }: EntryCardProp
   const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
   return (
-    <Link
-      href={`/entries/${id}`}
-      className="group block border-b border-[var(--border-subtle)] py-4 transition-colors hover:rounded hover:bg-[rgba(200,180,140,0.04)]"
-      style={{ margin: '0 -12px', padding: '16px 12px' }}
+    <div
+      className="group relative border-b border-[var(--border-subtle)] transition-colors hover:rounded hover:bg-[rgba(200,180,140,0.04)]"
+      style={{ margin: '0 -12px' }}
     >
-      {/* Date */}
-      <div
-        className="mb-1 text-[10px] tracking-[0.1em] text-[var(--date-color)]"
-        style={{ fontFamily: 'Inter, sans-serif' }}
-      >
-        {dateStr}
-      </div>
-
-      {/* Title */}
-      <h3
-        className="mb-1.5 text-[15px] font-medium text-[var(--fg)]"
-        style={{ fontFamily: "'Noto Serif JP', serif" }}
-      >
-        {searchQuery ? highlightText(title, searchQuery) : title}
-      </h3>
-
-      {/* Preview */}
-      {preview && title !== preview && (
-        <p
-          className="mb-2 text-[13px] leading-relaxed text-[var(--fg)] opacity-70"
-          style={{
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
+      <Link href={`/entries/${id}`} className="block" style={{ padding: '16px 44px 16px 12px' }}>
+        {/* Date */}
+        <div
+          className="mb-1 text-[10px] tracking-[0.1em] text-[var(--date-color)]"
+          style={{ fontFamily: 'Inter, sans-serif' }}
         >
-          {searchQuery ? highlightText(preview, searchQuery) : preview}
-        </p>
-      )}
+          {dateStr}
+        </div>
 
-      {/* Meta */}
-      <div
-        className="text-[10px] tracking-[0.05em] text-[var(--date-color)]"
-        style={{ fontFamily: 'Inter, sans-serif' }}
-      >
-        文字数: {charCount}
-      </div>
-    </Link>
+        {/* Title */}
+        <h3
+          className="mb-1.5 text-[15px] font-medium text-[var(--fg)]"
+          style={{ fontFamily: "'Noto Serif JP', serif" }}
+        >
+          {searchQuery ? highlightText(title, searchQuery) : title}
+        </h3>
+
+        {/* Preview */}
+        {preview && title !== preview && (
+          <p
+            className="mb-2 text-[13px] leading-relaxed text-[var(--fg)] opacity-70"
+            style={{
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {searchQuery ? highlightText(preview, searchQuery) : preview}
+          </p>
+        )}
+
+        {/* Meta */}
+        <div
+          className="text-[10px] tracking-[0.05em] text-[var(--date-color)]"
+          style={{ fontFamily: 'Inter, sans-serif' }}
+        >
+          文字数: {charCount}
+        </div>
+      </Link>
+      {onDeleteClick && (
+        <div className="absolute right-2 top-3">
+          <EntryKebabMenu onDeleteClick={() => onDeleteClick(id)} />
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/client/src/features/entries/components/entry-kebab-menu.tsx
+++ b/apps/client/src/features/entries/components/entry-kebab-menu.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface EntryKebabMenuProps {
+  onDeleteClick: () => void;
+}
+
+export function EntryKebabMenu({ onDeleteClick }: EntryKebabMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-label="メニューを開く"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        className="flex h-8 w-8 items-center justify-center rounded-md text-[var(--date-color)] transition-colors hover:bg-[rgba(200,180,140,0.08)] hover:text-[var(--fg)]"
+      >
+        <svg
+          className="h-4 w-4"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          role="img"
+        >
+          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="12" cy="19" r="1.5" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-50 mt-1 min-w-[120px] overflow-hidden rounded-md border shadow-lg"
+          style={{
+            backgroundColor: 'var(--bg)',
+            borderColor: 'var(--border-subtle)',
+          }}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(false);
+              onDeleteClick();
+            }}
+            className="block w-full px-4 py-2 text-left text-xs transition-colors hover:bg-[rgba(200,180,140,0.08)]"
+            style={{ color: 'var(--fg)' }}
+          >
+            削除
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/entry-list.tsx
+++ b/apps/client/src/features/entries/components/entry-list.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useDebounce } from '@/features/entries/hooks/use-debounce';
+import { useDeleteEntry } from '@/features/entries/hooks/use-delete-entry';
 import { useEntries } from '@/features/entries/hooks/use-entries';
 import type { ApiClient } from '@/lib/api';
+import { DeleteConfirmModal } from './delete-confirm-modal';
 import { EntryCard } from './entry-card';
 
 interface EntryListProps {
@@ -70,9 +72,29 @@ export function EntryList({ api, authLoading }: EntryListProps) {
   const [searchInput, setSearchInput] = useState('');
   const debouncedSearch = useDebounce(searchInput, 300);
   const search = debouncedSearch.trim() || undefined;
-  const { entries, loading, hasMore, loadMore } = useEntries(api, authLoading, search);
+  const { entries, loading, hasMore, loadMore, removeEntry } = useEntries(api, authLoading, search);
+  const { deleteEntry, deleting } = useDeleteEntry(api);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const isSearching = !!search;
+
+  const handleDeleteClick = useCallback((id: string) => {
+    setPendingDeleteId(id);
+  }, []);
+
+  const handleDeleteCancel = useCallback(() => {
+    if (deleting) return;
+    setPendingDeleteId(null);
+  }, [deleting]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!pendingDeleteId) return;
+    const ok = await deleteEntry(pendingDeleteId);
+    if (ok) {
+      removeEntry(pendingDeleteId);
+      setPendingDeleteId(null);
+    }
+  }, [deleteEntry, pendingDeleteId, removeEntry]);
 
   return (
     <div className="flex flex-col">
@@ -140,6 +162,7 @@ export function EntryList({ api, authLoading }: EntryListProps) {
               content={entry.content}
               createdAt={entry.createdAt}
               searchQuery={search}
+              onDeleteClick={handleDeleteClick}
             />
           ))}
         </div>
@@ -161,6 +184,7 @@ export function EntryList({ api, authLoading }: EntryListProps) {
                     id={entry.id}
                     content={entry.content}
                     createdAt={entry.createdAt}
+                    onDeleteClick={handleDeleteClick}
                   />
                 ))}
               </div>
@@ -179,6 +203,13 @@ export function EntryList({ api, authLoading }: EntryListProps) {
           {loading ? '読み込み中...' : 'もっと見る'}
         </button>
       )}
+
+      <DeleteConfirmModal
+        open={pendingDeleteId !== null}
+        deleting={deleting}
+        onCancel={handleDeleteCancel}
+        onConfirm={handleDeleteConfirm}
+      />
     </div>
   );
 }

--- a/apps/client/src/features/entries/hooks/use-delete-entry.ts
+++ b/apps/client/src/features/entries/hooks/use-delete-entry.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { ApiClient } from '@/lib/api';
+
+export function useDeleteEntry(api: ApiClient | null) {
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState('');
+
+  const deleteEntry = useCallback(
+    async (entryId: string): Promise<boolean> => {
+      if (!api) return false;
+      setDeleting(true);
+      setError('');
+
+      const res = await api.fetch(`/api/v1/entries/${entryId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setError('削除に失敗しました');
+        setDeleting(false);
+        return false;
+      }
+
+      setDeleting(false);
+      return true;
+    },
+    [api],
+  );
+
+  return { deleteEntry, deleting, error };
+}

--- a/apps/client/src/features/entries/hooks/use-entries.ts
+++ b/apps/client/src/features/entries/hooks/use-entries.ts
@@ -66,5 +66,9 @@ export function useEntries(api: ApiClient | null, authLoading: boolean, search?:
     fetchEntries(cursor);
   }, [fetchEntries, cursor]);
 
-  return { entries, loading, hasMore, loadMore };
+  const removeEntry = useCallback((id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  return { entries, loading, hasMore, loadMore, removeEntry };
 }

--- a/apps/client/test/features/entries/hooks/use-delete-entry.test.ts
+++ b/apps/client/test/features/entries/hooks/use-delete-entry.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeleteEntry } from '@/features/entries/hooks/use-delete-entry';
+import type { ApiClient } from '@/lib/api';
+
+function createMockApi(fetchImpl: ReturnType<typeof vi.fn>): ApiClient {
+  return {
+    baseUrl: '',
+    headers: {},
+    fetch: fetchImpl,
+  };
+}
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 400,
+  } as Response;
+}
+
+describe('useDeleteEntry', () => {
+  let apiFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiFetch = vi.fn();
+  });
+
+  it('sends DELETE request and returns true on success', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(true, { ok: true }));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useDeleteEntry(api));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteEntry('e1');
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.error).toBe('');
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/v1/entries/e1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('returns false and sets error on failure', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(false, {}));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useDeleteEntry(api));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteEntry('e1');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toBe('削除に失敗しました');
+  });
+
+  it('returns false when api is null', async () => {
+    const { result } = renderHook(() => useDeleteEntry(null));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteEntry('e1');
+    });
+
+    expect(ok).toBe(false);
+  });
+});

--- a/apps/client/test/features/entries/hooks/use-entries.test.ts
+++ b/apps/client/test/features/entries/hooks/use-entries.test.ts
@@ -166,6 +166,30 @@ describe('useEntries', () => {
     expect(result.current.entries[0].id).toBe('2');
   });
 
+  it('removeEntry drops the matching entry from state', async () => {
+    const entries = [
+      { id: '1', userId: 'u1', content: 'a', mediaUrls: [], createdAt: '', updatedAt: '' },
+      { id: '2', userId: 'u1', content: 'b', mediaUrls: [], createdAt: '', updatedAt: '' },
+    ];
+    apiFetch.mockResolvedValueOnce(mockResponse(true, entries));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useEntries(api, false));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.entries).toHaveLength(2);
+
+    act(() => {
+      result.current.removeEntry('1');
+    });
+
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].id).toBe('2');
+  });
+
   it('does not send q param when search is empty', async () => {
     apiFetch.mockResolvedValueOnce(mockResponse(true, []));
     const api = createMockApi(apiFetch);


### PR DESCRIPTION
## Summary
- エントリ一覧の各カード右側に「︙」ボタンを設置し、メニュー内に「削除」を表示
- 削除選択時に確認モーダル（「本当に削除しますか？」→ 削除する / キャンセル）を表示
- 確認後に `DELETE /api/v1/entries/:id` を呼び、楽観的に一覧から除去

## Implementation
- `useDeleteEntry` フックを追加（`apps/client/src/features/entries/hooks/use-delete-entry.ts`）
- `useEntries` に `removeEntry(id)` を追加し、楽観的削除を可能に
- `DeleteConfirmModal` / `EntryKebabMenu` コンポーネントを新設
- `EntryCard` を再構成し、`<Link>` とメニュー用ボタンを兄弟要素化（`<a>` 内 `<button>` ネストを回避）

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (client 80件 / server 55件 すべて pass)
- [x] `pnpm dep-cruise`
- [x] `pnpm knip`
- [ ] localhost:3000 でログイン → `/entries` → 「︙」→「削除」→ 確認モーダル → 削除 / キャンセルの挙動確認

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)