### PR TITLE
chore: add vercel.json for admin app deployment

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install --filter @oryzae/admin...",
+  "buildCommand": "pnpm --filter @oryzae/shared build && pnpm --filter @oryzae/server build && pnpm --filter @oryzae/admin build"
+}


### PR DESCRIPTION
## Summary
- `apps/admin/vercel.json` を追加し、Vercel で `apps/admin` を Root Directory としてデプロイする際の install/build コマンドを monorepo (pnpm workspace) 対応にする
- `apps/client/vercel.json` と同じ形で揃え、`@oryzae/shared` → `@oryzae/server` → `@oryzae/admin` の順にビルドする

## Why
Vercel のデフォルト install/build では、pnpm workspace 依存（`@oryzae/server` の `@oryzae/admin` からの workspace 参照）が正しく解決されない可能性があるため、明示的に filter 付きで install/build を指定する。

## Test plan
- [ ] Vercel 上で admin プロジェクトが正常にビルド・デプロイされること
- [ ] client プロジェクトのデプロイに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)