### PR TITLE
fix(admin): 障害情報の取得失敗とダッシュボードのレイアウト崩れ

### DIFF
--- a/apps/admin/src/features/dashboard/components/failure-alerts.tsx
+++ b/apps/admin/src/features/dashboard/components/failure-alerts.tsx
@@ -83,18 +83,21 @@ export function FailureAlerts({
       <div className="divide-y divide-border/30">
         {groups.flatMap((group) =>
           group.failures.map((f) => (
-            <div key={f.fermentationId} className="flex items-center gap-3 px-4 py-2">
+            <div key={f.id} className="flex items-center gap-3 px-4 py-2">
               <span className="size-1.5 shrink-0 rounded-full bg-red-500" />
               <span className="shrink-0 text-xs text-muted-foreground w-36 truncate">
                 {group.email}
               </span>
-              <span className="flex-1 truncate text-sm text-foreground/80" title={f.errorMessage}>
-                {truncate(f.errorMessage, 80)}
+              <span
+                className="flex-1 truncate text-sm text-foreground/80"
+                title={f.errorMessage ?? ''}
+              >
+                {truncate(f.errorMessage ?? '不明なエラー', 80)}
               </span>
               <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
                 {formatRelativeTime(f.createdAt)}
               </span>
-              <RetryButton fermentationId={f.fermentationId} onRetry={retryFermentation} />
+              <RetryButton fermentationId={f.id} onRetry={retryFermentation} />
             </div>
           )),
         )}

--- a/apps/admin/src/features/dashboard/components/stats-cards.tsx
+++ b/apps/admin/src/features/dashboard/components/stats-cards.tsx
@@ -22,7 +22,7 @@ function StatCard({ label, value, subtitle }: StatCardProps) {
 
 export function StatsCards({ stats }: { stats: DashboardStats }) {
   return (
-    <div className="grid gap-4 grid-cols-3">
+    <>
       <StatCard label="Users" value={stats.totalUsers} />
       <StatCard label="Entries" value={stats.totalEntries} />
       <StatCard
@@ -30,6 +30,6 @@ export function StatsCards({ stats }: { stats: DashboardStats }) {
         value={stats.totalFermentations}
         subtitle={`${stats.completedFermentations} done / ${stats.failedFermentations} failed`}
       />
-    </div>
+    </>
   );
 }

--- a/apps/admin/src/features/dashboard/hooks/use-failure-alerts.ts
+++ b/apps/admin/src/features/dashboard/hooks/use-failure-alerts.ts
@@ -5,15 +5,14 @@ import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
 
 export interface FailureItem {
-  fermentationId: string;
-  errorMessage: string;
+  id: string;
+  errorMessage: string | null;
   createdAt: string;
 }
 
 export interface FailureGroup {
   userId: string;
   email: string;
-  avatarUrl: string | null;
   failures: FailureItem[];
 }
 
@@ -33,8 +32,11 @@ export function useFailureAlerts() {
     const res = await api.fetch('/api/v1/admin/dashboard/failures-24h');
     if (res.ok) {
       const data: unknown = await res.json();
-      if (Array.isArray(data)) {
-        setGroups(data as FailureGroup[]); // @type-assertion-allowed: APIレスポンスの型をバリデーション後にキャスト
+      if (typeof data === 'object' && data !== null && 'groups' in data) {
+        const groupsRaw = (data as { groups: unknown }).groups; // @type-assertion-allowed: in 演算子で存在確認後
+        if (Array.isArray(groupsRaw)) {
+          setGroups(groupsRaw as FailureGroup[]); // @type-assertion-allowed: API レスポンスの shape
+        }
       }
     } else {
       setError('障害情報の取得に失敗しました');

--- a/apps/admin/test/features/dashboard/hooks/use-failure-alerts.test.ts
+++ b/apps/admin/test/features/dashboard/hooks/use-failure-alerts.test.ts
@@ -17,10 +17,9 @@ const sampleGroups = [
   {
     userId: 'u1',
     email: 'test@example.com',
-    avatarUrl: null,
     failures: [
       {
-        fermentationId: 'f1',
+        id: 'f1',
         errorMessage: 'Something went wrong',
         createdAt: '2026-04-12T10:00:00Z',
       },
@@ -35,7 +34,7 @@ describe('useFailureAlerts', () => {
   });
 
   it('fetches failure groups on mount', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse(true, sampleGroups));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { groups: sampleGroups }));
 
     const { result } = renderHook(() => useFailureAlerts());
 
@@ -44,6 +43,19 @@ describe('useFailureAlerts', () => {
     });
 
     expect(result.current.groups).toEqual(sampleGroups);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles empty groups response', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { groups: [] }));
+
+    const { result } = renderHook(() => useFailureAlerts());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.groups).toEqual([]);
     expect(result.current.error).toBeNull();
   });
 
@@ -70,7 +82,7 @@ describe('useFailureAlerts', () => {
   });
 
   it('retryFermentation calls POST and refreshes', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse(true, sampleGroups));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { groups: sampleGroups }));
 
     const { result } = renderHook(() => useFailureAlerts());
 
@@ -80,7 +92,7 @@ describe('useFailureAlerts', () => {
 
     // Mock the retry POST and the subsequent refresh GET
     mockFetch.mockResolvedValueOnce(mockResponse(true, { ok: true }));
-    mockFetch.mockResolvedValueOnce(mockResponse(true, []));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { groups: [] }));
 
     let retryResult: boolean;
     await act(async () => {
@@ -95,7 +107,7 @@ describe('useFailureAlerts', () => {
   });
 
   it('retryFermentation returns false on failure', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse(true, sampleGroups));
+    mockFetch.mockResolvedValueOnce(mockResponse(true, { groups: sampleGroups }));
 
     const { result } = renderHook(() => useFailureAlerts());
 

--- a/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
@@ -69,7 +69,7 @@ export const adminDashboard = new Hono<Env>()
 
     const { data, error } = await supabase
       .from('fermentation_results')
-      .select('id, user_id, question_id, entry_id, error_message, created_at')
+      .select('id, user_id, question_id, error_message, created_at')
       .eq('status', 'failed')
       .gt('created_at', since);
 
@@ -83,7 +83,6 @@ export const adminDashboard = new Hono<Env>()
       {
         id: string;
         questionId: string;
-        entryId: string;
         errorMessage: string | null;
         createdAt: string;
       }[]
@@ -93,7 +92,6 @@ export const adminDashboard = new Hono<Env>()
       list.push({
         id: row.id,
         questionId: row.question_id,
-        entryId: row.entry_id,
         errorMessage: row.error_message,
         createdAt: row.created_at,
       });


### PR DESCRIPTION
## Summary

ユーザー報告: https://oryzae-admin-delta.vercel.app/dashboard で
- 「障害情報の取得に失敗しました」エラー表示
- FERMENTATIONS カードのラベルがはみ出し、`0 done / 0 failed` の subtitle が縦に潰れる

の 2 点を修正。

## Root cause

### 1. /failures-24h が 500
`admin-dashboard.ts` の `/failures-24h` ルートで `fermentation_results.entry_id` を SELECT していた。Migration 00012 で `fermentation_results.entry_id` は drop 済み（`fermentation_scanned_entries` join テーブルに移行）。コード側のクリーンアップ漏れ。

production schema を Supabase MCP で確認:
```
fermentation_results: id, user_id, question_id, target_period, status, created_at, updated_at, generation_id, error_message
（entry_id は無い）
```

### 2. UI レイアウト崩れ
\`StatsCards\` が内部で \`grid grid-cols-3\` ラップしていたため、親の \`grid lg:grid-cols-5\` の **1 スロット**に 3 カード（USERS/ENTRIES/FERMENTATIONS）が押し込まれていた。各カードが 1/15 幅になり、ラベル truncate と subtitle 縦潰れが発生。

### 3. (おまけ) クライアント-サーバ間のデータ形状不一致
- server は \`{ groups: [...] }\` を返すが、client の \`useFailureAlerts\` は \`Array.isArray(data)\` で配列を期待 → silently drop（500 エラーが出てなくても、表示が空のままになる潜在バグ）
- server は \`failures[].id\` を返すが、client 型は \`fermentationId\` を期待 → 同上
- client 型に \`avatarUrl\` があったが server response には無い（dead field）

## Changes

| ファイル | 変更 |
|---|---|
| \`apps/server/.../admin-dashboard.ts\` | \`/failures-24h\` で \`entry_id\` を SELECT しないよう修正 |
| \`apps/admin/.../use-failure-alerts.ts\` | \`{ groups: [...] }\` をパース、型を server 実態に合わせる（\`id\`/no-avatarUrl/\`errorMessage: string \| null\`） |
| \`apps/admin/.../failure-alerts.tsx\` | \`f.fermentationId\` → \`f.id\`、null fallback |
| \`apps/admin/.../stats-cards.tsx\` | Fragment 化、親 grid の直接子に |
| \`apps/admin/test/.../use-failure-alerts.test.ts\` | mock 形状を server 実態に合わせる + 空 groups の test 追加 |

## Test plan

- [x] \`pnpm typecheck && pnpm test\` 全 pass（server 206 / client 97 / admin 56）
- [ ] Vercel preview で /dashboard を開き、障害情報エラーが消えていることを確認
- [ ] 5 カラム（USERS / ENTRIES / FERMENTATIONS / MONTHLY COST / ACTIVE WRITERS）が均等幅で表示されることを確認
- [ ] FERMENTATIONS の subtitle \`0 done / 0 failed\` が 1 行で表示されることを確認

## Note

admin-dashboard ルートには integration test が無いため、今回は client-side のみ test 追加。server-side の API contract test 追加は別 PR で検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)