### PR TITLE
fix(server): applyDateFilter の型再帰回避（Supabase 2.105 対応）

### DIFF
--- a/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/admin-dashboard.ts
@@ -15,15 +15,17 @@ export const adminDashboard = new Hono<Env>()
     const dateFrom = c.req.query('date_from');
     const dateTo = c.req.query('date_to');
 
-    const applyDateFilter = <
-      T extends { gte: (col: string, val: string) => T; lte: (col: string, val: string) => T },
-    >(
-      query: T,
-    ): T => {
-      let q = query;
+    type DateFilterable = {
+      gte: (col: string, val: string) => DateFilterable;
+      lte: (col: string, val: string) => DateFilterable;
+    };
+    const applyDateFilter = <T>(query: T): T => {
+      // @type-assertion-allowed: Supabase 2.105 で `T extends { gte/lte... }` の generic 制約が型インスタンス化深度を超えて TS2589 を起こす。runtime は同じ method chain なので、generic を緩めて中で DateFilterable に narrow する。
+      let q = query as unknown as DateFilterable;
       if (dateFrom) q = q.gte('created_at', dateFrom);
       if (dateTo) q = q.lte('created_at', `${dateTo}T23:59:59.999Z`);
-      return q;
+      // @type-assertion-allowed: 上の理由と同じく、型を元の builder 型に戻す。runtime では同じオブジェクトの chain。
+      return q as unknown as T;
     };
 
     const [usersRes, entriesRes, allFermRes, completedRes, failedRes, costTrackedRes] =


### PR DESCRIPTION
## Summary

Dependabot PR #248 (npm minor-and-patch, 13 packages) の TypeCheck 失敗を解消する事前 fix。

\`@supabase/supabase-js\` 2.103 → 2.105 で内部 query builder の型パラメータが増え、\`apps/server/.../admin-dashboard.ts\` の \`applyDateFilter\` の generic 制約 \`<T extends { gte/lte: ... => T }>\` が型インスタンス化深度上限を踏み抜き **TS2589: Type instantiation is excessively deep and possibly infinite** で失敗するようになった。

## Fix

generic 制約を外し、関数内部で内部用 \`DateFilterable\` 型に narrow する形にリファクタ。runtime 動作は同一（同じ method chain）。

```typescript
type DateFilterable = {
  gte: (col: string, val: string) => DateFilterable;
  lte: (col: string, val: string) => DateFilterable;
};
const applyDateFilter = <T>(query: T): T => {
  // @type-assertion-allowed: ...
  let q = query as unknown as DateFilterable;
  if (dateFrom) q = q.gte('created_at', dateFrom);
  if (dateTo) q = q.lte('created_at', \`\${dateTo}T23:59:59.999Z\`);
  return q as unknown as T;
};
```

\`as\` キャスト 2 箇所には \`@type-assertion-allowed\` 注釈を付与（CLAUDE.md 準拠）。

## Test plan

- [x] \`pnpm typecheck\` ✅
- [x] \`pnpm test\` ✅ (server 206 / client 99 / admin 56)
- [x] \`pnpm knip\` ✅
- [ ] main マージ後、#248 を \`@dependabot recreate\` で再生成 → CI 全 pass を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)