### PR TITLE
feat(server): 発酵完了時にメール通知を送信 (#213)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@ VERCEL_TOKEN=
 # Webhook URL — https://discord.com/api/webhooks/xxx/yyy
 DISCORD_WEBHOOK_URL=
 
+# ── Resend (transactional email) ──
+# API key — https://resend.com/api-keys
+RESEND_API_KEY=
+# Sender identity. Requires verified domain in Resend dashboard.
+EMAIL_FROM=Oryzae <noreply@oryzae.ephemere.io>
+# Set to "false" to disable email sending (e.g. in dev). Default: enabled when RESEND_API_KEY is set.
+EMAIL_ENABLED=true
+
 # ── Cron ──
 # Secret for Vercel Cron job authentication
 CRON_SECRET=

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -25,6 +25,7 @@ export class ScheduledFermentationUsecase {
     private llmGateway: LlmAnalysisGateway,
     private generateId: () => string,
     private listActiveUserIds: () => Promise<string[]>,
+    private sendDigest: (userId: string, questionTitles: string[]) => Promise<void>,
   ) {}
 
   async execute(dateKey: string): Promise<ScheduledFermentationResult> {
@@ -56,6 +57,8 @@ export class ScheduledFermentationUsecase {
       this.generateId,
     );
 
+    const successfulTitlesByUser = new Map<string, string[]>();
+
     for (const { userId, entries } of usersWithEntries) {
       const activeQuestions = await this.questionRepo.listActiveByUserId(userId);
       if (activeQuestions.length === 0) continue;
@@ -86,6 +89,9 @@ export class ScheduledFermentationUsecase {
             entryContent: combinedContent,
           });
           result.succeeded++;
+          const titles = successfulTitlesByUser.get(userId) ?? [];
+          titles.push(questionText);
+          successfulTitlesByUser.set(userId, titles);
         } catch (error) {
           result.failed++;
           result.errors.push({
@@ -94,6 +100,15 @@ export class ScheduledFermentationUsecase {
             error: error instanceof Error ? error.message : 'Unknown error',
           });
         }
+      }
+    }
+
+    // 3. Send one digest email per user for their successful fermentations.
+    for (const [userId, titles] of successfulTitlesByUser) {
+      try {
+        await this.sendDigest(userId, titles);
+      } catch {
+        // Notification failure must not break the scheduled job.
       }
     }
 

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -1,0 +1,32 @@
+import type { EmailNotifier } from '../../domain/gateways/email-notifier.gateway.js';
+
+const SUBJECT = 'あなたの瓶の発酵が進みました';
+const JAR_URL = 'https://oryzae.vercel.app/jar';
+
+export class SendFermentationDigestUsecase {
+  constructor(
+    private emailNotifier: EmailNotifier,
+    private resolveVerifiedEmail: (userId: string) => Promise<string | null>,
+  ) {}
+
+  async execute(params: { userId: string; questionTitles: string[] }): Promise<void> {
+    const uniqueTitles = Array.from(
+      new Set(params.questionTitles.map((t) => t.trim()).filter((t) => t.length > 0)),
+    );
+    if (uniqueTitles.length === 0) return;
+
+    const email = await this.resolveVerifiedEmail(params.userId);
+    if (!email) return;
+
+    const bodyText = composeBody(uniqueTitles);
+    await this.emailNotifier.send({ to: email, subject: SUBJECT, bodyText });
+  }
+}
+
+function composeBody(titles: string[]): string {
+  if (titles.length === 1) {
+    return `${titles[0]}についてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n${JAR_URL}`;
+  }
+  const list = titles.map((t) => `・${t}`).join('\n');
+  return `以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n${list}\n\n${JAR_URL}`;
+}

--- a/apps/server/src/contexts/fermentation/domain/gateways/email-notifier.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/email-notifier.gateway.ts
@@ -1,0 +1,9 @@
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  bodyText: string;
+}
+
+export interface EmailNotifier {
+  send(params: SendEmailParams): Promise<void>;
+}

--- a/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
@@ -1,0 +1,32 @@
+import type {
+  EmailNotifier,
+  SendEmailParams,
+} from '../../domain/gateways/email-notifier.gateway.js';
+
+export class ResendEmailNotifier implements EmailNotifier {
+  async send(params: SendEmailParams): Promise<void> {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from = process.env.EMAIL_FROM ?? 'Oryzae <noreply@oryzae.ephemere.io>';
+    const enabled = process.env.EMAIL_ENABLED !== 'false';
+
+    if (!enabled || !apiKey) return;
+
+    try {
+      await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from,
+          to: [params.to],
+          subject: params.subject,
+          text: params.bodyText,
+        }),
+      });
+    } catch {
+      // Silently ignore — notification failure must not break the app.
+    }
+  }
+}

