### PR TITLE
fix(server): 発酵 rate limit を POST のみに限定

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -12,7 +12,6 @@ import { authMiddleware } from './contexts/shared/presentation/middleware/auth.j
 import { errorHandler } from './contexts/shared/presentation/middleware/error-handler.js';
 import {
   rateLimitAuth,
-  rateLimitFermentation,
   rateLimitGeneral,
 } from './contexts/shared/presentation/middleware/rate-limit.js';
 import { adminDashboard } from './contexts/shared/presentation/routes/admin-dashboard.js';
@@ -36,7 +35,6 @@ const app = new Hono()
   .route('/api/v1/admin/analytics', adminAnalytics)
   .route('/api/v1/admin/observability', adminObservability)
   .use('/api/v1/*', authMiddleware)
-  .use('/api/v1/fermentations', rateLimitFermentation())
   .use('/api/v1/*', rateLimitGeneral())
   .route('/api/v1/users/me', userStats)
   .route('/api/v1/board', board)

--- a/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
 import { getSupabaseClient } from '../../../shared/infrastructure/supabase-client.js';
+import { rateLimitFermentation } from '../../../shared/presentation/middleware/rate-limit.js';
 import { GetFermentationResultUsecase } from '../../application/usecases/get-fermentation-result.usecase.js';
 import { ListFermentationResultsUsecase } from '../../application/usecases/list-fermentation-results.usecase.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
@@ -28,7 +29,7 @@ const runFermentationSchema = z.object({
 const generateId = () => crypto.randomUUID();
 
 export const fermentations = new Hono<Env>()
-  .post('/', async (c) => {
+  .post('/', rateLimitFermentation(), async (c) => {
     const body = runFermentationSchema.parse(await c.req.json());
     const supabase = c.get('supabase');
     const repo = new SupabaseFermentationRepository(supabase);


### PR DESCRIPTION
## Summary
- `/jar` ページで円形要素の中身（keywords / snippets / letter）が空になる本番バグの hotfix
- `UnreadProvider` の 3 件 + `QuestionCircle` × 3 の list + detail で計 9 リクエストが `/api/v1/fermentations` に同時に飛んでおり、path-level で効いていた fermentation tier (5 req/min) が GET にも適用されて 6 発目以降が 429 で落ちていた
- fermentation tier は本来高コストな LLM 呼び出しを守るためのものなので、**POST /fermentations のみに掛け替え**（GET は general tier 60 req/min でカバー）

## 変更
- `apps/server/src/app.ts`: `.use('/api/v1/fermentations', rateLimitFermentation())` を削除
- `apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts`: `.post('/', rateLimitFermentation(), handler)` にルート単位で適用

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (206 + 76 + 55 = 337 tests)
- [x] `pnpm lint` clean
- [x] `pnpm dep-cruise` clean
- [x] `pnpm knip` clean
- [ ] マージ後、Vercel デプロイ完了を確認
- [ ] `https://oryzae.vercel.app/jar` で円形要素にキーワード/スニペット/手紙が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)