### PR TITLE
chore: drop unused exports flagged by knip 6.7.0

### DIFF
--- a/apps/admin/src/features/dashboard/hooks/use-failure-alerts.ts
+++ b/apps/admin/src/features/dashboard/hooks/use-failure-alerts.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { createApiClient } from '@/lib/api';
 import { getAccessToken } from '@/lib/auth';
 
-export interface FailureItem {
+interface FailureItem {
   id: string;
   errorMessage: string | null;
   createdAt: string;

--- a/apps/client/src/features/entries/components/settings-drawer.tsx
+++ b/apps/client/src/features/entries/components/settings-drawer.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-export type WritingMode = 'vertical' | 'horizontal';
-export type FontFamily = 'serif' | 'sans';
+type WritingMode = 'vertical' | 'horizontal';
+type FontFamily = 'serif' | 'sans';
 export type TimeInscriptionMode = 'fontSize' | 'fontWeight' | 'pressureBleed';
-export type GhostMode = 'block' | 'dust';
+type GhostMode = 'block' | 'dust';
 
 export interface EditorSettings {
   writingMode: WritingMode;

--- a/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
@@ -1,4 +1,4 @@
-export interface FermentationOutput {
+interface FermentationOutput {
   worksheetMarkdown: string;
   resultDiagramMarkdown: string;
   snippets: {
@@ -11,7 +11,7 @@ export interface FermentationOutput {
   keywords: { keyword: string; description: string }[];
 }
 
-export interface LlmUsage {
+interface LlmUsage {
   inputTokens: number;
   outputTokens: number;
 }

--- a/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
+++ b/apps/server/src/contexts/fermentation/domain/models/fermentation-result.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
-export type FermentationStatus = 'pending' | 'processing' | 'completed' | 'failed';
+type FermentationStatus = 'pending' | 'processing' | 'completed' | 'failed';
 
 type FermentationResultError = { type: 'INVALID_STATUS'; message: string };
 


### PR DESCRIPTION
## Summary

knip 6.4.0 → 6.7.0 (PR #238) で detector が強化され、unused exports 7 件が新規検出された。すべて宣言ファイル内でのみ使用されているため、`export` 修飾子を外して internal 型に変更。

## Affected types

| ファイル | 型 |
|---|---|
| \`apps/admin/.../use-failure-alerts.ts\` | \`FailureItem\` |
| \`apps/client/.../settings-drawer.tsx\` | \`WritingMode\`, \`FontFamily\`, \`GhostMode\` |
| \`apps/server/.../llm-analysis.gateway.ts\` | \`FermentationOutput\`, \`LlmUsage\` |
| \`apps/server/.../fermentation-result.ts\` | \`FermentationStatus\` |

## Why this is the right fix

これらは Dependabot bump が壊したわけではなく、knip 検出力が向上して既存のずっと前から放置されていた dead export が顕在化しただけ。`export` を外しても同ファイル内で参照は続くので、ロジックには一切影響なし。

\`apps/server/dist/\` 配下の compiled output に \`FermentationStatus\` が残っているように見えるが、TypeScript の dts は declaration merging で\` interface \` の export structure を残すだけで実害なし（再 build で消える）。

## Context

Dependabot PR #238 (npm minor-and-patch group, 12 packages) の Knip CI 失敗を解消するための事前 cleanup。本 PR が main に入った後、#238 を rebase すれば全 CI green で merge 可能になる。

## Test plan

- [x] \`pnpm typecheck\` ✅ (server / shared / client / admin)
- [x] \`pnpm test\` ✅ (server 206 / client 99 / admin 56)
- [x] \`pnpm knip\` ✅ (no dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)