### PR TITLE
fix(client): タイトル保存モーダルで IME 確定 Enter による誤送信を防止

### DIFF
--- a/apps/client/src/features/entries/components/save-title-modal.tsx
+++ b/apps/client/src/features/entries/components/save-title-modal.tsx
@@ -75,6 +75,12 @@ export function SaveTitleModal({
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={(e) => {
+            // IME 変換確定の Enter で保存されないようにする
+            if (e.key === 'Enter' && e.nativeEvent.isComposing) {
+              e.preventDefault();
+            }
+          }}
           maxLength={100}
           placeholder="タイトルを入力..."
           className="mb-4 w-full rounded-md border px-3 py-2.5 text-sm outline-none"

--- a/apps/client/test/features/entries/components/save-title-modal.test.tsx
+++ b/apps/client/test/features/entries/components/save-title-modal.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SaveTitleModal } from '@/features/entries/components/save-title-modal';
+
+describe('SaveTitleModal', () => {
+  function setup() {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SaveTitleModal
+        open
+        initialTitle="default-title"
+        saving={false}
+        onSave={onSave}
+        onClose={onClose}
+      />,
+    );
+    return { onSave, onClose };
+  }
+
+  it('Enter キーで送信される（通常入力時）', () => {
+    const { onSave } = setup();
+    const input = screen.getByLabelText('タイトル') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: false });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    expect(onSave).toHaveBeenCalledWith('hello');
+  });
+
+  it('IME 変換確定の Enter（isComposing=true）では送信されない', () => {
+    const { onSave } = setup();
+    const input = screen.getByLabelText('タイトル') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'にほんご' } });
+    // isComposing=true の Enter は preventDefault され、フォーム submit が走らない
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `SaveTitleModal` のタイトル入力で日本語等の IME 変換確定 Enter がそのままフォーム送信を起こし、変換途中で保存される不具合を修正
- `isComposing` 中の Enter は `preventDefault` するだけで、フォーム自体の通常送信動作（変換確定後の Enter / 「保存」ボタン）はそのまま

## Test plan
- [ ] vitest で `SaveTitleModal` の挙動を検証（通常 Enter は送信、IME 中の Enter は送信されない）
- [ ] 実機で日本語タイトルを入力 → 変換中の Enter で保存されないことを確認
- [ ] 変換確定後の Enter（isComposing=false）で保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)