--- a/apps/server/src/contexts/fermentation/infrastructure/email/supabase-verified-email-resolver.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/supabase-verified-email-resolver.ts
@@ -1,0 +1,13 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export function createSupabaseVerifiedEmailResolver(
+  supabase: SupabaseClient,
+): (userId: string) => Promise<string | null> {
+  return async (userId: string): Promise<string | null> => {
+    const { data } = await supabase.auth.admin.getUserById(userId);
+    const user = data?.user;
+    if (!user?.email) return null;
+    if (!user.email_confirmed_at) return null;
+    return user.email;
+  };
+}

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -9,6 +9,9 @@ import { SupabaseQuestionTransactionRepository } from '../../../question/infrast
 import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
 import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
+import { SendFermentationDigestUsecase } from '../../application/usecases/send-fermentation-digest.usecase.js';
+import { ResendEmailNotifier } from '../../infrastructure/email/resend-email-notifier.js';
+import { createSupabaseVerifiedEmailResolver } from '../../infrastructure/email/supabase-verified-email-resolver.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
 import { getFermentationTargetDateKey } from './cron-target-date.js';
@@ -361,6 +364,11 @@ export const adminFermentations = new Hono<Env>()
       return [...new Set((data ?? []).map((row: { user_id: string }) => row.user_id))];
     };
 
+    const digestUsecase = new SendFermentationDigestUsecase(
+      new ResendEmailNotifier(),
+      createSupabaseVerifiedEmailResolver(supabase),
+    );
+
     const usecase = new ScheduledFermentationUsecase(
       entryRepo,
       questionRepo,
@@ -370,6 +378,7 @@ export const adminFermentations = new Hono<Env>()
       llmGateway,
       () => crypto.randomUUID(),
       listActiveUserIds,
+      (userId, titles) => digestUsecase.execute({ userId, questionTitles: titles }),
     );
 
     const result = await usecase.execute(dateKey);
@@ -452,6 +461,17 @@ export const adminFermentations = new Hono<Env>()
       entryId: fermentation.entry_id,
       entryContent: entry.content,
     });
+
+    // 5. Send digest email (fire-and-forget)
+    const digestUsecase = new SendFermentationDigestUsecase(
+      new ResendEmailNotifier(),
+      createSupabaseVerifiedEmailResolver(supabase),
+    );
+    digestUsecase
+      .execute({ userId: fermentation.user_id, questionTitles: [questionText] })
+      .catch(() => {
+        // Notification failure must not break retry response.
+      });
 
     return c.json({ id: result.id }, 201);
   });

--- a/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
@@ -5,6 +5,9 @@ import { SupabaseQuestionRepository } from '../../../question/infrastructure/rep
 import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
 import { getSupabaseClient } from '../../../shared/infrastructure/supabase-client.js';
 import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
+import { SendFermentationDigestUsecase } from '../../application/usecases/send-fermentation-digest.usecase.js';
+import { ResendEmailNotifier } from '../../infrastructure/email/resend-email-notifier.js';
+import { createSupabaseVerifiedEmailResolver } from '../../infrastructure/email/supabase-verified-email-resolver.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
 import { getFermentationTargetDateKey } from './cron-target-date.js';
@@ -48,6 +51,11 @@ export const cronFermentation = new Hono()
       return uniqueUserIds;
     };
 
+    const digestUsecase = new SendFermentationDigestUsecase(
+      new ResendEmailNotifier(),
+      createSupabaseVerifiedEmailResolver(supabase),
+    );
+
     const usecase = new ScheduledFermentationUsecase(
       entryRepo,
       questionRepo,
@@ -57,6 +65,7 @@ export const cronFermentation = new Hono()
       llmGateway,
       generateId,
       listActiveUserIds,
+      (userId, titles) => digestUsecase.execute({ userId, questionTitles: titles }),
     );
 
     // Cron は JST 03:00 に発火するため、対象は「直前に閉じた一日」= JST での前日

--- a/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
@@ -1,9 +1,13 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
+import { getSupabaseClient } from '../../../shared/infrastructure/supabase-client.js';
 import { GetFermentationResultUsecase } from '../../application/usecases/get-fermentation-result.usecase.js';
 import { ListFermentationResultsUsecase } from '../../application/usecases/list-fermentation-results.usecase.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
+import { SendFermentationDigestUsecase } from '../../application/usecases/send-fermentation-digest.usecase.js';
+import { ResendEmailNotifier } from '../../infrastructure/email/resend-email-notifier.js';
+import { createSupabaseVerifiedEmailResolver } from '../../infrastructure/email/supabase-verified-email-resolver.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
 
