### PR TITLE
feat(client): / にランディングページを追加 (#255)

### DIFF
--- a/apps/client/e2e/landing.spec.ts
+++ b/apps/client/e2e/landing.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('ランディングページ', () => {
+  test('未認証で / にアクセスすると LP が表示される', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('h1')).toContainText('発酵させる');
+    await expect(page.locator('text=コンセプト').first()).toBeVisible();
+    await expect(page.locator('text=発酵の三段').first()).toBeVisible();
+  });
+
+  test('「アプリを試す」CTAから /login に遷移できる', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('header a:has-text("アプリを試す")').click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('言語トグルで EN に切り替わる', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('button:has-text("English")').click();
+    await expect(page.locator('h1')).toContainText('ferment');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  });
+
+  test('FAQ をクリックすると展開する', async ({ page }) => {
+    await page.goto('/');
+    const firstFaqButton = page.locator('button[aria-expanded]').filter({ hasText: 'Pickles' });
+    await expect(firstFaqButton).toHaveAttribute('aria-expanded', 'false');
+    await firstFaqButton.click();
+    await expect(firstFaqButton).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/apps/client/public/landing/logo/P3_appicon_cream.svg
+++ b/apps/client/public/landing/logo/P3_appicon_cream.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+<rect width="200" height="200" rx="44" fill="#F2EDE0"></rect>
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="#F2EDE0"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#7A7440" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#7A7440" stroke-width="3.5"></ellipse>
+    <g fill="#9C9658">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#7A7440">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/public/landing/logo/P3_appicon_moss.svg
+++ b/apps/client/public/landing/logo/P3_appicon_moss.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+<rect width="200" height="200" rx="44" fill="#7A7440"></rect>
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="#F2EDE0"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#F2EDE0" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#F2EDE0" stroke-width="3.5"></ellipse>
+    <g fill="#E8B838">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#F2EDE0">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/public/landing/logo/P3_appicon_paper.svg
+++ b/apps/client/public/landing/logo/P3_appicon_paper.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+<rect width="200" height="200" rx="44" fill="#F7F2E5"></rect>
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="#F2EDE0"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#7A7440" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#7A7440" stroke-width="3.5"></ellipse>
+    <g fill="#9C9658">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#7A7440">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/public/landing/logo/P3_mark_color.svg
+++ b/apps/client/public/landing/logo/P3_mark_color.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="#F2EDE0"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#7A7440" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#7A7440" stroke-width="3.5"></ellipse>
+    <g fill="#9C9658">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#7A7440">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/public/landing/logo/P3_mono_ink.svg
+++ b/apps/client/public/landing/logo/P3_mono_ink.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#1F2A22" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#1F2A22" stroke-width="3.5"></ellipse>
+    <g fill="#1F2A22">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#1F2A22">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/public/landing/logo/P3_mono_white_on_ink.svg
+++ b/apps/client/public/landing/logo/P3_mono_white_on_ink.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="512" height="512">
+<rect width="200" height="200" rx="44" fill="#1F2A22"></rect>
+<path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none"></path>
+    <path d="M 86 36 L 86 78 C 86 88, 50 100, 42 138 C 36 172, 64 196, 100 196 C 136 196, 164 172, 158 138 C 150 100, 114 88, 114 78 L 114 36 Z" fill="none" stroke="#F2EDE0" stroke-width="3.5"></path>
+    <ellipse cx="100" cy="36" rx="14" ry="3.5" fill="none" stroke="#F2EDE0" stroke-width="3.5"></ellipse>
+    <g fill="#F2EDE0">
+      <circle cx="100" cy="96" r="9.5"></circle>
+      <circle cx="100" cy="118" r="7.5"></circle>
+      <circle cx="100" cy="138" r="5.5"></circle>
+      <circle cx="78" cy="108" r="7.5"></circle>
+      <circle cx="78" cy="128" r="6"></circle>
+      <circle cx="122" cy="108" r="7.5"></circle>
+      <circle cx="122" cy="128" r="6"></circle>
+    </g>
+    <g fill="#F2EDE0">
+      <ellipse cx="86" cy="160" rx="3.5" ry="9"></ellipse>
+      <ellipse cx="100" cy="162" rx="3.5" ry="10"></ellipse>
+      <ellipse cx="114" cy="160" rx="3.5" ry="9"></ellipse>
+    </g>
+</svg>

--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { LandingPage } from '@/features/landing/components/landing-page';
 import { getAccessToken, setTokens } from '@/lib/auth';
 
 function parseHashParams(hash: string): Record<string, string> {
@@ -18,6 +19,7 @@ function parseHashParams(hash: string): Record<string, string> {
 
 export default function HomePage() {
   const router = useRouter();
+  const [showLanding, setShowLanding] = useState(false);
 
   useEffect(() => {
     const hash = window.location.hash;
@@ -30,17 +32,18 @@ export default function HomePage() {
 
       if (accessToken && refreshToken) {
         setTokens(accessToken, refreshToken);
-        router.replace('/entries');
+        router.replace('/jar');
         return;
       }
     }
 
     if (getAccessToken()) {
-      router.replace('/entries');
+      router.replace('/jar');
     } else {
-      router.replace('/login');
+      setShowLanding(true);
     }
   }, [router]);
 
-  return null;
+  if (!showLanding) return null;
+  return <LandingPage />;
 }

--- a/apps/client/src/features/landing/components/landing-faq-item.tsx
+++ b/apps/client/src/features/landing/components/landing-faq-item.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './landing.module.css';
+
+interface LandingFaqItemProps {
+  question: string;
+  answer: string;
+}
+
+export function LandingFaqItem({ question, answer }: LandingFaqItemProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <li className={styles.faqItem}>
+      <button
+        type="button"
+        className={styles.faqQ}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span>{question}</span>
+        <span className={styles.faqToggle} aria-hidden="true">
+          +
+        </span>
+      </button>
+      <div className={styles.faqA}>
+        <p>{answer}</p>
+      </div>
+    </li>
+  );
+}

--- a/apps/client/src/features/landing/components/landing-page.tsx
+++ b/apps/client/src/features/landing/components/landing-page.tsx
@@ -1,0 +1,623 @@
+'use client';
+
+import Link from 'next/link';
+import { useLandingI18n } from '../hooks/use-landing-i18n';
+import type { LandingLang } from '../types';
+import styles from './landing.module.css';
+import { LandingFaqItem } from './landing-faq-item';
+
+const APP_HREF = '/login';
+const LOGO_SRC = '/landing/logo/P3_mark_color.svg';
+
+export function LandingPage() {
+  const { lang, setLang, t } = useLandingI18n();
+
+  return (
+    <div className={styles.landingRoot}>
+      <SiteHeader lang={lang} setLang={setLang} t={t} />
+      <main id="top">
+        <Hero t={t} />
+        <Concept t={t} />
+        <Process t={t} />
+        <Preview t={t} />
+        <Philosophy t={t} />
+        <Faq t={t} />
+        <Outro t={t} />
+      </main>
+      <SiteFooter t={t} />
+    </div>
+  );
+}
+
+type T = (key: string) => string;
+
+interface HeaderProps {
+  lang: LandingLang;
+  setLang: (lang: LandingLang) => void;
+  t: T;
+}
+
+function SiteHeader({ lang, setLang, t }: HeaderProps) {
+  return (
+    <header className={styles.siteHeader}>
+      <a className={styles.brand} href="#top" aria-label="Oryzae">
+        {/* biome-ignore lint/performance/noImgElement: small inline SVG, next/image overkill */}
+        <img src={LOGO_SRC} alt="" className={styles.brandMark} />
+        <span className={styles.brandName}>Oryzae</span>
+      </a>
+      <nav className={styles.siteNav} aria-label="primary">
+        <a href="#concept">{t('nav.concept')}</a>
+        <a href="#process">{t('nav.process')}</a>
+        <a href="#preview">{t('nav.preview')}</a>
+        <a href="#philosophy">{t('nav.philosophy')}</a>
+        <a href="#faq">{t('nav.faq')}</a>
+      </nav>
+      <div className={styles.headerActions}>
+        {/* biome-ignore lint/a11y/useSemanticElements: pill-style toggle, fieldset would force legend/border styling */}
+        <div className={styles.langToggle} role="group" aria-label="Language">
+          <button
+            type="button"
+            className={styles.langBtn}
+            aria-pressed={lang === 'ja'}
+            onClick={() => setLang('ja')}
+          >
+            日本語
+          </button>
+          <button
+            type="button"
+            className={styles.langBtn}
+            aria-pressed={lang === 'en'}
+            onClick={() => setLang('en')}
+          >
+            English
+          </button>
+        </div>
+        <Link className={`${styles.cta} ${styles.ctaSmall}`} href={APP_HREF}>
+          {t('nav.cta')}
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function Hero({ t }: { t: T }) {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroGrid}>
+        <div>
+          <p className={styles.eyebrow}>{t('hero.eyebrow')}</p>
+          <h1 className={styles.heroTitle}>
+            <span>{t('hero.title.l1')}</span>
+            <span>{t('hero.title.l2')}</span>
+          </h1>
+          <p className={styles.heroLead}>{t('hero.lead')}</p>
+          <div className={styles.heroActions}>
+            <Link className={styles.cta} href={APP_HREF}>
+              {t('hero.cta.primary')}
+            </Link>
+            <a className={`${styles.cta} ${styles.ctaGhost}`} href="#concept">
+              {t('hero.cta.secondary')}
+            </a>
+          </div>
+        </div>
+
+        <div className={styles.heroVisual} aria-hidden="true">
+          <svg
+            viewBox="0 0 520 600"
+            className={styles.jarSvg}
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <defs>
+              <radialGradient id="lpLiquid" cx="50%" cy="60%" r="55%">
+                <stop offset="0%" stopColor="#F9EFD8" />
+                <stop offset="60%" stopColor="#F2EDE0" />
+                <stop offset="100%" stopColor="#E8E1CB" />
+              </radialGradient>
+              <radialGradient id="lpGlow" cx="50%" cy="55%" r="60%">
+                <stop offset="0%" stopColor="#FFF6DC" stopOpacity="0.9" />
+                <stop offset="100%" stopColor="#FFF6DC" stopOpacity="0" />
+              </radialGradient>
+            </defs>
+            <circle cx="260" cy="340" r="240" fill="url(#lpGlow)" />
+            <g>
+              <path
+                d="M 220 110 L 220 218 C 220 244, 124 270, 100 360 C 80 444, 160 510, 260 510 C 360 510, 440 444, 420 360 C 396 270, 300 244, 300 218 L 300 110 Z"
+                fill="url(#lpLiquid)"
+                stroke="#7A7440"
+                strokeWidth="1.6"
+                strokeOpacity="0.55"
+              />
+              <ellipse
+                cx="260"
+                cy="110"
+                rx="40"
+                ry="9"
+                fill="none"
+                stroke="#7A7440"
+                strokeWidth="1.6"
+                strokeOpacity="0.55"
+              />
+            </g>
+            <g>
+              <circle cx="260" cy="298" r="13" fill="#9C9658" opacity="0.55" />
+              <circle cx="260" cy="338" r="10" fill="#9C9658" opacity="0.45" />
+              <circle cx="260" cy="375" r="7" fill="#9C9658" opacity="0.35" />
+              <circle cx="220" cy="320" r="9" fill="#9C9658" opacity="0.45" />
+              <circle cx="220" cy="356" r="7" fill="#9C9658" opacity="0.35" />
+              <circle cx="300" cy="320" r="9" fill="#9C9658" opacity="0.45" />
+              <circle cx="300" cy="356" r="7" fill="#9C9658" opacity="0.35" />
+            </g>
+            <g>
+              <line
+                x1="260"
+                y1="300"
+                x2="80"
+                y2="160"
+                stroke="#7A7440"
+                strokeOpacity="0.18"
+                strokeDasharray="2 4"
+              />
+              <line
+                x1="260"
+                y1="300"
+                x2="450"
+                y2="160"
+                stroke="#7A7440"
+                strokeOpacity="0.18"
+                strokeDasharray="2 4"
+              />
+              <line
+                x1="260"
+                y1="300"
+                x2="60"
+                y2="430"
+                stroke="#7A7440"
+                strokeOpacity="0.18"
+                strokeDasharray="2 4"
+              />
+              <line
+                x1="260"
+                y1="300"
+                x2="475"
+                y2="430"
+                stroke="#7A7440"
+                strokeOpacity="0.18"
+                strokeDasharray="2 4"
+              />
+            </g>
+          </svg>
+
+          <div className={styles.chips}>
+            <div className={`${styles.chip} ${styles.chip1}`}>{t('hero.chip.1')}</div>
+            <div className={`${styles.chip} ${styles.chip2}`}>{t('hero.chip.2')}</div>
+            <div className={`${styles.chip} ${styles.chip3}`}>{t('hero.chip.3')}</div>
+            <div className={`${styles.chip} ${styles.chip4}`}>{t('hero.chip.4')}</div>
+            <div className={styles.snippet}>
+              <span className={styles.snippetIcon} aria-hidden="true">
+                ✉
+              </span>
+              <span>{t('hero.snippet.1')}</span>
+            </div>
+            <div className={styles.questionLabel}>{t('hero.question')}</div>
+          </div>
+        </div>
+      </div>
+
+      <p className={styles.heroFoot}>{t('hero.foot')}</p>
+    </section>
+  );
+}
+
+function Concept({ t }: { t: T }) {
+  return (
+    <section id="concept" className={`${styles.section} ${styles.sectionConcept}`}>
+      <div className={styles.sectionHead}>
+        <p className={styles.kicker}>{t('concept.kicker')}</p>
+        <h2 className={styles.sectionTitle}>{t('concept.title')}</h2>
+      </div>
+      <div className={styles.conceptGrid}>
+        <p className={styles.conceptLead}>{t('concept.lead')}</p>
+        <ul className={styles.conceptPillars}>
+          <li>
+            <span className={styles.pillarNum}>01</span>
+            <h3>{t('concept.p1.title')}</h3>
+            <p>{t('concept.p1.body')}</p>
+          </li>
+          <li>
+            <span className={styles.pillarNum}>02</span>
+            <h3>{t('concept.p2.title')}</h3>
+            <p>{t('concept.p2.body')}</p>
+          </li>
+          <li>
+            <span className={styles.pillarNum}>03</span>
+            <h3>{t('concept.p3.title')}</h3>
+            <p>{t('concept.p3.body')}</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function Process({ t }: { t: T }) {
+  return (
+    <section id="process" className={`${styles.section} ${styles.sectionProcess}`}>
+      <div className={styles.sectionHead}>
+        <p className={styles.kicker}>{t('process.kicker')}</p>
+        <h2 className={styles.sectionTitle}>
+          <span>{t('process.title.l1')}</span>
+          <span className={styles.sectionTitleSub}>{t('process.title.l2')}</span>
+        </h2>
+        <p className={styles.sectionLead}>{t('process.lead')}</p>
+      </div>
+
+      <div className={styles.microbes}>
+        <article className={styles.microbe}>
+          <div className={styles.microbeMark} aria-hidden="true">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <circle
+                cx="50"
+                cy="50"
+                r="34"
+                fill="none"
+                stroke="#7A7440"
+                strokeWidth="1.5"
+                strokeOpacity="0.6"
+              />
+              <g fill="#9C9658">
+                <circle cx="50" cy="38" r="6" />
+                <circle cx="50" cy="56" r="5" />
+                <circle cx="38" cy="48" r="4.5" />
+                <circle cx="62" cy="48" r="4.5" />
+                <circle cx="42" cy="62" r="3.5" />
+                <circle cx="58" cy="62" r="3.5" />
+              </g>
+            </svg>
+          </div>
+          <p className={styles.microbeStep}>01</p>
+          <h3 className={styles.microbeName}>
+            <span className={styles.nameJa}>コウジカビ</span>
+            <span className={styles.nameEn}>Koji</span>
+          </h3>
+          <p className={styles.microbeRole}>{t('process.koji.role')}</p>
+          <p className={styles.microbeBody}>{t('process.koji.body')}</p>
+          <p className={styles.microbeOutput}>{t('process.koji.output')}</p>
+        </article>
+
+        <article className={styles.microbe}>
+          <div className={styles.microbeMark} aria-hidden="true">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <rect
+                x="20"
+                y="32"
+                width="60"
+                height="40"
+                rx="3"
+                fill="#FFFBE0"
+                stroke="#7A7440"
+                strokeWidth="1.5"
+                strokeOpacity="0.6"
+              />
+              <path
+                d="M 20 34 L 50 56 L 80 34"
+                fill="none"
+                stroke="#7A7440"
+                strokeWidth="1.5"
+                strokeOpacity="0.6"
+              />
+              <line
+                x1="32"
+                y1="60"
+                x2="68"
+                y2="60"
+                stroke="#7A7440"
+                strokeOpacity="0.4"
+                strokeWidth="1"
+              />
+              <line
+                x1="32"
+                y1="65"
+                x2="58"
+                y2="65"
+                stroke="#7A7440"
+                strokeOpacity="0.4"
+                strokeWidth="1"
+              />
+            </svg>
+          </div>
+          <p className={styles.microbeStep}>02</p>
+          <h3 className={styles.microbeName}>
+            <span className={styles.nameJa}>乳酸菌</span>
+            <span className={styles.nameEn}>Lactic</span>
+          </h3>
+          <p className={styles.microbeRole}>{t('process.lactic.role')}</p>
+          <p className={styles.microbeBody}>{t('process.lactic.body')}</p>
+          <p className={styles.microbeOutput}>{t('process.lactic.output')}</p>
+        </article>
+
+        <article className={styles.microbe}>
+          <div className={styles.microbeMark} aria-hidden="true">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <g fill="none" stroke="#7A7440" strokeWidth="1.5" strokeOpacity="0.6">
+                <circle cx="34" cy="44" r="9" />
+                <circle cx="60" cy="36" r="7" />
+                <circle cx="58" cy="62" r="11" />
+                <circle cx="38" cy="68" r="6" />
+              </g>
+              <g fill="#E8B838" opacity="0.55">
+                <circle cx="34" cy="44" r="3" />
+                <circle cx="60" cy="36" r="2.5" />
+                <circle cx="58" cy="62" r="3.5" />
+                <circle cx="38" cy="68" r="2" />
+              </g>
+            </svg>
+          </div>
+          <p className={styles.microbeStep}>03</p>
+          <h3 className={styles.microbeName}>
+            <span className={styles.nameJa}>酵母</span>
+            <span className={styles.nameEn}>Yeast</span>
+          </h3>
+          <p className={styles.microbeRole}>{t('process.yeast.role')}</p>
+          <p className={styles.microbeBody}>{t('process.yeast.body')}</p>
+          <p className={styles.microbeOutput}>{t('process.yeast.output')}</p>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+function Preview({ t }: { t: T }) {
+  return (
+    <section id="preview" className={styles.section}>
+      <div className={styles.sectionHead}>
+        <p className={styles.kicker}>{t('preview.kicker')}</p>
+        <h2 className={styles.sectionTitle}>{t('preview.title')}</h2>
+        <p className={styles.sectionLead}>{t('preview.lead')}</p>
+      </div>
+
+      <div className={styles.previews}>
+        <figure className={styles.previewCard}>
+          <div className={styles.windowEl}>
+            <div className={styles.windowRail}>
+              <div className={styles.railBrand}>ORYZAE</div>
+              <div className={styles.railIcons}>
+                <div className={styles.railIcon} />
+                <div className={styles.railIcon} />
+                <div className={styles.railIcon} />
+                <div className={`${styles.railIcon} ${styles.railIconActive}`} />
+              </div>
+              <div className={styles.railAvatar}>D</div>
+            </div>
+            <div className={styles.windowBody}>
+              <div className={styles.windowToolbar}>
+                <span className={styles.toolDate}>2026.5.3 — 日曜日 · 17:33</span>
+                <span className={styles.toolTitle}>{t('preview.editor.title')}</span>
+              </div>
+              <div className={styles.verticalPane}>
+                <p className={styles.verticalText}>{t('preview.editor.prompt')}</p>
+              </div>
+              <div className={styles.windowFoot}>
+                <span>{t('preview.editor.status')}</span>
+                <span>0 CHARS</span>
+              </div>
+            </div>
+          </div>
+          <figcaption>{t('preview.editor.caption')}</figcaption>
+        </figure>
+
+        <figure className={styles.previewCard}>
+          <div className={styles.windowEl}>
+            <div className={`${styles.windowRail} ${styles.railMini}`}>
+              <div className={styles.railIcons}>
+                <div className={`${styles.railIcon} ${styles.railIconActive}`} />
+                <div className={styles.railIcon} />
+                <div className={styles.railIcon} />
+                <div className={styles.railIcon} />
+              </div>
+            </div>
+            <div className={`${styles.windowBody} ${styles.windowBodyJar}`}>
+              <svg
+                viewBox="0 0 520 360"
+                className={styles.jarMini}
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M 230 30 L 230 110 C 230 130, 160 150, 140 220 C 124 280, 200 326, 260 326 C 320 326, 396 280, 380 220 C 360 150, 290 130, 290 110 L 290 30 Z"
+                  fill="#F2EDE0"
+                  stroke="#7A7440"
+                  strokeWidth="1.4"
+                  strokeOpacity="0.55"
+                />
+                <ellipse
+                  cx="260"
+                  cy="30"
+                  rx="30"
+                  ry="6"
+                  fill="none"
+                  stroke="#7A7440"
+                  strokeWidth="1.4"
+                  strokeOpacity="0.55"
+                />
+                <g fill="#9C9658" opacity="0.5">
+                  <circle cx="260" cy="200" r="9" />
+                  <circle cx="240" cy="220" r="6" />
+                  <circle cx="280" cy="220" r="6" />
+                  <circle cx="260" cy="240" r="5" />
+                </g>
+                <line
+                  x1="120"
+                  y1="80"
+                  x2="220"
+                  y2="160"
+                  stroke="#7A7440"
+                  strokeOpacity="0.18"
+                  strokeDasharray="2 3"
+                />
+                <line
+                  x1="420"
+                  y1="80"
+                  x2="300"
+                  y2="160"
+                  stroke="#7A7440"
+                  strokeOpacity="0.18"
+                  strokeDasharray="2 3"
+                />
+                <line
+                  x1="80"
+                  y1="280"
+                  x2="200"
+                  y2="240"
+                  stroke="#7A7440"
+                  strokeOpacity="0.18"
+                  strokeDasharray="2 3"
+                />
+                <line
+                  x1="460"
+                  y1="280"
+                  x2="320"
+                  y2="240"
+                  stroke="#7A7440"
+                  strokeOpacity="0.18"
+                  strokeDasharray="2 3"
+                />
+              </svg>
+              <div className={styles.jarMiniChips}>
+                <span className={`${styles.miniChip} ${styles.mc1}`}>
+                  {t('preview.jar.chip.1')}
+                </span>
+                <span className={`${styles.miniChip} ${styles.mc2}`}>
+                  {t('preview.jar.chip.2')}
+                </span>
+                <span className={`${styles.miniChip} ${styles.mc3}`}>
+                  {t('preview.jar.chip.3')}
+                </span>
+                <span className={`${styles.miniChip} ${styles.mc4}`}>
+                  {t('preview.jar.chip.4')}
+                </span>
+              </div>
+              <p className={styles.jarMiniLabel}>{t('preview.jar.label')}</p>
+            </div>
+          </div>
+          <figcaption>{t('preview.jar.caption')}</figcaption>
+        </figure>
+
+        <figure className={`${styles.previewCard} ${styles.previewLetter}`}>
+          <div className={styles.letterPaper}>
+            <p className={styles.letterHeader}>
+              <span className={styles.letterFrom}>{t('preview.letter.from')}</span>
+              <span>2026.05.03</span>
+            </p>
+            <p className={styles.letterBody}>{t('preview.letter.body')}</p>
+            <p className={styles.letterFoot}>
+              <span className={styles.letterStamp} aria-hidden="true">
+                ●
+              </span>
+            </p>
+          </div>
+          <figcaption>{t('preview.letter.caption')}</figcaption>
+        </figure>
+      </div>
+    </section>
+  );
+}
+
+function Philosophy({ t }: { t: T }) {
+  return (
+    <section id="philosophy" className={`${styles.section} ${styles.sectionPhilosophy}`}>
+      <div className={styles.sectionHead}>
+        <p className={styles.kicker}>{t('philosophy.kicker')}</p>
+        <h2 className={styles.sectionTitle}>{t('philosophy.title')}</h2>
+      </div>
+
+      <div className={styles.principles}>
+        {(['1', '2', '3', '4'] as const).map((n, idx) => (
+          <div key={n} className={styles.principle}>
+            <p className={styles.principleNum}>{['i', 'ii', 'iii', 'iv'][idx]}</p>
+            <h3>{t(`philo.${n}.title`)}</h3>
+            <p>{t(`philo.${n}.body`)}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.lineage}>
+        <p className={styles.lineageLabel}>{t('philo.lineage.label')}</p>
+        <p className={styles.lineageBody}>{t('philo.lineage.body')}</p>
+        <p className={styles.lineageLinks}>
+          <a
+            href="https://github.com/ephemere-io/pickles"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/ephemere-io/pickles
+          </a>
+          <span className={styles.lineageDot}>·</span>
+          <a href="https://ephemere.io" target="_blank" rel="noopener noreferrer">
+            ephemere.io
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function Faq({ t }: { t: T }) {
+  return (
+    <section id="faq" className={`${styles.section} ${styles.sectionFaq}`}>
+      <div className={styles.sectionHead}>
+        <p className={styles.kicker}>{t('faq.kicker')}</p>
+        <h2 className={styles.sectionTitle}>{t('faq.title')}</h2>
+      </div>
+      <ul className={styles.faqList}>
+        {(['1', '2', '3', '4', '5'] as const).map((n) => (
+          <LandingFaqItem key={n} question={t(`faq.${n}.q`)} answer={t(`faq.${n}.a`)} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function Outro({ t }: { t: T }) {
+  return (
+    <section className={styles.outro}>
+      <h2 className={styles.outroTitle}>
+        <span>{t('outro.l1')}</span>
+        <span>{t('outro.l2')}</span>
+      </h2>
+      <Link className={`${styles.cta} ${styles.ctaBig}`} href={APP_HREF}>
+        {t('outro.cta')}
+      </Link>
+    </section>
+  );
+}
+
+function SiteFooter({ t }: { t: T }) {
+  return (
+    <footer className={styles.siteFooter}>
+      <div className={styles.footGrid}>
+        <div>
+          {/* biome-ignore lint/performance/noImgElement: small inline SVG, next/image overkill */}
+          <img src={LOGO_SRC} alt="" className={styles.footMark} />
+          <p className={styles.footName}>Oryzae</p>
+          <p className={styles.footTag}>{t('foot.tag')}</p>
+        </div>
+        <nav className={styles.footNav} aria-label="footer">
+          <a href="#concept">{t('nav.concept')}</a>
+          <a href="#process">{t('nav.process')}</a>
+          <a href="#preview">{t('nav.preview')}</a>
+          <a href="#philosophy">{t('nav.philosophy')}</a>
+          <a href="#faq">{t('nav.faq')}</a>
+        </nav>
+        <div className={styles.footMeta}>
+          <p>© 2026 Ephemere</p>
+          <p>
+            <a href="https://ephemere.io" target="_blank" rel="noopener noreferrer">
+              ephemere.io
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/client/src/features/landing/components/landing.module.css
+++ b/apps/client/src/features/landing/components/landing.module.css
@@ -1,0 +1,1125 @@
+/* =====================================================
+   Oryzae Landing Page — scoped styles (CSS module)
+   Original palette inspired by P3-OliveMoss & the running app.
+   ===================================================== */
+
+.landingRoot {
+  /* paper & ink */
+  --lp-paper: #f9f8f4;
+  --lp-paper-2: #f2ede0;
+  --lp-paper-3: #fffdf8;
+  --lp-ink: #2d2d2d;
+  --lp-ink-soft: #5c4f3f;
+  --lp-ink-muted: #877e6e;
+
+  /* olive moss palette */
+  --lp-olive: #7a7440;
+  --lp-olive-light: #9c9658;
+  --lp-olive-soft: #b8b289;
+  --lp-gold: #e8b838;
+  --lp-moss: #4a9e8e;
+
+  /* snippet & utility */
+  --lp-snippet: #fffbe0;
+  --lp-line: rgba(42, 33, 26, 0.1);
+  --lp-line-strong: rgba(42, 33, 26, 0.18);
+  --lp-shadow: 0 30px 60px -40px rgba(60, 50, 30, 0.3);
+
+  /* type */
+  --lp-serif-jp: "Shippori Mincho", "Noto Serif JP", serif;
+  --lp-serif-jp-body: "Noto Serif JP", "Shippori Mincho", serif;
+  --lp-sans: "Inter", system-ui, -apple-system, "Helvetica Neue", sans-serif;
+  --lp-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+
+  --lp-maxw: 1240px;
+  --lp-gutter: clamp(20px, 5vw, 64px);
+
+  background: var(--lp-paper);
+  color: var(--lp-ink);
+  font-family: var(--lp-sans);
+  font-size: 16px;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.landingRoot * {
+  box-sizing: border-box;
+}
+
+html[lang="ja"] .landingRoot {
+  font-family: var(--lp-serif-jp-body);
+  font-weight: 400;
+}
+
+.landingRoot img,
+.landingRoot svg {
+  display: block;
+  max-width: 100%;
+}
+
+.landingRoot a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.landingRoot a:hover {
+  color: var(--lp-olive);
+}
+
+/* ============== HEADER ============== */
+.siteHeader {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 3vw, 32px);
+  padding: 18px var(--lp-gutter);
+  background: rgba(249, 248, 244, 0.85);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  border-bottom: 1px solid var(--lp-line);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.brandMark {
+  width: 32px;
+  height: 32px;
+}
+.brandName {
+  font-family: var(--lp-serif-jp);
+  font-weight: 600;
+  font-size: 19px;
+  letter-spacing: 0.02em;
+}
+.siteNav {
+  display: flex;
+  gap: clamp(10px, 2vw, 28px);
+  margin-left: auto;
+}
+.siteNav a {
+  font-family: var(--lp-sans);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: var(--lp-ink-soft);
+  padding: 6px 2px;
+  transition: color 0.2s;
+}
+.siteNav a:hover {
+  color: var(--lp-olive);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.langToggle {
+  display: inline-flex;
+  border: 1px solid var(--lp-line-strong);
+  border-radius: 999px;
+  padding: 2px;
+  background: var(--lp-paper-3);
+}
+.langBtn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font-family: var(--lp-sans);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  padding: 5px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--lp-ink-soft);
+  transition: all 0.2s;
+}
+.langBtn[aria-pressed="true"] {
+  background: var(--lp-olive);
+  color: #fff;
+}
+
+/* CTA */
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--lp-sans);
+  font-weight: 500;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  padding: 13px 26px;
+  background: var(--lp-ink);
+  color: #fff;
+  border-radius: 999px;
+  border: 1px solid var(--lp-ink);
+  transition: all 0.25s ease;
+  white-space: nowrap;
+}
+.cta:hover {
+  background: var(--lp-olive);
+  border-color: var(--lp-olive);
+  color: #fff;
+  transform: translateY(-1px);
+}
+.ctaSmall {
+  padding: 9px 18px;
+  font-size: 12.5px;
+}
+.ctaBig {
+  padding: 18px 38px;
+  font-size: 16px;
+}
+.ctaGhost {
+  background: transparent;
+  color: var(--lp-ink);
+  border: 1px solid var(--lp-line-strong);
+}
+.ctaGhost:hover {
+  background: var(--lp-paper-2);
+  color: var(--lp-ink);
+  border-color: var(--lp-olive);
+  transform: translateY(-1px);
+}
+
+/* ============== HERO ============== */
+.hero {
+  padding: clamp(50px, 10vh, 110px) var(--lp-gutter) clamp(60px, 12vh, 120px);
+  position: relative;
+}
+.heroGrid {
+  max-width: var(--lp-maxw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  gap: clamp(40px, 6vw, 96px);
+  align-items: center;
+}
+.eyebrow {
+  font-family: var(--lp-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--lp-olive);
+  margin: 0 0 28px;
+}
+.heroTitle {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: clamp(38px, 5.6vw, 76px);
+  line-height: 1.18;
+  letter-spacing: 0.01em;
+  margin: 0 0 28px;
+  color: var(--lp-ink);
+}
+.heroTitle span {
+  display: block;
+}
+.heroLead {
+  font-size: 16px;
+  line-height: 1.95;
+  color: var(--lp-ink-soft);
+  max-width: 540px;
+  margin: 0 0 36px;
+}
+html[lang="en"] .heroLead {
+  font-family: var(--lp-sans);
+}
+.heroActions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.heroFoot {
+  max-width: var(--lp-maxw);
+  margin: clamp(40px, 6vw, 80px) auto 0;
+  text-align: center;
+  font-family: var(--lp-mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--lp-ink-muted);
+}
+
+.heroVisual {
+  position: relative;
+  aspect-ratio: 1 / 1.05;
+  width: 100%;
+}
+.jarSvg {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 30px 60px rgba(122, 116, 64, 0.18));
+  animation: lpDrift 14s ease-in-out infinite alternate;
+}
+@keyframes lpDrift {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-8px);
+  }
+}
+
+/* floating chips overlay on the jar */
+.chips {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.chip {
+  position: absolute;
+  font-family: var(--lp-serif-jp);
+  font-size: 13px;
+  padding: 7px 14px;
+  background: rgba(255, 253, 248, 0.95);
+  border: 1px solid var(--lp-line-strong);
+  border-radius: 999px;
+  color: var(--lp-olive);
+  box-shadow: var(--lp-shadow);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  animation: lpFloat 9s ease-in-out infinite alternate;
+}
+@keyframes lpFloat {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-6px);
+  }
+}
+.chip1 {
+  top: 18%;
+  left: 4%;
+  animation-delay: -1s;
+}
+.chip2 {
+  top: 12%;
+  right: 8%;
+  animation-delay: -3s;
+}
+.chip3 {
+  bottom: 24%;
+  left: 1%;
+  animation-delay: -5s;
+}
+.chip4 {
+  bottom: 18%;
+  right: 0%;
+  animation-delay: -7s;
+}
+
+.snippet {
+  position: absolute;
+  bottom: 6%;
+  right: 4%;
+  max-width: 220px;
+  font-size: 11px;
+  line-height: 1.7;
+  background: var(--lp-snippet);
+  border: 1px solid var(--lp-line-strong);
+  border-radius: 6px;
+  padding: 10px 12px 10px 30px;
+  color: var(--lp-ink-soft);
+  box-shadow: var(--lp-shadow);
+}
+.snippetIcon {
+  position: absolute;
+  left: 10px;
+  top: 9px;
+  font-size: 12px;
+  color: var(--lp-olive);
+}
+.questionLabel {
+  position: absolute;
+  bottom: 26%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  color: var(--lp-ink-muted);
+  text-transform: uppercase;
+}
+
+/* ============== SECTIONS ============== */
+.section {
+  padding: clamp(80px, 12vh, 140px) var(--lp-gutter);
+  max-width: var(--lp-maxw);
+  margin: 0 auto;
+}
+.section + .section {
+  padding-top: 0;
+}
+.sectionHead {
+  max-width: 760px;
+  margin: 0 auto 64px;
+  text-align: center;
+}
+.sectionHead .sectionTitle {
+  text-align: center;
+}
+.kicker {
+  font-family: var(--lp-mono);
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--lp-olive);
+  margin: 0 0 18px;
+}
+.sectionTitle {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: clamp(28px, 3.6vw, 46px);
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+  margin: 0;
+  color: var(--lp-ink);
+}
+.sectionTitleSub {
+  display: block;
+  font-size: 0.55em;
+  color: var(--lp-ink-muted);
+  margin-top: 10px;
+  letter-spacing: 0.06em;
+}
+.sectionLead {
+  margin: 22px auto 0;
+  max-width: 620px;
+  font-size: 15px;
+  color: var(--lp-ink-soft);
+  line-height: 1.95;
+}
+
+/* ============== CONCEPT ============== */
+.sectionConcept {
+  border-top: 1px solid var(--lp-line);
+}
+.conceptGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(40px, 6vw, 80px);
+  align-items: start;
+}
+.conceptLead {
+  font-family: var(--lp-serif-jp-body);
+  font-size: clamp(17px, 1.7vw, 21px);
+  line-height: 2.1;
+  color: var(--lp-ink);
+  max-width: 820px;
+  margin: 0 auto;
+  text-align: left;
+}
+.conceptPillars {
+  list-style: none;
+  padding: 0;
+  margin: 40px 0 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(24px, 3vw, 48px);
+}
+.conceptPillars li {
+  border-top: 1px solid var(--lp-line);
+  padding-top: 22px;
+}
+.pillarNum {
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--lp-olive);
+  display: block;
+  margin-bottom: 10px;
+}
+.conceptPillars h3 {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: 22px;
+  margin: 0 0 12px;
+  color: var(--lp-ink);
+}
+.conceptPillars p {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.85;
+  color: var(--lp-ink-soft);
+}
+
+/* ============== PROCESS / MICROBES ============== */
+.sectionProcess {
+  background: linear-gradient(
+    180deg,
+    var(--lp-paper) 0%,
+    var(--lp-paper-2) 60%,
+    var(--lp-paper) 100%
+  );
+  max-width: none;
+  padding-left: var(--lp-gutter);
+  padding-right: var(--lp-gutter);
+}
+.sectionProcess .sectionHead,
+.sectionProcess .microbes {
+  max-width: var(--lp-maxw);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.microbes {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(20px, 2.5vw, 36px);
+}
+.microbe {
+  background: var(--lp-paper-3);
+  border: 1px solid var(--lp-line);
+  border-radius: 14px;
+  padding: clamp(28px, 3vw, 40px);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  transition:
+    transform 0.3s,
+    box-shadow 0.3s;
+}
+.microbe:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--lp-shadow);
+}
+.microbeMark {
+  width: 70px;
+  height: 70px;
+  margin-bottom: 22px;
+}
+.microbeMark svg {
+  width: 100%;
+  height: 100%;
+}
+.microbeStep {
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--lp-olive);
+  margin: 0 0 10px;
+}
+.microbeName {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: 26px;
+  margin: 0 0 4px;
+  color: var(--lp-ink);
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+}
+.microbeName .nameJa {
+  /* default JA on top */
+}
+.microbeName .nameEn {
+  font-family: var(--lp-sans);
+  font-weight: 300;
+  font-size: 15px;
+  color: var(--lp-ink-muted);
+  letter-spacing: 0.04em;
+}
+html[lang="en"] .microbeName .nameJa {
+  font-size: 17px;
+  color: var(--lp-ink-muted);
+  font-weight: 400;
+  order: 2;
+}
+html[lang="en"] .microbeName .nameEn {
+  order: 1;
+  font-size: 26px;
+  color: var(--lp-ink);
+  font-weight: 500;
+}
+.microbeRole {
+  font-family: var(--lp-mono);
+  font-size: 11.5px;
+  color: var(--lp-olive);
+  letter-spacing: 0.05em;
+  margin: 14px 0 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--lp-line);
+}
+.microbeBody {
+  margin: 0 0 22px;
+  font-size: 14.5px;
+  line-height: 1.9;
+  color: var(--lp-ink-soft);
+}
+.microbeOutput {
+  margin-top: auto;
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  color: var(--lp-ink-muted);
+  letter-spacing: 0.04em;
+  padding-top: 14px;
+  border-top: 1px dashed var(--lp-line);
+}
+
+/* ============== APP PREVIEW ============== */
+.previews {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(28px, 3vw, 48px);
+  align-items: start;
+}
+.previewCard {
+  margin: 0;
+}
+.previewLetter {
+  grid-column: 1 / -1;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.windowEl {
+  background: var(--lp-paper-3);
+  border: 1px solid var(--lp-line);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--lp-shadow);
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  min-height: 360px;
+}
+.windowRail {
+  background: linear-gradient(180deg, #faf8f2 0%, #f2ede0 100%);
+  border-right: 1px solid var(--lp-line);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 18px 0;
+  gap: 22px;
+}
+.railBrand {
+  font-family: var(--lp-serif-jp);
+  font-size: 9px;
+  letter-spacing: 0.45em;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  color: var(--lp-olive);
+  margin-bottom: 8px;
+}
+.railIcons {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.railIcon {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: rgba(122, 116, 64, 0.18);
+  position: relative;
+}
+.railIcon::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: 1.5px solid var(--lp-olive);
+  border-radius: 2px;
+  opacity: 0.5;
+}
+.railIconActive {
+  background: rgba(74, 158, 142, 0.12);
+  outline: 1px solid rgba(74, 158, 142, 0.5);
+}
+.railIconActive::after {
+  border-color: var(--lp-moss);
+  opacity: 0.85;
+}
+.railAvatar {
+  margin-top: auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--lp-moss);
+  color: #fff;
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  letter-spacing: 0;
+}
+.railMini {
+  padding-top: 22px;
+}
+
+.windowBody {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 360px;
+}
+.windowToolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid var(--lp-line);
+}
+.toolDate {
+  font-family: var(--lp-mono);
+  font-size: 10.5px;
+  color: var(--lp-ink-muted);
+  letter-spacing: 0.04em;
+}
+.toolTitle {
+  font-family: var(--lp-serif-jp);
+  font-size: 13px;
+  color: var(--lp-ink-muted);
+  margin-top: 4px;
+}
+.verticalPane {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 28px 36px 8px;
+  overflow: hidden;
+}
+.verticalText {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-family: var(--lp-serif-jp-body);
+  font-size: 22px;
+  line-height: 1.7;
+  letter-spacing: 0.06em;
+  color: rgba(45, 45, 45, 0.35);
+  margin: 0;
+}
+html[lang="en"] .verticalText {
+  writing-mode: horizontal-tb;
+  font-family: var(--lp-serif-jp-body);
+}
+.windowFoot {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 18px;
+  font-family: var(--lp-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--lp-ink-muted);
+  border-top: 1px solid var(--lp-line);
+}
+
+/* Jar mock */
+.windowBodyJar {
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  text-align: center;
+  min-height: 360px;
+  position: relative;
+}
+.jarMini {
+  width: min(100%, 460px);
+  height: auto;
+}
+.jarMiniChips {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.miniChip {
+  position: absolute;
+  font-family: var(--lp-serif-jp);
+  font-size: 11px;
+  padding: 5px 10px;
+  background: rgba(255, 253, 248, 0.95);
+  border: 1px solid var(--lp-line);
+  border-radius: 999px;
+  color: var(--lp-olive);
+  letter-spacing: 0.04em;
+  box-shadow: 0 6px 20px -10px rgba(60, 50, 30, 0.25);
+  white-space: nowrap;
+}
+.mc1 {
+  top: 18%;
+  left: 8%;
+}
+.mc2 {
+  top: 12%;
+  right: 10%;
+}
+.mc3 {
+  bottom: 28%;
+  left: 4%;
+}
+.mc4 {
+  bottom: 22%;
+  right: 6%;
+}
+.jarMiniLabel {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--lp-mono);
+  font-size: 10px;
+  color: var(--lp-ink-muted);
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  max-width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Letter mock */
+.letterPaper {
+  background: linear-gradient(180deg, #fffdf4 0%, #fbf5e2 100%);
+  border: 1px solid var(--lp-line);
+  border-radius: 8px;
+  padding: clamp(32px, 4vw, 56px) clamp(28px, 5vw, 64px);
+  box-shadow: var(--lp-shadow);
+  position: relative;
+}
+.letterPaper::before {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border: 1px dashed rgba(122, 116, 64, 0.18);
+  border-radius: 4px;
+  pointer-events: none;
+}
+.letterHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin: 0 0 28px;
+  font-family: var(--lp-mono);
+  font-size: 11.5px;
+  color: var(--lp-olive);
+  letter-spacing: 0.04em;
+}
+.letterFrom {
+  font-family: var(--lp-serif-jp);
+  font-size: 14px;
+  color: var(--lp-olive);
+  letter-spacing: 0.02em;
+}
+.letterBody {
+  font-family: var(--lp-serif-jp-body);
+  font-size: 15.5px;
+  line-height: 2.1;
+  color: var(--lp-ink);
+  margin: 0;
+  text-align: justify;
+}
+.letterFoot {
+  text-align: right;
+  margin: 24px 0 0;
+}
+.letterStamp {
+  color: var(--lp-gold);
+  font-size: 14px;
+}
+
+.previewCard figcaption {
+  margin: 18px 4px 0;
+  font-size: 13px;
+  color: var(--lp-ink-muted);
+  font-family: var(--lp-mono);
+  letter-spacing: 0.02em;
+  line-height: 1.7;
+}
+html[lang="ja"] .previewCard figcaption {
+  font-family: var(--lp-serif-jp-body);
+  font-size: 13.5px;
+  letter-spacing: 0.04em;
+}
+
+/* ============== PHILOSOPHY ============== */
+.sectionPhilosophy {
+  border-top: 1px solid var(--lp-line);
+  padding-top: clamp(80px, 12vh, 140px);
+}
+.principles {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(28px, 3vw, 56px);
+  max-width: 920px;
+  margin: 0 auto;
+}
+.principle {
+  border-top: 1px solid var(--lp-line);
+  padding-top: 24px;
+}
+.principleNum {
+  font-family: var(--lp-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--lp-olive);
+  margin: 0 0 12px;
+}
+.principle h3 {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: 22px;
+  margin: 0 0 14px;
+  color: var(--lp-ink);
+}
+.principle p {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.95;
+  color: var(--lp-ink-soft);
+}
+
+.lineage {
+  margin: clamp(56px, 8vw, 96px) auto 0;
+  text-align: center;
+  max-width: 640px;
+  padding: clamp(28px, 3vw, 44px) clamp(24px, 4vw, 56px);
+  border: 1px dashed var(--lp-line-strong);
+  border-radius: 12px;
+  background: rgba(242, 237, 224, 0.4);
+}
+.lineageLabel {
+  font-family: var(--lp-mono);
+  font-size: 11px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--lp-olive);
+  margin: 0 0 14px;
+}
+.lineageBody {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.95;
+  color: var(--lp-ink-soft);
+}
+.lineageLinks {
+  margin: 18px 0 0;
+  font-family: var(--lp-mono);
+  font-size: 12px;
+  color: var(--lp-ink-muted);
+}
+.lineageLinks a {
+  color: var(--lp-olive);
+  border-bottom: 1px solid var(--lp-line);
+  padding-bottom: 1px;
+}
+.lineageLinks a:hover {
+  color: var(--lp-ink);
+  border-bottom-color: var(--lp-olive);
+}
+.lineageDot {
+  margin: 0 12px;
+  opacity: 0.5;
+}
+
+/* ============== FAQ ============== */
+.sectionFaq {
+  border-top: 1px solid var(--lp-line);
+  padding-top: clamp(80px, 12vh, 140px);
+}
+.faqList {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
+  max-width: 800px;
+}
+.faqItem {
+  border-top: 1px solid var(--lp-line);
+}
+.faqItem:last-child {
+  border-bottom: 1px solid var(--lp-line);
+}
+.faqQ {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  padding: 22px 4px;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--lp-serif-jp);
+  font-size: 17px;
+  color: var(--lp-ink);
+  transition: color 0.2s;
+}
+.faqQ:hover {
+  color: var(--lp-olive);
+}
+.faqToggle {
+  font-family: var(--lp-mono);
+  font-size: 22px;
+  font-weight: 300;
+  color: var(--lp-olive);
+  transition: transform 0.3s;
+}
+.faqQ[aria-expanded="true"] .faqToggle {
+  transform: rotate(45deg);
+}
+.faqA {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.faqQ[aria-expanded="true"] + .faqA {
+  max-height: 400px;
+}
+.faqA p {
+  margin: 0;
+  padding: 0 4px 24px;
+  font-size: 14.5px;
+  line-height: 1.95;
+  color: var(--lp-ink-soft);
+}
+
+/* ============== OUTRO ============== */
+.outro {
+  text-align: center;
+  padding: clamp(100px, 14vh, 180px) var(--lp-gutter);
+  background: var(--lp-paper-2);
+  margin-top: clamp(80px, 12vh, 140px);
+}
+.outroTitle {
+  font-family: var(--lp-serif-jp);
+  font-weight: 500;
+  font-size: clamp(28px, 4.2vw, 56px);
+  line-height: 1.4;
+  margin: 0 0 44px;
+  color: var(--lp-ink);
+}
+.outroTitle span {
+  display: block;
+}
+
+/* ============== FOOTER ============== */
+.siteFooter {
+  border-top: 1px solid var(--lp-line);
+  padding: clamp(40px, 6vh, 64px) var(--lp-gutter);
+}
+.footGrid {
+  max-width: var(--lp-maxw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.2fr 2fr 1fr;
+  gap: clamp(24px, 4vw, 48px);
+  align-items: start;
+}
+.footMark {
+  width: 36px;
+  height: 36px;
+  margin-bottom: 8px;
+}
+.footName {
+  font-family: var(--lp-serif-jp);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.footTag {
+  margin: 0;
+  font-family: var(--lp-mono);
+  font-size: 11.5px;
+  color: var(--lp-olive);
+  letter-spacing: 0.04em;
+}
+.footNav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 24px;
+  font-size: 13px;
+  color: var(--lp-ink-soft);
+}
+.footNav a:hover {
+  color: var(--lp-olive);
+}
+.footMeta {
+  font-family: var(--lp-mono);
+  font-size: 11.5px;
+  color: var(--lp-ink-muted);
+  text-align: right;
+  line-height: 2;
+}
+.footMeta a {
+  color: var(--lp-olive);
+}
+
+/* ============== RESPONSIVE ============== */
+@media (max-width: 960px) {
+  .heroGrid {
+    grid-template-columns: 1fr;
+  }
+  .heroVisual {
+    aspect-ratio: 1 / 0.95;
+    max-width: 460px;
+    margin: 30px auto 0;
+  }
+  .conceptPillars {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+  .microbes {
+    grid-template-columns: 1fr;
+  }
+  .previews {
+    grid-template-columns: 1fr;
+  }
+  .principles {
+    grid-template-columns: 1fr;
+  }
+  .footGrid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .footMeta {
+    text-align: left;
+  }
+  .siteNav {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .headerActions .ctaSmall {
+    display: none;
+  }
+  .langBtn {
+    font-size: 10.5px;
+    padding: 5px 9px;
+  }
+  .heroTitle {
+    font-size: 38px;
+  }
+  .chip {
+    font-size: 11px;
+    padding: 5px 10px;
+  }
+  .snippet {
+    max-width: 170px;
+    font-size: 10px;
+  }
+  .windowRail {
+    width: 44px;
+  }
+  .windowEl {
+    grid-template-columns: 44px 1fr;
+  }
+  .verticalText {
+    font-size: 18px;
+  }
+}
+
+/* prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .landingRoot *,
+  .landingRoot *::before,
+  .landingRoot *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/apps/client/src/features/landing/components/landing.module.css
+++ b/apps/client/src/features/landing/components/landing.module.css
@@ -58,12 +58,12 @@ html[lang="ja"] .landingRoot {
   max-width: 100%;
 }
 
-.landingRoot a {
+.landingRoot a:not(.cta) {
   color: inherit;
   text-decoration: none;
 }
 
-.landingRoot a:hover {
+.landingRoot a:not(.cta):hover {
   color: var(--lp-olive);
 }
 

--- a/apps/client/src/features/landing/hooks/use-landing-i18n.ts
+++ b/apps/client/src/features/landing/hooks/use-landing-i18n.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { LANDING_I18N, LANDING_TITLES } from '../i18n';
+import { isLandingLang, type LandingLang } from '../types';
+
+export const LANDING_LANG_STORAGE_KEY = 'oryzae-lp-lang';
+
+function readStoredLang(): LandingLang | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const saved = window.localStorage.getItem(LANDING_LANG_STORAGE_KEY);
+    if (saved && isLandingLang(saved)) return saved;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function readUrlLang(): LandingLang | null {
+  if (typeof window === 'undefined') return null;
+  const url = new URL(window.location.href);
+  const q = url.searchParams.get('lang');
+  if (q && isLandingLang(q)) return q;
+  return null;
+}
+
+function readNavigatorLang(): LandingLang {
+  if (typeof navigator === 'undefined') return 'ja';
+  const langs =
+    navigator.languages && navigator.languages.length > 0
+      ? navigator.languages
+      : [navigator.language || ''];
+  for (const l of langs) {
+    if (!l) continue;
+    const code = l.toLowerCase().split('-')[0];
+    if (code === 'ja') return 'ja';
+    if (code === 'en') return 'en';
+  }
+  return 'ja';
+}
+
+export function detectInitialLang(): LandingLang {
+  return readStoredLang() ?? readUrlLang() ?? readNavigatorLang();
+}
+
+interface UseLandingI18n {
+  lang: LandingLang;
+  setLang: (lang: LandingLang) => void;
+  t: (key: string) => string;
+}
+
+export function useLandingI18n(): UseLandingI18n {
+  const [lang, setLangState] = useState<LandingLang>('ja');
+
+  useEffect(() => {
+    setLangState(detectInitialLang());
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.lang = lang;
+    document.title = LANDING_TITLES[lang];
+  }, [lang]);
+
+  const setLang = useCallback((next: LandingLang) => {
+    setLangState(next);
+    try {
+      window.localStorage.setItem(LANDING_LANG_STORAGE_KEY, next);
+    } catch {
+      // ignore storage failures (private browsing, quota)
+    }
+  }, []);
+
+  const t = useCallback(
+    (key: string) => {
+      const dict = LANDING_I18N[lang];
+      return dict[key] ?? key;
+    },
+    [lang],
+  );
+
+  return { lang, setLang, t };
+}

--- a/apps/client/src/features/landing/i18n.ts
+++ b/apps/client/src/features/landing/i18n.ts
@@ -1,0 +1,248 @@
+import type { LandingLang } from './types';
+
+type LandingDict = Record<string, string>;
+
+const ja: LandingDict = {
+  'nav.concept': 'コンセプト',
+  'nav.process': '発酵の三段',
+  'nav.preview': 'アプリ',
+  'nav.philosophy': '思想',
+  'nav.faq': 'FAQ',
+  'nav.cta': 'アプリを試す',
+
+  'hero.eyebrow': 'AN ASPERGILLUS FOR WORDS.',
+  'hero.title.l1': '書くことを、',
+  'hero.title.l2': '発酵させる。',
+  'hero.lead':
+    'Oryzaeは、日々の言葉を醸成し、あなたの問いを深める執筆の場です。コウジカビが澱粉を糖に変えるように、書かれた文章を分解し、問いの核となる切片と、ひと通の手紙を返します。',
+  'hero.cta.primary': 'アプリを試す',
+  'hero.cta.secondary': 'コンセプトを読む',
+  'hero.foot': '縦書き・横書きいずれにも対応。日本語と英語で書き、考える人のための場。',
+  'hero.chip.1': '死者の自律性',
+  'hero.chip.2': '発酵的時間',
+  'hero.chip.3': '媒介者',
+  'hero.chip.4': '忘却の倫理',
+  'hero.snippet.1': '「ぬか床が徐々に人の影響を吸収するように、AIもまた変化していく…」',
+  'hero.question': '現在の問い',
+
+  'concept.kicker': 'CONCEPT',
+  'concept.title': '問いを、書きながら醸成する。',
+  'concept.lead':
+    'Oryzaeは「問い」を中心に据えた執筆アプリです。あなたが今いちばん考えたい問いをひとつ立て、その問いに沿って一週間日記を書く。週末、コウジカビ・乳酸菌・酵母の三段階を経てAIが文章を分解し、ふたたびあなたへ手渡します。要約ではなく、思考を進めるためのささやかなインスピレーションとして。',
+  'concept.p1.title': '問いを立てる',
+  'concept.p1.body': 'いま気になっていることを一文の問いとして書き留める。これが発酵の中核となる。',
+  'concept.p2.title': '日々書く',
+  'concept.p2.body':
+    '縦書きの白い紙に、思いついたことをそのまま綴る。誤字も、寄り道も、書いた跡として残る。',
+  'concept.p3.title': '手紙が届く',
+  'concept.p3.body':
+    '週ごとに、あなた自身の言葉から醸成された手紙とキーワードが返ってくる。読むのは、また書きはじめるため。',
+
+  'process.kicker': 'THREE MICROBES',
+  'process.title.l1': 'コウジカビ・乳酸菌・酵母',
+  'process.title.l2': '— 発酵の三段',
+  'process.lead':
+    'Oryzaeの内部では、糠床のような三つの微生物がそれぞれ別の役割を担い、あなたの一週間の言葉を醸成する。',
+  'process.koji.role': '分解 — Decomposition',
+  'process.koji.body':
+    '一週間ぶんの日記を、立てた問いに照らして読み解く。修正版グラウンデッド・セオリー・アプローチを参照しながら、原文から問いの核に触れる切片を抽出する。',
+  'process.koji.output': '出力：分析ワークシート、結果図、問いを照らす切片',
+  'process.lactic.role': '手紙 — A letter',
+  'process.lactic.body':
+    '切片とワークシートを参照して、問いをめぐる思考の変化を整理する。要約ではなく、書き手の語彙からあえてずらした言葉で、500字ほどの詩的なコメントが綴られる。',
+  'process.lactic.output': '出力：500字の手紙',
+  'process.yeast.role': 'キーワード — Widening',
+  'process.yeast.body':
+    '問いに囚われすぎないよう、視点を少し引いた角度から差し出すための語が3〜5つ生成される。「死者の自律性」「生者による死者の活性」のような短いフレーズが、想像の余白を広げる。',
+  'process.yeast.output': '出力：3〜5のキーワード',
+
+  'preview.kicker': 'THE APP',
+  'preview.title': '三つの場所で書く。',
+  'preview.lead':
+    'Oryzaeのアプリは、書く・眺める・受け取るを別々の場所として用意している。日々の手は「Editor」へ。一週間ごとの俯瞰は「Jar」へ。',
+  'preview.editor.title': 'タイトルを追加',
+  'preview.editor.prompt': '今日は何を感じましたか？',
+  'preview.editor.status': '編集中',
+  'preview.editor.caption': 'Editor — 縦書きの白い紙、日本語IMEに最適化された静かな執筆面。',
+  'preview.jar.chip.1': '却像的距離感',
+  'preview.jar.chip.2': '認知的聖域',
+  'preview.jar.chip.3': '霊的代行者',
+  'preview.jar.chip.4': '与格的関係',
+  'preview.jar.label': '現在の問い · 自然環境を身に宿すためのデザインとは？',
+  'preview.jar.caption': 'Jar — 一週間の言葉が問いを軸に星座となって浮かび上がる眺め。',
+  'preview.letter.from': '— Oryzae より、第18週の手紙',
+  'preview.letter.body':
+    'あなたは「死者と生者はどのように共生し続けられるのか」という問いの周りを、一週間ゆっくりと歩いていた。夢のなかで現れたYは、しゅるしゅると胎児にまで縮みながら去ったという。それは喪失の場面であると同時に、起源への回帰であり、円環としての生死観をかすかに照らしている。書き手はこの一週間、分析ではない仕方で大切な存在に向き合うことの必要に気づきはじめている。忘却もまた、共生のひとつのかたちかもしれない、と。',
+  'preview.letter.caption':
+    'Letter — 週ごとに届く、500字の手紙。要約ではなく、書き続けるためのちいさな種火。',
+
+  'philosophy.kicker': 'PHILOSOPHY',
+  'philosophy.title': '道具は、卒業されるためにある。',
+  'philo.1.title': '身体性の回復',
+  'philo.1.body':
+    '縦書きと余白、明朝体。デジタルの整理整頓よりも、たしかに自分が書いたという手の感覚を優先する。',
+  'philo.2.title': '即時性の排除',
+  'philo.2.body':
+    'AIの返答はあえて遅らせる。週に一度、手紙のように届くことで、やりとりは情報処理から関係性に変わる。',
+  'philo.3.title': '発酵的時間',
+  'philo.3.body':
+    '即答ではなく、醸成。ぬか床が家ごとに固有の味になるように、思考もまた書き手の時間と微生物叢を吸って熟していく。',
+  'philo.4.title': '卒業できるテクノロジー',
+  'philo.4.body':
+    '最終的にはツールに依存せず、自律的に自己と対話できるようになることを支援する。Oryzaeはそのための補助輪。',
+  'philo.lineage.label': '系譜',
+  'philo.lineage.body':
+    'Oryzaeは、ジャーナリングを通じた自己対話のためのアプリ「Pickles」(2020–) の知見を引き継いでいます。研究の文脈は ephemere.io をご覧ください。',
+
+  'faq.kicker': 'QUESTIONS',
+  'faq.title': 'よくある問い',
+  'faq.1.q': 'Picklesとの違いは？',
+  'faq.1.a':
+    'Picklesは日記そのものを書く場でした。Oryzaeは「問い」を中心に据え、書かれた言葉を発酵プロセスにかけて返すという、書く前後の時間まで含めて設計し直したものです。',
+  'faq.2.q': '縦書きは必須ですか？',
+  'faq.2.a':
+    'いいえ。縦書きをデフォルトとしていますが、ワンクリックで横書きに切り替えられます。フォントも明朝とゴシックを選べます。',
+  'faq.3.q': 'AIは何を読みますか？',
+  'faq.3.a':
+    'あなたが立てた「問い」と、その週に書いたエントリーのみです。問いに紐づけなかったエントリーは発酵に含まれません。',
+  'faq.4.q': '日本語以外でも書けますか？',
+  'faq.4.a':
+    '英語をはじめとする多言語に対応しています。縦書きは日本語・中国語に最適化されています。',
+  'faq.5.q': 'いまどの段階ですか？',
+  'faq.5.a':
+    'Oryzaeはリサーチ・プレビュー段階のプロジェクトです。仕様や挙動は研究の進行に伴って変化します。',
+
+  'outro.l1': '問いはひとつあれば、',
+  'outro.l2': '一週間が変わる。',
+  'outro.cta': 'Oryzaeを開く',
+
+  'foot.tag': 'Aspergillus oryzae for words.',
+};
+
+const en: LandingDict = {
+  'nav.concept': 'Concept',
+  'nav.process': 'Three microbes',
+  'nav.preview': 'The app',
+  'nav.philosophy': 'Philosophy',
+  'nav.faq': 'FAQ',
+  'nav.cta': 'Open the app',
+
+  'hero.eyebrow': 'AN ASPERGILLUS FOR WORDS.',
+  'hero.title.l1': 'Let your writing',
+  'hero.title.l2': 'ferment.',
+  'hero.lead':
+    'Oryzae is a writing app inspired by koji mold — Aspergillus oryzae. Set a question that matters to you, write into it for a week, and the system decomposes your text, surfaces a few essential snippets, and returns a single short letter. Slow self-dialogue, made on purpose.',
+  'hero.cta.primary': 'Open the app',
+  'hero.cta.secondary': 'Read the concept',
+  'hero.foot': 'Vertical or horizontal writing, in Japanese, English, and beyond.',
+  'hero.chip.1': 'autonomy of the dead',
+  'hero.chip.2': 'fermentative time',
+  'hero.chip.3': 'the mediator',
+  'hero.chip.4': 'an ethics of forgetting',
+  'hero.snippet.1':
+    '"As a nukadoko slowly absorbs the household it lives in, an AI may also change its character…"',
+  'hero.question': 'YOUR QUESTION',
+
+  'concept.kicker': 'CONCEPT',
+  'concept.title': 'Brew your question while you write.',
+  'concept.lead':
+    "Oryzae is a writing app organised around a single question. Choose a question that won't leave you alone, and write into it for a week. At week's end, three microbes — koji, lactic, yeast — work in turn: the system decomposes your entries, returns a few essential snippets, a short letter, and a handful of keywords. Not a summary, but a small spark to keep you writing.",
+  'concept.p1.title': 'Set a question',
+  'concept.p1.body':
+    'Capture, in one sentence, the question that matters most right now. Everything else ferments around it.',
+  'concept.p2.title': 'Write daily',
+  'concept.p2.body':
+    'On a quiet vertical page, write whatever comes — typos, detours and all. The trace of your hand stays.',
+  'concept.p3.title': 'A letter arrives',
+  'concept.p3.body':
+    'Each week, a short letter and a few keywords distilled from your own words come back. Read them, then begin again.',
+
+  'process.kicker': 'THREE MICROBES',
+  'process.title.l1': 'Koji · Lactic · Yeast',
+  'process.title.l2': '— three stages of fermentation',
+  'process.lead':
+    'Inside Oryzae, three microbes — like the inhabitants of a nukadoko — each take a different role, and together brew a week of your words.',
+  'process.koji.role': 'Decomposition — 分解',
+  'process.koji.body':
+    "Reads a week of entries through the lens of your question. Drawing on the Modified Grounded Theory Approach, it extracts the snippets that touch the core of what you've been asking.",
+  'process.koji.output':
+    'Output: an analysis worksheet, a result diagram, snippets that illuminate the question.',
+  'process.lactic.role': 'A letter — 手紙',
+  'process.lactic.body':
+    'Working from the worksheet and the snippets, this stage traces how your thinking has moved this week — not as a summary, but as a roughly 500-character poetic note in vocabulary deliberately offset from your own.',
+  'process.lactic.output': 'Output: a single 500-character letter.',
+  'process.yeast.role': 'Widening — キーワード',
+  'process.yeast.body':
+    'Three to five short phrases — "the autonomy of the dead", "the dead activated by the living" — that step a little back from your question and widen the imaginative space around it.',
+  'process.yeast.output': 'Output: 3–5 keywords.',
+
+  'preview.kicker': 'THE APP',
+  'preview.title': 'Three places to write.',
+  'preview.lead':
+    'Oryzae separates the writing, the looking, and the receiving. Daily hands belong to the Editor. The weekly view belongs to the Jar.',
+  'preview.editor.title': 'Add a title',
+  'preview.editor.prompt': 'What did you feel today?',
+  'preview.editor.status': 'editing',
+  'preview.editor.caption':
+    'Editor — a quiet vertical page, tuned for Japanese IME, generous with whitespace.',
+  'preview.jar.chip.1': 'reflective distance',
+  'preview.jar.chip.2': 'cognitive sanctuary',
+  'preview.jar.chip.3': 'a spiritual proxy',
+  'preview.jar.chip.4': 'dative relations',
+  'preview.jar.label': 'YOUR QUESTION · What is a design that lets nature inhabit the body?',
+  'preview.jar.caption': "Jar — a week's words drawn into a constellation around your question.",
+  'preview.letter.from': '— from Oryzae · Letter, week 18',
+  'preview.letter.body':
+    'You have walked, this week, around the question of how the dead and the living might continue to live together. In a dream, the figure of Y arrives in ordinary clothes, then shrinks — quietly — back into the shape of a foetus and disappears. It is loss, and it is also a return to origin, a faint outline of a circular view of life and death. Across the week you begin to notice that an analytical posture may not be the right one toward what matters most. Forgetting, perhaps, is one form of living-with.',
+  'preview.letter.caption':
+    'Letter — a 500-character letter, weekly. Not a summary; a small ember to keep you writing.',
+
+  'philosophy.kicker': 'PHILOSOPHY',
+  'philosophy.title': 'A tool worth outgrowing.',
+  'philo.1.title': 'Embodied writing',
+  'philo.1.body':
+    "Vertical lines, generous margins, a serif. The point isn't to file information cleanly — it's to feel that you, in fact, wrote this.",
+  'philo.2.title': 'Without immediacy',
+  'philo.2.body':
+    'AI replies are deliberately delayed — once a week, like a letter. The exchange shifts from information processing to a quiet kind of relationship.',
+  'philo.3.title': 'Fermentative time',
+  'philo.3.body':
+    'Not an answer, a brewing. As a nukadoko takes on the flavour of the household it lives in, your thinking absorbs your own time and microbiome and slowly ripens.',
+  'philo.4.title': 'Tech you can outgrow',
+  'philo.4.body':
+    'The point is not dependence. Oryzae is meant to support, then quietly fall away as your own self-dialogue gets stronger.',
+  'philo.lineage.label': 'LINEAGE',
+  'philo.lineage.body':
+    'Oryzae carries forward what we learned from Pickles (2020–), a journaling tool for self-dialogue. The wider research context lives at ephemere.io.',
+
+  'faq.kicker': 'QUESTIONS',
+  'faq.title': 'Frequent questions',
+  'faq.1.q': 'How is this different from Pickles?',
+  'faq.1.a':
+    'Pickles was a place to write the journal itself. Oryzae sets a question at the centre and adds the time around the writing — a fermentation process that returns your own words to you in a different shape.',
+  'faq.2.q': 'Do I have to write vertically?',
+  'faq.2.a':
+    'No. Vertical writing is the default, but you can switch to horizontal in one click. The font flips between mincho (serif) and gothic (sans) too.',
+  'faq.3.q': 'What does the AI read?',
+  'faq.3.a':
+    'Only the question you set, and the entries you tied to it during that week. Anything not tied to a question stays out of the fermentation.',
+  'faq.4.q': 'Can I write in languages other than Japanese?',
+  'faq.4.a':
+    'Yes — multilingual input is supported, including English. Vertical writing is tuned for Japanese and Chinese.',
+  'faq.5.q': 'What stage is the project at?',
+  'faq.5.a':
+    'Oryzae is a research preview. The shape of the app and its behaviour will continue to shift alongside the research.',
+
+  'outro.l1': 'One question is enough',
+  'outro.l2': 'to change a week.',
+  'outro.cta': 'Open Oryzae',
+
+  'foot.tag': 'Aspergillus oryzae for words.',
+};
+
+export const LANDING_I18N: Record<LandingLang, LandingDict> = { ja, en };
+
+export const LANDING_TITLES: Record<LandingLang, string> = {
+  ja: 'Oryzae — 書くことを、発酵させる。',
+  en: 'Oryzae — Let your writing ferment.',
+};

--- a/apps/client/src/features/landing/types.ts
+++ b/apps/client/src/features/landing/types.ts
@@ -1,0 +1,5 @@
+export type LandingLang = 'ja' | 'en';
+
+export function isLandingLang(value: string): value is LandingLang {
+  return value === 'ja' || value === 'en';
+}

--- a/apps/client/test/features/landing/hooks/use-landing-i18n.test.ts
+++ b/apps/client/test/features/landing/hooks/use-landing-i18n.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  detectInitialLang,
+  LANDING_LANG_STORAGE_KEY,
+  useLandingI18n,
+} from '@/features/landing/hooks/use-landing-i18n';
+
+describe('detectInitialLang', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('prefers a stored lang over navigator', () => {
+    localStorage.setItem(LANDING_LANG_STORAGE_KEY, 'en');
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['ja-JP']);
+    expect(detectInitialLang()).toBe('en');
+  });
+
+  it('ignores unsupported stored lang and falls back to navigator', () => {
+    localStorage.setItem(LANDING_LANG_STORAGE_KEY, 'fr');
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['ja-JP']);
+    expect(detectInitialLang()).toBe('ja');
+  });
+
+  it('uses ?lang= query param when no stored lang', () => {
+    window.history.replaceState({}, '', '/?lang=en');
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['ja-JP']);
+    expect(detectInitialLang()).toBe('en');
+  });
+
+  it('falls back to navigator language', () => {
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en-US']);
+    expect(detectInitialLang()).toBe('en');
+  });
+
+  it('defaults to ja for unknown navigator languages', () => {
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['fr-FR']);
+    expect(detectInitialLang()).toBe('ja');
+  });
+});
+
+describe('useLandingI18n', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, '', '/');
+    document.documentElement.lang = '';
+    document.title = '';
+  });
+
+  it('returns translated strings via t()', async () => {
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['en-US']);
+    const { result } = renderHook(() => useLandingI18n());
+    await waitFor(() => expect(result.current.lang).toBe('en'));
+    expect(result.current.t('nav.concept')).toBe('Concept');
+  });
+
+  it('falls back to the key when missing', async () => {
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['ja-JP']);
+    const { result } = renderHook(() => useLandingI18n());
+    await waitFor(() => expect(result.current.lang).toBe('ja'));
+    expect(result.current.t('nonexistent.key')).toBe('nonexistent.key');
+  });
+
+  it('setLang persists choice and updates document.title and lang', async () => {
+    vi.spyOn(navigator, 'languages', 'get').mockReturnValue(['ja-JP']);
+    const { result } = renderHook(() => useLandingI18n());
+    await waitFor(() => expect(result.current.lang).toBe('ja'));
+
+    act(() => {
+      result.current.setLang('en');
+    });
+
+    await waitFor(() => expect(result.current.lang).toBe('en'));
+    expect(localStorage.getItem(LANDING_LANG_STORAGE_KEY)).toBe('en');
+    expect(document.documentElement.lang).toBe('en');
+    expect(document.title).toBe('Oryzae — Let your writing ferment.');
+  });
+});


### PR DESCRIPTION
Closes #255

## Summary
- 未認証で `/` にアクセスすると LP（コンセプト・三段の発酵プロセス・アプリプレビュー・哲学・FAQ）を表示
- 認証済みユーザーは `/jar` に自動リダイレクト
- `features/landing/` スライスを新設。JA/EN 言語切替（localStorage 永続化 + `?lang=` + `navigator.language` 検出）と FAQ アコーディオンを実装
- ログイン画面は `/login` に既存（変更なし）

## Implementation
- `app/page.tsx` を書き換え。Supabase email confirm の hash トークン処理は維持しつつ、リダイレクト先は `/entries` → `/jar` に更新
- 元の HTML/CSS/JS（`docs/landing-page/`）を Next.js + React + CSS Module へ移植。LP-only スタイルは `.lp-` プレフィックス付き CSS 変数でスコープ
- ロゴ SVG は `apps/client/public/landing/logo/` に配置

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm dep-cruise` / `pnpm knip` 全通過
- [x] hooks テスト追加（`test/features/landing/hooks/use-landing-i18n.test.ts`、8 ケース）
- [x] E2E テスト追加（`e2e/landing.spec.ts`、LP 表示・CTA → /login・言語切替・FAQ 展開）
- [x] Chrome DevTools MCP で実機確認（hero / 全セクション / コンソールエラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)