### PR TITLE
fix: client URL を oryzae-client.vercel.app に統一 (#239)

### DIFF
--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -1,7 +1,7 @@
 import type { EmailNotifier } from '../../domain/gateways/email-notifier.gateway.js';
 
 const SUBJECT = 'あなたの瓶の発酵が進みました';
-const JAR_URL = 'https://oryzae.vercel.app/jar';
+const JAR_URL = 'https://oryzae-client.vercel.app/jar';
 
 export class SendFermentationDigestUsecase {
   constructor(

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -43,7 +43,7 @@ describe('SendFermentationDigestUsecase', () => {
       to: 'user@example.com',
       subject: 'あなたの瓶の発酵が進みました',
       bodyText:
-        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.vercel.app/jar',
+        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae-client.vercel.app/jar',
     });
   });
 
@@ -62,7 +62,7 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae.vercel.app/jar',
+      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae-client.vercel.app/jar',
     );
   });
 
@@ -98,7 +98,7 @@ describe('SendFermentationDigestUsecase', () => {
 
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.vercel.app/jar',
+      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae-client.vercel.app/jar',
     );
   });
 });

--- a/docs/infra-guide.md
+++ b/docs/infra-guide.md
@@ -14,7 +14,7 @@ Browser → Next.js (same origin) → Hono (internal app.fetch()) → Supabase C
 
 | アプリ | URL | Vercel プロジェクト | 用途 |
 |---|---|---|---|
-| client | https://oryzae.vercel.app | oryzae | ユーザー向け |
+| client | https://oryzae-client.vercel.app | oryzae-client | ユーザー向け |
 | admin | https://oryzae-admin.vercel.app | oryzae-admin | 管理画面・Observability |
 
 ### なぜこの構成か


### PR DESCRIPTION
## Summary
- Vercel プロジェクトが `oryzae` → `oryzae-client` に改名されたが、コードとドキュメントに旧 URL が残っていたため統一
- `docs/infra-guide.md`、メール本文に埋め込む `JAR_URL`、対応するテスト期待値を更新
- 関連 issue: #239

## なお SSO callback 自体の修正には別作業が必要
このコミットは内部の URL 参照を新ドメインに揃えるだけ。SSO のコールバックが `oryzae.vercel.app` に飛ぶ根本原因は **Supabase Dashboard 側の URL Configuration（Site URL / Redirect URLs）が旧ドメインのまま**であるため、別途以下のダッシュボード操作が必要：

- Site URL を `https://oryzae-client.vercel.app` に変更
- Redirect URLs に `https://oryzae-client.vercel.app/**` と `http://localhost:3000/**` を追加
- 旧 `https://oryzae.vercel.app/**` を削除

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm --filter @oryzae/server test` 通過（206 tests）
- [ ] Supabase 側 URL Configuration 更新後、Google SSO で `oryzae-client.vercel.app/callback` に正しく戻ることを確認
- [ ] 発酵ダイジェストメールの本文に新 URL が表示されることを次回送信時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)