### PR TITLE
fix(client): タイトルインライン入力の IME 確定 Enter による誤確定を防止 (#218)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -598,6 +598,8 @@ export function EntryEditor({
               value={draftTitle}
               onChange={(e) => setDraftTitle(e.target.value)}
               onKeyDown={(e) => {
+                // IME 変換確定の Enter / Escape は無視する（日本語入力途中で確定されてしまう不具合の対策）
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === 'Enter') {
                   e.preventDefault();
                   commitTitleEdit();

--- a/apps/server/test/contexts/shared/presentation/middleware/error-handler.test.ts
+++ b/apps/server/test/contexts/shared/presentation/middleware/error-handler.test.ts
@@ -41,15 +41,16 @@ describe('errorHandler', () => {
     const app = createApp();
     await app.request('/unhandled');
 
-    // Wait for the async dynamic import to resolve
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(mockCaptureException).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Something went wrong' }),
-      expect.objectContaining({
-        extra: { method: 'GET', path: '/unhandled' },
-      }),
-    );
+    // errorHandler は dynamic import を fire-and-forget で実行するため、
+    // 解決を待つ。waitFor のポーリングで決定的にブロックする。
+    await vi.waitFor(() => {
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Something went wrong' }),
+        expect.objectContaining({
+          extra: { method: 'GET', path: '/unhandled' },
+        }),
+      );
+    });
   });
 
   it('does not call Sentry for ApplicationError', async () => {
@@ -57,7 +58,9 @@ describe('errorHandler', () => {
     const app = createApp();
     await app.request('/app-error');
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // ApplicationError は dynamic import を起動しないので、十分な余裕を取って
+    // 他テスト由来の遅延した呼び出しが漏れていないことを確認する。
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(mockCaptureException).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Issue #218 修正: エディタのトップバーに表示されるインラインタイトル入力で、日本語等の IME 変換確定 Enter が `commitTitleEdit` を発火させ、変換途中で編集モードを抜けてしまう不具合を修正
- `e.nativeEvent.isComposing` を見て composition 中の Enter / Escape はハンドラ内で早期 return（`apps/client/src/features/entries/components/entry-editor.tsx`）
- ついでに `apps/server` の `error-handler.test.ts` の flaky を解消（fire-and-forget の dynamic import を `vi.waitFor` で決定的に待つように変更。本 PR の検証中に main 側で常に再現することを確認）

## 関連
- Closes #218
- 補足: PR #245 が `SaveTitleModal`（保存モーダル内のタイトル入力）の同種バグを修正済み。本 PR はインライン側の同根の問題を修正。

## Test plan
- [x] `pnpm typecheck`（client + server + admin）通過
- [x] `pnpm test`: client 99/99、server 206/206、admin 56/56 通過
- [ ] 実機: `/entries/new` でインライン「タイトルを追加」を開き、日本語タイトル入力 → 変換確定 Enter で edit モードを抜けないことを確認
- [ ] 実機: 確定後の Enter（`isComposing=false`）で `commitTitleEdit` が走り edit モードを抜けることを確認
- [ ] 実機: Escape 中の IME composition 中も誤って取り消されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)