### PR TITLE
chore: add Stop hook running typecheck + tests

### DIFF
--- a/.claude/hooks/run-tests-on-stop.sh
+++ b/.claude/hooks/run-tests-on-stop.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Stop hook: run typecheck + unit tests. If anything fails, force Claude to keep working.
+#
+# - Reads stop_hook_active from stdin to break out of infinite loops
+# - Emits {"decision":"block","reason":"..."} to stdout (exit 0) on failure
+#   so Claude is told to fix the failures before stopping
+# - Exits 0 silently on success
+
+set -uo pipefail
+
+INPUT=$(cat 2>/dev/null || true)
+STOP_HOOK_ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+
+# Already in a stop-hook iteration → let Claude actually stop, even if tests still fail.
+# (Claude will have surfaced the failure in the previous turn; user can intervene.)
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+run_step() {
+  local label="$1"
+  shift
+  local output
+  output=$("$@" 2>&1)
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    local trunc
+    trunc=$(printf '%s' "$output" | tail -c 4000)
+    jq -n --arg label "$label" --arg out "$trunc" \
+      '{decision: "block", reason: ("Stop hook: \($label) failed. Fix it before stopping.\n\n```\n\($out)\n```")}'
+    exit 0
+  fi
+}
+
+run_step "pnpm typecheck" pnpm typecheck
+run_step "pnpm test" pnpm test
+
+exit 0

--- a/.claude/rules/quality.md
+++ b/.claude/rules/quality.md
@@ -37,3 +37,16 @@ take_screenshot filePath=.tmp/screenshots/{名前}.png
 ```bash
 pnpm typecheck && pnpm lint && pnpm test && pnpm dep-cruise && pnpm knip
 ```
+
+## Stop hook による自動テスト
+
+Claude の応答完了時に `.claude/hooks/run-tests-on-stop.sh` が `pnpm typecheck && pnpm test` を実行する。失敗するとブロックされ、Claude がもう一周して修正する（`stop_hook_active` で 2 周目は通す）。
+
+## フロントエンド変更時の検証
+
+`apps/client` / `apps/admin` の UI を変更したら、報告前に必ず Chrome DevTools MCP で実機確認する。Stop hook の vitest は表示・操作までは検証しない。
+
+- `/auto-qa` skill を呼ぶ、または `mcp__chrome-devtools__*` を直接使う
+- dev server (`pnpm --filter @oryzae/client dev` or `admin`) を立てて `navigate_page` → 該当フロー実行 → `take_screenshot`
+- `list_console_messages` でエラーが出てないかも確認
+- スクリーンショット保存先は `.tmp/screenshots/`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-tests-on-stop.sh",
+            "timeout": 600
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/hooks/run-tests-on-stop.sh` を追加。Claude の応答完了時に `pnpm typecheck && pnpm test` を実行
- 失敗時は `{"decision": "block", "reason": "..."}` を stdout に返して Claude にもう一周させる
- `stop_hook_active` フラグで 2 周目以降は通すので無限ループにはならない
- `.claude/settings.json` に Stop hook を登録（既存の git push PreToolUse hook はそのまま）
- `quality.md` にフロントエンド変更時の Chrome DevTools MCP / `/auto-qa` 利用ルールを追記

## Why
[超並列LLMコーディングのハーネスエンジニアリング](https://qiita.com/ot12/items/06420caf41a34a910c53) の「テストが通るまで Claude が自動で周回する」構成を導入。型エラー・ユニットテスト失敗を検知して自動修正させる。

UI の見た目・操作までは vitest では検証できないため、視覚確認は既存の `auto-qa` skill / Chrome DevTools MCP に任せる運用ルールを明文化。

## 動作仕様
- **正常時**: typecheck + test pass → 何も出力せず exit 0 → Claude 通常停止
- **失敗時**: 失敗ステップ名と末尾 4000 字をログとして JSON 出力 → Claude が修正してまた応答
- **2 周目**: `stop_hook_active=true` なら即 exit 0 → ユーザに制御戻る（タイトループ防止）

## Test plan
- [ ] typecheck エラーを意図的に出して Stop hook が block を返すか確認
- [ ] テスト失敗時に Claude が自動でもう一周するか確認
- [ ] 正常完了時に静かに通過するか確認
- [ ] 連続失敗時に 2 周目で抜けられるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)