@@ -39,6 +43,17 @@ export const fermentations = new Hono<Env>()
         entryId: body.entryId,
         entryContent: body.entryContent,
       });
+
+      // Send digest email (fire-and-forget). Uses service-role client for auth.admin lookup.
+      const digestUsecase = new SendFermentationDigestUsecase(
+        new ResendEmailNotifier(),
+        createSupabaseVerifiedEmailResolver(getSupabaseClient()),
+      );
+      digestUsecase
+        .execute({ userId: c.get('userId'), questionTitles: [body.questionText] })
+        .catch(() => {
+          // Notification failure must not break the API response.
+        });
 
       return c.json(result, 201);
     } catch (error) {

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -142,6 +142,7 @@ describe('ScheduledFermentationUsecase', () => {
       mockLlm(),
       generateId,
       listActiveUserIds,
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -180,6 +181,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -208,6 +210,7 @@ describe('ScheduledFermentationUsecase', () => {
       mockLlm(),
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -243,6 +246,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -294,6 +298,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -315,6 +320,7 @@ describe('ScheduledFermentationUsecase', () => {
       mockLlm(),
       generateId,
       vi.fn().mockResolvedValue([]),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -355,6 +361,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     await usecase.execute(dateKey);
@@ -403,6 +410,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -449,6 +457,7 @@ describe('ScheduledFermentationUsecase', () => {
       llm,
       generateId,
       vi.fn().mockResolvedValue(['user-1']),
+      vi.fn().mockResolvedValue(undefined),
     );
 
     const result = await usecase.execute(dateKey);
@@ -456,5 +465,122 @@ describe('ScheduledFermentationUsecase', () => {
     expect(result.totalUsers).toBe(1);
     expect(result.totalFermentations).toBe(0);
     expect(llm.analyze).not.toHaveBeenCalled();
+  });
+
+  it('calls digest once per user with all successful question titles', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const q1 = makeQuestion('user-1', 'q1');
+    const q2 = makeQuestion('user-1', 'q2');
+    const t1 = makeQuestionTransaction('q1', 'Q1 title');
+    const t2 = makeQuestionTransaction('q2', 'Q2 title');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdAndDate).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1, q2]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockImplementation(async (id) =>
+      id === 'q1' ? t1 : t2,
+    );
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const sendDigest = vi.fn().mockResolvedValue(undefined);
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      mockFermentationRepo(),
+      mockLlm(),
+      generateId,
+      vi.fn().mockResolvedValue(['user-1']),
+      sendDigest,
+    );
+
+    await usecase.execute(dateKey);
+
+    expect(sendDigest).toHaveBeenCalledOnce();
+    expect(sendDigest).toHaveBeenCalledWith('user-1', ['Q1 title', 'Q2 title']);
+  });
+
+  it('does not call digest for users with zero successful fermentations', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const question = makeQuestion('user-1', 'q1');
+    const transaction = makeQuestionTransaction('q1', 'Q');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdAndDate).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([question]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const fermentationRepo = mockFermentationRepo();
+    vi.mocked(fermentationRepo.save).mockRejectedValue(new Error('boom'));
+
+    const sendDigest = vi.fn().mockResolvedValue(undefined);
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      fermentationRepo,
+      mockLlm(),
+      generateId,
+      vi.fn().mockResolvedValue(['user-1']),
+      sendDigest,
+    );
+
+    await usecase.execute(dateKey);
+
+    expect(sendDigest).not.toHaveBeenCalled();
+  });
+
+  it('does not let digest failure break the scheduled run', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const question = makeQuestion('user-1', 'q1');
+    const transaction = makeQuestionTransaction('q1', 'Q');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdAndDate).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([question]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const sendDigest = vi.fn().mockRejectedValue(new Error('email down'));
+
+    const usecase = new ScheduledFermentationUsecase(
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      mockFermentationRepo(),
+      mockLlm(),
+      generateId,
+      vi.fn().mockResolvedValue(['user-1']),
+      sendDigest,
+    );
+
+    const result = await usecase.execute(dateKey);
+
+    expect(result.succeeded).toBe(1);
+    expect(sendDigest).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SendFermentationDigestUsecase } from '@/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.js';
+import type { EmailNotifier } from '@/contexts/fermentation/domain/gateways/email-notifier.gateway.js';
+
+function mockNotifier(): EmailNotifier {
+  return { send: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe('SendFermentationDigestUsecase', () => {
+  it('no-ops when there are no question titles', async () => {
+    const notifier = mockNotifier();
+    const resolve = vi.fn().mockResolvedValue('user@example.com');
+    const usecase = new SendFermentationDigestUsecase(notifier, resolve);
+
+    await usecase.execute({ userId: 'u1', questionTitles: [] });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when resolver returns null (unverified or missing email)', async () => {
+    const notifier = mockNotifier();
+    const resolve = vi.fn().mockResolvedValue(null);
+    const usecase = new SendFermentationDigestUsecase(notifier, resolve);
+
+    await usecase.execute({ userId: 'u1', questionTitles: ['Q1'] });
+
+    expect(resolve).toHaveBeenCalledWith('u1');
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('sends single-title body in the original issue wording', async () => {
+    const notifier = mockNotifier();
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    await usecase.execute({ userId: 'u1', questionTitles: ['なぜ働くのか'] });
+
+    expect(notifier.send).toHaveBeenCalledOnce();
+    expect(notifier.send).toHaveBeenCalledWith({
+      to: 'user@example.com',
+      subject: 'あなたの瓶の発酵が進みました',
+      bodyText:
+        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.vercel.app/jar',
+    });
+  });
+
+  it('sends bullet list body for multiple unique titles', async () => {
+    const notifier = mockNotifier();
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    await usecase.execute({
+      userId: 'u1',
+      questionTitles: ['問い A', '問い B'],
+    });
+
+    expect(notifier.send).toHaveBeenCalledOnce();
+    const call = vi.mocked(notifier.send).mock.calls[0][0];
+    expect(call.bodyText).toBe(
+      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae.vercel.app/jar',
+    );
+  });
+
+  it('dedupes and trims titles before composing the body', async () => {
+    const notifier = mockNotifier();
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    await usecase.execute({
+      userId: 'u1',
+      questionTitles: ['問い A', '  問い A  ', '', '問い B'],
+    });
+
+    const call = vi.mocked(notifier.send).mock.calls[0][0];
+    expect(call.bodyText).toContain('・問い A');
+    expect(call.bodyText).toContain('・問い B');
+    expect(call.bodyText.match(/・問い A/g)).toHaveLength(1);
+  });
+
+  it('sends single-title body when only one title remains after trim/dedupe', async () => {
+    const notifier = mockNotifier();
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    await usecase.execute({
+      userId: 'u1',
+      questionTitles: ['Q', '  Q  ', ''],
+    });
+
+    const call = vi.mocked(notifier.send).mock.calls[0][0];
+    expect(call.bodyText).toBe(
+      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.vercel.app/jar',
+    );
+  });
+});


### PR DESCRIPTION
Closes #213

## Summary
- 発酵分析完了時、メール登録（verified）済みユーザーに Resend 経由で通知を送る
- cron 経路ではユーザーごとに1通の **digest** にまとめ、手動/再実行/admin トリガーでは都度 1 通送信
- 送信失敗は fire-and-forget で発酵プロセスを止めない（Discord 通知と同じパターン）

## 変更点
- **新規 gateway**: `EmailNotifier`（`domain/gateways/email-notifier.gateway.ts`）
- **新規 infra**: `ResendEmailNotifier`（fetch 直呼び、SDK 依存なし）+ `createSupabaseVerifiedEmailResolver`（`email_confirmed_at` チェック）
- **新規 usecase**: `SendFermentationDigestUsecase` — 1 件なら原文、複数なら箇条書き body
- **既存変更**: `ScheduledFermentationUsecase` に `sendDigest` callback を追加、user ごとに成功 titles を集約して 1 回呼ぶ
- **ルート**: cron / admin trigger-scheduled / admin retry / ユーザー手動 POST の 4 経路で digest を DI
- `.env.example` に `RESEND_API_KEY` / `EMAIL_FROM` / `EMAIL_ENABLED` を追記

## 文面
- Subject: `あなたの瓶の発酵が進みました`
- Body (1 件):
  ```
  [問いタイトル]についてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。
  https://oryzae.vercel.app/jar
  ```
- Body (複数): 箇条書き `・` で並べる形

## 環境
- Resend ドメイン `oryzae.ephemere.io` は設定済み（SPF/DKIM/DMARC: user が Route53 で完了）
- `RESEND_API_KEY` は Vercel **production** env に設定済み
- デフォルト From: `Oryzae <noreply@oryzae.ephemere.io>`
- `EMAIL_ENABLED=false` で送信を無効化可能（無料枠を超えそうな時の非常停止）

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm dep-cruise && pnpm knip` — 全 pass
- [x] `SendFermentationDigestUsecase` ユニットテスト（6 ケース: 空リスト / 未 verified / 単数文面 / 複数箇条書き / dedupe / trim）
- [x] `ScheduledFermentationUsecase` に digest 呼び出し検証テスト 3 件追加
- [ ] Production デプロイ後、admin trigger-scheduled で自分のアカウントを対象に動作確認
- [ ] 受信メール（ドメイン認証・SPF/DKIM pass・レンダリング）の目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)