### PR TITLE
fix(client): 縦書きエディタの先頭フェードを削除 (#227)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -122,7 +122,6 @@ export function EntryEditor({
   const [voiceActive, setVoiceActive] = useState(false);
   const [pendingNavPath, setPendingNavPath] = useState<string | null>(null);
   const [fadeLeft, setFadeLeft] = useState(false);
-  const [fadeRight, setFadeRight] = useState(false);
   const [status, setStatus] = useState<EditorStatus>('editing');
   const isAutosavingRef = useRef(false);
   const [linkedIds, setLinkedIds] = useState<Set<string>>(new Set(initialLinkedIds));
@@ -200,28 +199,23 @@ export function EntryEditor({
     if (saving) setStatus(isAutosavingRef.current ? 'autosaving' : 'saving');
   }, [saving]);
 
-  // Track scroll position of editor to show/hide fade overlays
+  // Track scroll position of editor to show/hide end-side fade overlay
   useEffect(() => {
     const el = editorRef.current;
     if (!el || settings.writingMode !== 'vertical') {
       setFadeLeft(false);
-      setFadeRight(false);
       return;
     }
     function updateFade() {
       if (!el) return;
       const { scrollLeft, scrollWidth, clientWidth } = el;
-      // vertical-rl: scrollLeft is 0 at start (rightmost), negative when scrolled left
       const maxScroll = scrollWidth - clientWidth;
       // vertical-rl: scrollLeft=0 at start (rightmost/beginning), goes negative when scrolled left
-      // Right fade (beginning clipped): show when scrolled away from start
-      setFadeRight(Math.abs(scrollLeft) > 5);
-      // Left fade (end clipped): show when not scrolled all the way to the left
+      // End-side fade: show when not scrolled all the way to the end
       setFadeLeft(maxScroll > 5 && Math.abs(scrollLeft) < maxScroll - 5);
     }
     updateFade();
     el.addEventListener('scroll', updateFade);
-    // Also update on content change via ResizeObserver
     const ro = new ResizeObserver(updateFade);
     ro.observe(el);
     return () => {
@@ -799,9 +793,9 @@ export function EntryEditor({
         style={{ left: sidebarWidth }}
       />
 
-      {/* Editor area — outer wrapper (no overflow) holds fade overlays; inner div scrolls */}
+      {/* Editor area — outer wrapper (no overflow) holds fade overlay; inner div scrolls */}
       <div className="relative flex-1">
-        {/* Fade overlays for vertical mode — appear only when content is clipped */}
+        {/* End-side fade for vertical mode — appears only when content is clipped at the end */}
         {settings.writingMode === 'vertical' && fadeLeft && (
           <div
             className="pointer-events-none absolute top-0 bottom-0 z-[10] transition-opacity duration-300"
@@ -809,16 +803,6 @@ export function EntryEditor({
               left: 0,
               width: '18%',
               background: 'linear-gradient(to right, var(--bg), transparent)',
-            }}
-          />
-        )}
-        {settings.writingMode === 'vertical' && fadeRight && (
-          <div
-            className="pointer-events-none absolute top-0 bottom-0 z-[10] transition-opacity duration-300"
-            style={{
-              right: '15%',
-              width: '12%',
-              background: 'linear-gradient(to left, var(--bg), transparent)',
             }}
           />
         )}


### PR DESCRIPTION
## Summary
- 縦書き (`vertical-rl`) モードで右端（先頭）にかかっていた `fadeRight` グラデーションオーバーレイを削除し、本文の先頭が白っぽく見える問題を解消
- 終端側の `fadeLeft` フェードは維持（はみ出し表示のヒントとして引き続き機能）
- 不要になった `fadeRight` state とスクロール追跡ロジックを除去

Fixes #227

## Test plan
- [x] `pnpm --filter @oryzae/client typecheck`
- [x] `pnpm --filter @oryzae/client test` (41 passed)
- [x] `pnpm lint`
- [x] `pnpm dep-cruise`
- [ ] 縦書きモードでスクロールしても先頭側に白いフェードが出ないことを目視確認
- [ ] 終端側のフェードは引き続き表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)