### PR TITLE
chore: supabase/.temp/ を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ playwright-report/
 screenshots/
 .claude/worktrees/
 .vercel
+supabase/.temp/


### PR DESCRIPTION
## Summary
- Supabase CLI が自動生成するキャッシュファイル群（`cli-latest`, `gotrue-version`, `project-ref` 等）が untracked のまま残っていたので gitignore に追加

## Test plan
- [ ] `supabase/.temp/` 配下のファイルが `git status` に出てこないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)