### PR TITLE
feat(admin): 発酵プロセスが走査したエントリを詳細画面に表示 (#152)

### DIFF
--- a/apps/admin/src/app/(protected)/fermentations/[id]/page.tsx
+++ b/apps/admin/src/app/(protected)/fermentations/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { FermentationDetailHeader } from '@/features/fermentations/components/fermentation-detail-header';
 import { FermentationKeywords } from '@/features/fermentations/components/fermentation-keywords';
 import { FermentationLetter } from '@/features/fermentations/components/fermentation-letter';
+import { FermentationScannedEntries } from '@/features/fermentations/components/fermentation-scanned-entries';
 import { FermentationSnippets } from '@/features/fermentations/components/fermentation-snippets';
 import { FermentationWorksheet } from '@/features/fermentations/components/fermentation-worksheet';
 import { useFermentationDetail } from '@/features/fermentations/hooks/use-fermentation-detail';
@@ -52,6 +53,8 @@ export default function FermentationDetailPage() {
           他のユーザーのジャーナリング内容はプライバシー保護のためマスクされています
         </div>
       )}
+
+      <FermentationScannedEntries entries={data.scannedEntries} />
 
       {data.worksheet && <FermentationWorksheet worksheet={data.worksheet} />}
 

--- a/apps/admin/src/features/fermentations/components/fermentation-scanned-entries.tsx
+++ b/apps/admin/src/features/fermentations/components/fermentation-scanned-entries.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { ScannedEntryData } from '../hooks/use-fermentation-detail';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+interface FermentationScannedEntriesProps {
+  entries: ScannedEntryData[];
+}
+
+export function FermentationScannedEntries({ entries }: FermentationScannedEntriesProps) {
+  if (entries.length === 0) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Scanned Entries
+        </h3>
+        <p className="text-sm text-muted-foreground">走査されたエントリーはありません</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Scanned Entries ({entries.length})
+      </h3>
+      <ul className="space-y-2">
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            className="rounded-md border border-border bg-muted/30 p-3 space-y-1.5"
+          >
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+              <span>
+                ID <span className="font-mono text-foreground">{entry.id.slice(0, 8)}</span>
+              </span>
+              <span>
+                Created{' '}
+                <span className="font-mono text-foreground">{formatDate(entry.createdAt)}</span>
+              </span>
+              {entry.updatedAt !== entry.createdAt && (
+                <span>
+                  Updated{' '}
+                  <span className="font-mono text-foreground">{formatDate(entry.updatedAt)}</span>
+                </span>
+              )}
+            </div>
+            <p className="text-sm leading-relaxed text-foreground/90 whitespace-pre-wrap">
+              {entry.content}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/admin/src/features/fermentations/hooks/use-fermentation-detail.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-fermentation-detail.ts
@@ -41,11 +41,17 @@ export interface KeywordData {
   updatedAt: string;
 }
 
+export interface ScannedEntryData {
+  id: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface FermentationDetailResponse {
   id: string;
   userId: string;
   questionId: string;
-  entryId: string;
   targetPeriod: string;
   status: string;
   generationId: string | null;
@@ -60,6 +66,7 @@ export interface FermentationDetailResponse {
   snippets: SnippetData[];
   letter: LetterData | null;
   keywords: KeywordData[];
+  scannedEntries: ScannedEntryData[];
 }
 
 export function useFermentationDetail(id: string) {

--- a/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
+++ b/apps/admin/src/features/fermentations/hooks/use-fermentations.ts
@@ -9,7 +9,6 @@ export interface FermentationItem {
   user_id: string;
   user_email: string;
   question_id: string;
-  entry_id: string;
   target_period: string;
   status: string;
   generation_id: string | null;

--- a/apps/admin/test/features/fermentations/hooks/use-fermentation-detail.test.ts
+++ b/apps/admin/test/features/fermentations/hooks/use-fermentation-detail.test.ts
@@ -18,7 +18,6 @@ const mockData: FermentationDetailResponse = {
   id: 'f1',
   userId: 'u1',
   questionId: 'q1',
-  entryId: 'e1',
   targetPeriod: '2026-04-11',
   status: 'completed',
   generationId: 'gen-1',
@@ -64,6 +63,14 @@ const mockData: FermentationDetailResponse = {
       description: 'What drives you',
       createdAt: '2026-04-11T10:00:00Z',
       updatedAt: '2026-04-11T10:00:00Z',
+    },
+  ],
+  scannedEntries: [
+    {
+      id: 'e1',
+      content: 'Today I thought about motivation.',
+      createdAt: '2026-04-11T09:00:00Z',
+      updatedAt: '2026-04-11T09:00:00Z',
     },
   ],
 };

--- a/apps/admin/test/features/fermentations/hooks/use-fermentations.test.ts
+++ b/apps/admin/test/features/fermentations/hooks/use-fermentations.test.ts
@@ -26,7 +26,6 @@ describe('useFermentations', () => {
           id: 'f1',
           user_id: 'u1',
           question_id: 'q1',
-          entry_id: 'e1',
           target_period: '2026-04-11',
           status: 'completed',
           generation_id: null,

--- a/apps/client/src/features/fermentation/hooks/use-fermentation-results.ts
+++ b/apps/client/src/features/fermentation/hooks/use-fermentation-results.ts
@@ -31,7 +31,6 @@ interface Worksheet {
 export interface FermentationDetail {
   id: string;
   questionId: string;
-  entryId: string;
   targetPeriod: string;
   status: string;
   worksheet: Worksheet | null;
@@ -43,7 +42,6 @@ export interface FermentationDetail {
 interface FermentationSummary {
   id: string;
   questionId: string;
-  entryId: string;
   status: string;
   createdAt: string;
 }

--- a/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
@@ -7,6 +7,11 @@ import { Keyword } from '../../domain/models/keyword.js';
 import { Letter } from '../../domain/models/letter.js';
 import { LlmAnalysisError } from '../errors/fermentation.errors.js';
 
+interface RunFermentationEntry {
+  id: string;
+  content: string;
+}
+
 export class RunFermentationUsecase {
   constructor(
     private fermentationRepo: FermentationRepositoryGateway,
@@ -18,9 +23,12 @@ export class RunFermentationUsecase {
     userId: string;
     questionId: string;
     questionText: string;
-    entryId: string;
-    entryContent: string;
+    entries: RunFermentationEntry[];
   }): Promise<{ id: string }> {
+    if (params.entries.length === 0) {
+      throw new LlmAnalysisError('At least one entry is required');
+    }
+
     const today = new Date().toISOString().slice(0, 10);
     const targetPeriod = today;
 
@@ -29,7 +37,6 @@ export class RunFermentationUsecase {
       {
         userId: params.userId,
         questionId: params.questionId,
-        entryId: params.entryId,
         targetPeriod,
       },
       this.generateId,
@@ -40,17 +47,25 @@ export class RunFermentationUsecase {
     const fermentationResult = createResult.value;
     await this.fermentationRepo.save(fermentationResult);
 
+    // 1.5. Record which entries were scanned (before LLM so it's preserved even on failure)
+    await this.fermentationRepo.saveScannedEntries(
+      fermentationResult.id,
+      params.entries.map((e) => e.id),
+    );
+
     // 2. Update to processing
     const processingResult = fermentationResult.withStatus('processing');
     if (processingResult.success) {
       await this.fermentationRepo.update(processingResult.value);
     }
 
+    const combinedContent = params.entries.map((e) => e.content).join('\n\n---\n\n');
+
     try {
       // 3. Run LLM analysis
       const { output, generationId } = await this.llmGateway.analyze({
         question: params.questionText,
-        entryContent: params.entryContent,
+        entryContent: combinedContent,
         targetPeriod,
         userId: params.userId,
       });

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -74,16 +74,17 @@ export class ScheduledFermentationUsecase {
         if (!latestTransaction) continue;
 
         const questionText = latestTransaction.toProps().string;
-        const combinedContent = questionEntries.map((e) => e.toProps().content).join('\n\n---\n\n');
-        const entryId = questionEntries[0].toProps().id;
+        const runEntries = questionEntries.map((e) => {
+          const props = e.toProps();
+          return { id: props.id, content: props.content };
+        });
 
         try {
           await runUsecase.execute({
             userId,
             questionId: question.id,
             questionText,
-            entryId,
-            entryContent: combinedContent,
+            entries: runEntries,
           });
           result.succeeded++;
         } catch (error) {

--- a/apps/server/src/contexts/fermentation/domain/gateways/fermentation-repository.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/fermentation-repository.gateway.ts
@@ -10,6 +10,7 @@ export interface FermentationResultWithDetails {
   snippets: ExtractedSnippet[];
   letter: Letter | null;
   keywords: Keyword[];
+  scannedEntryIds: string[];
 }
 
 export interface FermentationRepositoryGateway {
@@ -19,6 +20,8 @@ export interface FermentationRepositoryGateway {
   findByIdWithDetails(id: string): Promise<FermentationResultWithDetails | null>;
   listByQuestionId(questionId: string): Promise<FermentationResult[]>;
 
+  saveScannedEntries(fermentationResultId: string, entryIds: string[]): Promise<void>;
+  listScannedEntryIds(fermentationResultId: string): Promise<string[]>;
   saveWorksheet(worksheet: AnalysisWorksheet): Promise<void>;
   saveSnippets(snippets: ExtractedSnippet[]): Promise<void>;
   saveLetter(letter: Letter): Promise<void>;

--- a/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
@@ -8,7 +8,6 @@ export interface FermentationResultProps {
   id: string;
   userId: string;
   questionId: string;
-  entryId: string;
   targetPeriod: string;
   status: FermentationStatus;
   generationId: string | null;
@@ -20,7 +19,6 @@ export interface FermentationResultProps {
 interface CreateParams {
   userId: string;
   questionId: string;
-  entryId: string;
   targetPeriod: string;
 }
 
@@ -30,7 +28,6 @@ export class FermentationResult {
   readonly id: string;
   readonly userId: string;
   readonly questionId: string;
-  readonly entryId: string;
   readonly targetPeriod: string;
   readonly status: FermentationStatus;
   readonly generationId: string | null;
@@ -42,7 +39,6 @@ export class FermentationResult {
     this.id = props.id;
     this.userId = props.userId;
     this.questionId = props.questionId;
-    this.entryId = props.entryId;
     this.targetPeriod = props.targetPeriod;
     this.status = props.status;
     this.generationId = props.generationId;
@@ -63,7 +59,6 @@ export class FermentationResult {
         id: generateId(),
         userId: params.userId,
         questionId: params.questionId,
-        entryId: params.entryId,
         targetPeriod: params.targetPeriod,
         status: 'pending',
         generationId: null,
@@ -98,7 +93,6 @@ export class FermentationResult {
       id: this.id,
       userId: this.userId,
       questionId: this.questionId,
-      entryId: this.entryId,
       targetPeriod: this.targetPeriod,
       status: this.status,
       generationId: this.generationId,

--- a/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/repositories/supabase-fermentation.repository.ts
@@ -18,7 +18,6 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       id: props.id,
       user_id: props.userId,
       question_id: props.questionId,
-      entry_id: props.entryId,
       target_period: props.targetPeriod,
       status: props.status,
       error_message: props.errorMessage,
@@ -53,7 +52,6 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       id: data.id,
       userId: data.user_id,
       questionId: data.question_id,
-      entryId: data.entry_id,
       targetPeriod: data.target_period,
       status: data.status,
       generationId: data.generation_id ?? null,
@@ -67,7 +65,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
     const result = await this.findById(id);
     if (!result) return null;
 
-    const [worksheetRes, snippetsRes, letterRes, keywordsRes] = await Promise.all([
+    const [worksheetRes, snippetsRes, letterRes, keywordsRes, scannedEntryIds] = await Promise.all([
       this.supabase
         .from('analysis_worksheets')
         .select('*')
@@ -76,6 +74,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       this.supabase.from('extracted_snippets').select('*').eq('fermentation_result_id', id),
       this.supabase.from('letters').select('*').eq('fermentation_result_id', id).single(),
       this.supabase.from('keywords').select('*').eq('fermentation_result_id', id),
+      this.listScannedEntryIds(id),
     ]);
 
     const worksheet = worksheetRes.data
@@ -123,7 +122,7 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
       }),
     );
 
-    return { result, worksheet, snippets, letter, keywords };
+    return { result, worksheet, snippets, letter, keywords, scannedEntryIds };
   }
 
   async listByQuestionId(questionId: string): Promise<FermentationResult[]> {
@@ -138,7 +137,6 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         id: row.id,
         userId: row.user_id,
         questionId: row.question_id,
-        entryId: row.entry_id,
         targetPeriod: row.target_period,
         status: row.status as 'pending' | 'processing' | 'completed' | 'failed',
         generationId: row.generation_id ?? null,
@@ -147,6 +145,28 @@ export class SupabaseFermentationRepository implements FermentationRepositoryGat
         updatedAt: row.updated_at,
       }),
     );
+  }
+
+  async saveScannedEntries(fermentationResultId: string, entryIds: string[]): Promise<void> {
+    if (entryIds.length === 0) return;
+    const rows = entryIds.map((entryId) => ({
+      fermentation_result_id: fermentationResultId,
+      entry_id: entryId,
+    }));
+    const { error } = await this.supabase
+      .from('fermentation_scanned_entries')
+      .upsert(rows, { onConflict: 'fermentation_result_id,entry_id' });
+    if (error) throw new Error(`Failed to save scanned entries: ${error.message}`);
+  }
+
+  async listScannedEntryIds(fermentationResultId: string): Promise<string[]> {
+    const { data, error } = await this.supabase
+      .from('fermentation_scanned_entries')
+      .select('entry_id, created_at')
+      .eq('fermentation_result_id', fermentationResultId)
+      .order('created_at', { ascending: true });
+    if (error) throw new Error(`Failed to list scanned entries: ${error.message}`);
+    return (data ?? []).map((row: { entry_id: string }) => row.entry_id);
   }
 
   async saveWorksheet(worksheet: AnalysisWorksheet): Promise<void> {

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -101,7 +101,7 @@ export const adminFermentations = new Hono<Env>()
     let listQuery = supabase
       .from('fermentation_results')
       .select(
-        'id, user_id, question_id, entry_id, target_period, status, generation_id, error_message, created_at, updated_at',
+        'id, user_id, question_id, target_period, status, generation_id, error_message, created_at, updated_at',
         { count: 'exact' },
       );
     if (resolvedUserId) listQuery = listQuery.eq('user_id', resolvedUserId);
@@ -228,12 +228,54 @@ export const adminFermentations = new Hono<Env>()
     }
 
     // 2. Fetch related data in parallel
-    const [worksheetRes, snippetsRes, letterRes, keywordsRes] = await Promise.all([
+    const [worksheetRes, snippetsRes, letterRes, keywordsRes, scannedRes] = await Promise.all([
       supabase.from('analysis_worksheets').select('*').eq('fermentation_result_id', id).single(),
       supabase.from('extracted_snippets').select('*').eq('fermentation_result_id', id),
       supabase.from('letters').select('*').eq('fermentation_result_id', id).single(),
       supabase.from('keywords').select('*').eq('fermentation_result_id', id),
+      supabase
+        .from('fermentation_scanned_entries')
+        .select('entry_id, created_at')
+        .eq('fermentation_result_id', id)
+        .order('created_at', { ascending: true }),
     ]);
+
+    // 2.5. Fetch entry details for scanned entries
+    const scannedEntryIds = (scannedRes.data ?? []).map(
+      (row: { entry_id: string }) => row.entry_id,
+    );
+    let scannedEntries: Array<{
+      id: string;
+      content: string;
+      createdAt: string;
+      updatedAt: string;
+    }> = [];
+    if (scannedEntryIds.length > 0) {
+      const { data: entryRows } = await supabase
+        .from('entries')
+        .select('id, content, created_at, updated_at')
+        .in('id', scannedEntryIds);
+      const entryMap = new Map(
+        (entryRows ?? []).map(
+          (row: { id: string; content: string; created_at: string; updated_at: string }) => [
+            row.id,
+            row,
+          ],
+        ),
+      );
+      scannedEntries = scannedEntryIds.flatMap((entryId) => {
+        const row = entryMap.get(entryId);
+        if (!row) return [];
+        return [
+          {
+            id: row.id,
+            content: row.content,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+          },
+        ];
+      });
+    }
 
     // 3. Fetch cost info if generation_id exists
     let cost: unknown = null;
@@ -310,7 +352,6 @@ export const adminFermentations = new Hono<Env>()
       id: fermentation.id,
       userId: fermentation.user_id,
       questionId: fermentation.question_id,
-      entryId: fermentation.entry_id,
       targetPeriod: fermentation.target_period,
       status: fermentation.status,
       generationId: fermentation.generation_id ?? null,
@@ -339,6 +380,9 @@ export const adminFermentations = new Hono<Env>()
           })),
       letter: isOwner ? letter : letter ? { ...letter, bodyText: MASKED } : null,
       keywords: isOwner ? keywords : keywords.map((k) => ({ ...k, description: MASKED })),
+      scannedEntries: isOwner
+        ? scannedEntries
+        : scannedEntries.map((e) => ({ ...e, content: MASKED })),
     });
   })
   .post('/trigger-scheduled', async (c) => {
@@ -404,7 +448,7 @@ export const adminFermentations = new Hono<Env>()
     // 1. Look up the failed fermentation
     const { data: fermentation, error: fetchError } = await supabase
       .from('fermentation_results')
-      .select('id, user_id, question_id, entry_id, status')
+      .select('id, user_id, question_id, status')
       .eq('id', id)
       .single();
 
@@ -429,14 +473,28 @@ export const adminFermentations = new Hono<Env>()
       return c.json({ error: 'Question text not found' }, 404);
     }
 
-    // 3. Fetch entry content
-    const { data: entry } = await supabase
-      .from('entries')
-      .select('content')
-      .eq('id', fermentation.entry_id)
-      .single();
+    // 3. Fetch scanned entries (preserves what the original run saw)
+    const { data: scannedRows } = await supabase
+      .from('fermentation_scanned_entries')
+      .select('entry_id, created_at')
+      .eq('fermentation_result_id', id)
+      .order('created_at', { ascending: true });
+    const scannedEntryIds = (scannedRows ?? []).map((row: { entry_id: string }) => row.entry_id);
+    if (scannedEntryIds.length === 0) {
+      return c.json({ error: 'No scanned entries found for this fermentation' }, 404);
+    }
 
-    if (!entry?.content) {
+    const { data: entryRows } = await supabase
+      .from('entries')
+      .select('id, content')
+      .in('id', scannedEntryIds);
+    const entryMap = new Map(
+      (entryRows ?? []).map((row: { id: string; content: string }) => [row.id, row.content]),
+    );
+    const entries = scannedEntryIds
+      .map((entryId) => ({ id: entryId, content: entryMap.get(entryId) ?? '' }))
+      .filter((e) => e.content);
+    if (entries.length === 0) {
       return c.json({ error: 'Entry content not found' }, 404);
     }
 
@@ -449,8 +507,7 @@ export const adminFermentations = new Hono<Env>()
       userId: fermentation.user_id,
       questionId: fermentation.question_id,
       questionText,
-      entryId: fermentation.entry_id,
-      entryContent: entry.content,
+      entries,
     });
 
     return c.json({ id: result.id }, 201);

--- a/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
@@ -36,8 +36,7 @@ export const fermentations = new Hono<Env>()
         userId: c.get('userId'),
         questionId: body.questionId,
         questionText: body.questionText,
-        entryId: body.entryId,
-        entryContent: body.entryContent,
+        entries: [{ id: body.entryId, content: body.entryContent }],
       });
 
       return c.json(result, 201);

--- a/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
@@ -12,6 +12,8 @@ function mockRepo(): FermentationRepositoryGateway {
     findById: vi.fn(),
     findByIdWithDetails: vi.fn(),
     listByQuestionId: vi.fn(),
+    saveScannedEntries: vi.fn(),
+    listScannedEntryIds: vi.fn().mockResolvedValue([]),
     saveWorksheet: vi.fn(),
     saveSnippets: vi.fn(),
     saveLetter: vi.fn(),
@@ -45,18 +47,51 @@ describe('RunFermentationUsecase', () => {
       userId: 'u1',
       questionId: 'q1',
       questionText: 'What is love?',
-      entryId: 'e1',
-      entryContent: 'Today I thought about love.',
+      entries: [{ id: 'e1', content: 'Today I thought about love.' }],
     });
 
     expect(result.id).toBe('test-id');
     expect(repo.save).toHaveBeenCalledOnce();
+    expect(repo.saveScannedEntries).toHaveBeenCalledWith('test-id', ['e1']);
     expect(repo.update).toHaveBeenCalledTimes(3); // processing + generationId + completed
     expect(llm.analyze).toHaveBeenCalledOnce();
     expect(repo.saveWorksheet).toHaveBeenCalledOnce();
     expect(repo.saveSnippets).toHaveBeenCalledOnce();
     expect(repo.saveLetter).toHaveBeenCalledOnce();
     expect(repo.saveKeywords).toHaveBeenCalledOnce();
+  });
+
+  it('saves all scanned entry ids when multiple entries are provided', async () => {
+    const repo = mockRepo();
+    const llm = mockLlm();
+    const usecase = new RunFermentationUsecase(repo, llm, generateId);
+
+    await usecase.execute({
+      userId: 'u1',
+      questionId: 'q1',
+      questionText: 'Q',
+      entries: [
+        { id: 'e1', content: 'content 1' },
+        { id: 'e2', content: 'content 2' },
+      ],
+    });
+
+    expect(repo.saveScannedEntries).toHaveBeenCalledWith('test-id', ['e1', 'e2']);
+    expect(llm.analyze).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entryContent: 'content 1\n\n---\n\ncontent 2',
+      }),
+    );
+  });
+
+  it('rejects execution when no entries are provided', async () => {
+    const repo = mockRepo();
+    const usecase = new RunFermentationUsecase(repo, mockLlm(), generateId);
+
+    await expect(
+      usecase.execute({ userId: 'u1', questionId: 'q1', questionText: 'Q', entries: [] }),
+    ).rejects.toThrow('LLM analysis failed');
+    expect(repo.save).not.toHaveBeenCalled();
   });
 
   it('marks result as failed when LLM throws', async () => {
@@ -71,12 +106,13 @@ describe('RunFermentationUsecase', () => {
         userId: 'u1',
         questionId: 'q1',
         questionText: 'test',
-        entryId: 'e1',
-        entryContent: 'test',
+        entries: [{ id: 'e1', content: 'test' }],
       }),
     ).rejects.toThrow('LLM analysis failed');
 
     // save (pending) + update (processing) + update (failed)
     expect(repo.update).toHaveBeenCalledTimes(2);
+    // scanned entries are recorded before LLM runs, so they persist on failure
+    expect(repo.saveScannedEntries).toHaveBeenCalledWith('test-id', ['e1']);
   });
 });

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -102,6 +102,8 @@ function mockFermentationRepo(): FermentationRepositoryGateway {
     findById: vi.fn(),
     findByIdWithDetails: vi.fn(),
     listByQuestionId: vi.fn(),
+    saveScannedEntries: vi.fn(),
+    listScannedEntryIds: vi.fn().mockResolvedValue([]),
     saveWorksheet: vi.fn(),
     saveSnippets: vi.fn(),
     saveLetter: vi.fn(),
@@ -325,7 +327,7 @@ describe('ScheduledFermentationUsecase', () => {
     expect(result.failed).toBe(0);
   });
 
-  it('combines multiple entries content with separator', async () => {
+  it('combines multiple entries content with separator and records all scanned entry ids', async () => {
     const e1 = makeEntry('user-1', 'e1');
     const e2 = makeEntry('user-1', 'e2');
     const question = makeQuestion('user-1', 'q1');
@@ -366,6 +368,8 @@ describe('ScheduledFermentationUsecase', () => {
         entryContent: expect.stringContaining('---'),
       }),
     );
+    // All scanned entry ids should be recorded (not just the first)
+    expect(fermentationRepo.saveScannedEntries).toHaveBeenCalledWith('test-id', ['e1', 'e2']);
   });
 
   it('only includes entries linked to each question (does not leak other-question entries)', async () => {

--- a/apps/server/test/contexts/fermentation/domain/models/fermentation-result.test.ts
+++ b/apps/server/test/contexts/fermentation/domain/models/fermentation-result.test.ts
@@ -9,7 +9,6 @@ describe('FermentationResult', () => {
       {
         userId: 'u1',
         questionId: 'q1',
-        entryId: 'e1',
         targetPeriod: '2025-12-01',
       },
       generateId,
@@ -29,7 +28,6 @@ describe('FermentationResult', () => {
       {
         userId: 'u1',
         questionId: 'q1',
-        entryId: 'e1',
         targetPeriod: '  ',
       },
       generateId,
@@ -40,7 +38,7 @@ describe('FermentationResult', () => {
 
   it('transitions status with withStatus', () => {
     const result = FermentationResult.create(
-      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      { userId: 'u1', questionId: 'q1', targetPeriod: '2025-12-01' },
       generateId,
     );
     expect(result.success).toBe(true);
@@ -56,7 +54,7 @@ describe('FermentationResult', () => {
 
   it('roundtrips through toProps/fromProps', () => {
     const result = FermentationResult.create(
-      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      { userId: 'u1', questionId: 'q1', targetPeriod: '2025-12-01' },
       generateId,
     );
     expect(result.success).toBe(true);
@@ -69,7 +67,7 @@ describe('FermentationResult', () => {
 
   it('sets generationId with withGenerationId', () => {
     const result = FermentationResult.create(
-      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      { userId: 'u1', questionId: 'q1', targetPeriod: '2025-12-01' },
       generateId,
     );
     expect(result.success).toBe(true);
@@ -83,7 +81,7 @@ describe('FermentationResult', () => {
 
   it('preserves generationId through toProps/fromProps roundtrip', () => {
     const result = FermentationResult.create(
-      { userId: 'u1', questionId: 'q1', entryId: 'e1', targetPeriod: '2025-12-01' },
+      { userId: 'u1', questionId: 'q1', targetPeriod: '2025-12-01' },
       generateId,
     );
     if (!result.success) return;

--- a/supabase/migrations/00012_create_fermentation_scanned_entries.sql
+++ b/supabase/migrations/00012_create_fermentation_scanned_entries.sql
@@ -1,0 +1,31 @@
+-- 発酵プロセスが走査したエントリ一覧を保持する join テーブル
+-- これまでは fermentation_results.entry_id に先頭エントリだけ記録していたが、
+-- ScheduledFermentationUsecase は複数エントリを結合して LLM に渡しており、
+-- 走査対象の完全な一覧が失われていた。本マイグレーションで解消する。
+
+create table fermentation_scanned_entries (
+  id uuid primary key default gen_random_uuid(),
+  fermentation_result_id uuid not null references fermentation_results(id) on delete cascade,
+  entry_id uuid not null references entries(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (fermentation_result_id, entry_id)
+);
+
+create index fermentation_scanned_entries_fermentation_idx
+  on fermentation_scanned_entries (fermentation_result_id);
+
+alter table fermentation_scanned_entries enable row level security;
+create policy "Users can read own scanned entries" on fermentation_scanned_entries
+  for all using (
+    fermentation_result_id in (
+      select id from fermentation_results where user_id = auth.uid()
+    )
+  );
+
+-- 既存レコードをバックフィル（entry_id は NOT NULL だったので必ず存在する）
+insert into fermentation_scanned_entries (fermentation_result_id, entry_id)
+select id, entry_id from fermentation_results
+on conflict (fermentation_result_id, entry_id) do nothing;
+
+-- 冗長になった entry_id カラムを削除
+alter table fermentation_results drop column entry_id;


### PR DESCRIPTION
Closes #152

## Summary
- ある問いに紐づく最新エントリが発酵分析シートに反映されたかを確認できなかったため、走査対象エントリを永続化して admin の発酵詳細画面で一覧表示する
- `fermentation_scanned_entries` join テーブルを新設し、既存の `fermentation_results.entry_id` カラムをバックフィル後に DROP（意味論的に「先頭エントリ」でしかなく冗長だったため）
- `RunFermentationUsecase` を単一 entry から `entries[]` ベースに変更し、LLM 実行前に scanned entries を保存（失敗時にも走査履歴が残る）
- admin 詳細画面の `Q` と `ANALYSIS WORKSHEET` の間に `FermentationScannedEntries` コンポーネントを挿入。他ユーザー分は content をマスク

## 変更ファイル
- `supabase/migrations/00012_create_fermentation_scanned_entries.sql` — join テーブル + バックフィル + entry_id DROP（**リモート DB への適用が別途必要**）
- server domain/application/infrastructure/presentation 各レイヤーと対応テスト
- admin hooks / 新規コンポーネント / 既存詳細ページ
- client: 未使用の entryId 型フィールドを撤去

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes（197 + 76 + 55 = 328 tests）
- [x] `pnpm lint` clean（warnings は既存のみ）
- [x] `pnpm dep-cruise` clean
- [x] `pnpm knip` clean
- [x] Supabase MCP または CLI でリモート DB に migration 00012 を適用
- [x] admin を立ち上げて `/fermentations/[id]` で走査エントリが表示されることを目視確認
- [ ] 複数エントリが同じ問いに紐づく日次の発酵を手動トリガーして、全エントリが scanned entries に記録されることを確認
- [ ] 失敗した発酵の retry で scanned_entries 経由でエントリが取得され動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)