### PR TITLE
fix(client): エディタの日付表示を created_at/updated_at の日付差で出し分ける (#240)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -7,6 +7,7 @@ import {
   type EditorStatus,
   EditorStatusBar,
 } from '@/features/entries/components/editor-status-bar';
+import { formatEntryDate } from '@/features/entries/components/format-entry-date';
 import { LeaveConfirmModal } from '@/features/entries/components/leave-confirm-modal';
 import { QuestionLinker } from '@/features/entries/components/question-linker';
 import { SaveTitleModal } from '@/features/entries/components/save-title-modal';
@@ -54,30 +55,6 @@ interface EntryEditorProps {
   onUnlinkQuestion?: (entryId: string, questionId: string) => Promise<void>;
   onSaveComplete?: (entryId: string, content: string) => void;
   onSaveTransition?: (text: string, editorEl: HTMLElement) => Promise<void>;
-}
-
-function formatTime(date: Date): string {
-  const hh = String(date.getHours()).padStart(2, '0');
-  const mm = String(date.getMinutes()).padStart(2, '0');
-  return `${hh}:${mm}`;
-}
-
-const DAY_KEYS = [
-  'date.day_sun',
-  'date.day_mon',
-  'date.day_tue',
-  'date.day_wed',
-  'date.day_thu',
-  'date.day_fri',
-  'date.day_sat',
-] as const;
-
-function formatDateStr(created: Date, updated: Date, t: (key: string) => string): string {
-  const y = created.getFullYear();
-  const m = created.getMonth() + 1;
-  const d = created.getDate();
-  const dayName = t(DAY_KEYS[created.getDay()]);
-  return `${y}.${m}.${d} — ${dayName} ${formatTime(created)} · ${formatTime(updated)}`;
 }
 
 function voiceStatusMessage(
@@ -143,7 +120,7 @@ export function EntryEditor({
     const now = new Date();
     const created = createdAtIso ? new Date(createdAtIso) : now;
     const updated = updatedAtIso ? new Date(updatedAtIso) : now;
-    return formatDateStr(created, updated, t);
+    return formatEntryDate(created, updated, t);
   });
   const { save, saving, error } = useSaveEntry(api, auth);
   const router = useRouter();
@@ -203,7 +180,7 @@ export function EntryEditor({
     if (!createdAtIso) {
       const timer = setInterval(() => {
         const now = new Date();
-        setDateStr(formatDateStr(now, now, t));
+        setDateStr(formatEntryDate(now, now, t));
       }, 60_000);
       return () => clearInterval(timer);
     }
@@ -296,7 +273,7 @@ export function EntryEditor({
         setIsEditingTitle(false);
         setStatus('saved');
         const created = createdAtIso ? new Date(createdAtIso) : new Date();
-        setDateStr(formatDateStr(created, new Date(), t));
+        setDateStr(formatEntryDate(created, new Date(), t));
         if (isNew && onLinkQuestion) {
           for (const qId of linkedIds) {
             await onLinkQuestion(savedId, qId);

--- a/apps/client/src/features/entries/components/format-entry-date.ts
+++ b/apps/client/src/features/entries/components/format-entry-date.ts
@@ -1,0 +1,38 @@
+const DAY_KEYS = [
+  'date.day_sun',
+  'date.day_mon',
+  'date.day_tue',
+  'date.day_wed',
+  'date.day_thu',
+  'date.day_fri',
+  'date.day_sat',
+] as const;
+
+function formatTime(date: Date): string {
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function dayName(date: Date, t: (key: string) => string): string {
+  return t(DAY_KEYS[date.getDay()]);
+}
+
+function formatYmd(date: Date): string {
+  return `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+}
+
+export function formatEntryDate(created: Date, updated: Date, t: (key: string) => string): string {
+  if (isSameDay(created, updated)) {
+    return `${formatYmd(created)} — ${dayName(created, t)} ${formatTime(created)} · ${formatTime(updated)}`;
+  }
+  return `${formatYmd(created)} ${dayName(created, t)} ${formatTime(created)} — ${formatYmd(updated)} ${dayName(updated, t)} ${formatTime(updated)}`;
+}

--- a/apps/client/test/features/entries/components/format-entry-date.test.ts
+++ b/apps/client/test/features/entries/components/format-entry-date.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { formatEntryDate } from '@/features/entries/components/format-entry-date';
+import jaMessages from '@/i18n/messages/ja.json';
+
+function jaT(key: string): string {
+  const segments = key.split('.');
+  let cursor: unknown = (jaMessages as Record<string, unknown>).editor;
+  for (const seg of segments) {
+    if (typeof cursor !== 'object' || cursor === null) return key;
+    cursor = (cursor as Record<string, unknown>)[seg];
+  }
+  return typeof cursor === 'string' ? cursor : key;
+}
+
+describe('formatEntryDate', () => {
+  it('同日の場合は date を 1 つだけ表示し、時刻範囲を中黒で繋ぐ', () => {
+    const created = new Date(2026, 4, 5, 14, 0); // 2026-05-05 (Tue) 14:00
+    const updated = new Date(2026, 4, 5, 16, 30); // 2026-05-05 (Tue) 16:30
+    expect(formatEntryDate(created, updated, jaT)).toBe('2026.5.5 — 火曜日 14:00 · 16:30');
+  });
+
+  it('日が異なる場合は created/updated それぞれの date+time を em dash で繋ぐ', () => {
+    const created = new Date(2026, 4, 5, 14, 0); // 2026-05-05 (Tue) 14:00
+    const updated = new Date(2026, 4, 6, 9, 5); // 2026-05-06 (Wed) 09:05
+    expect(formatEntryDate(created, updated, jaT)).toBe(
+      '2026.5.5 火曜日 14:00 — 2026.5.6 水曜日 09:05',
+    );
+  });
+
+  it('月をまたいでも日が異なる扱いとして両方表示される', () => {
+    const created = new Date(2026, 3, 30, 23, 50); // 2026-04-30 23:50
+    const updated = new Date(2026, 4, 1, 0, 5); // 2026-05-01 00:05
+    expect(formatEntryDate(created, updated, jaT)).toBe(
+      '2026.4.30 木曜日 23:50 — 2026.5.1 金曜日 00:05',
+    );
+  });
+
+  it('時/分は 0 埋めされ、月/日は 0 埋めされない', () => {
+    const created = new Date(2026, 0, 3, 1, 7); // 2026-01-03 01:07
+    const updated = new Date(2026, 0, 3, 2, 9);
+    expect(formatEntryDate(created, updated, jaT)).toBe('2026.1.3 — 土曜日 01:07 · 02:09');
+  });
+});


### PR DESCRIPTION
## Summary
- `formatEntryDate` を `entry-editor.tsx` から別ファイルに切り出し、unit test を追加
- 同日: 従来通り `2026.5.5 — 火曜日 14:00 · 16:30`
- 異なる日: `2026.5.5 火曜日 14:00 — 2026.5.6 水曜日 09:05`

Closes #240

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`（4 ケース追加: 同日 / 別日 / 月またぎ / 0埋め）
- [x] `pnpm dep-cruise`
- [x] `pnpm knip`
- [ ] ブラウザで実機確認（純粋関数の文字列フォーマット変更で unit test がフルカバーのため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)