### PR TITLE
feat(client): SSO とパスワードログイン後の遷移先を /entries/new に変更 (#265)

### DIFF
--- a/apps/client/e2e/auth.spec.ts
+++ b/apps/client/e2e/auth.spec.ts
@@ -4,7 +4,7 @@ const TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? 'yukiagatsuma@gmail.com';
 const TEST_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'Test123456';
 
 test.describe('認証フロー', () => {
-  test('ログインして /entries にリダイレクト', async ({ page }) => {
+  test('ログインして /entries/new にリダイレクト', async ({ page }) => {
     await page.goto('/login');
 
     await expect(page.locator('h1')).toHaveText('Oryzae');
@@ -14,8 +14,8 @@ test.describe('認証フロー', () => {
     await page.fill('input[type="password"]', TEST_PASSWORD);
     await page.click('button:has-text("ログイン")');
 
-    await page.waitForURL('**/entries**');
-    await expect(page).toHaveURL(/\/entries/);
+    await page.waitForURL('**/entries/new**');
+    await expect(page).toHaveURL(/\/entries\/new/);
   });
 
   test('未認証で /entries にアクセスすると /login にリダイレクト', async ({ page }) => {

--- a/apps/client/src/app/(auth)/callback/page.tsx
+++ b/apps/client/src/app/(auth)/callback/page.tsx
@@ -48,7 +48,7 @@ function CallbackHandler() {
 
         setTokens(data.session.accessToken, data.session.refreshToken);
         posthog.identify(data.user.id, { email: data.user.email });
-        router.push('/entries');
+        router.push('/entries/new');
         return;
       }
 
@@ -71,7 +71,7 @@ function CallbackHandler() {
             posthog.identify(data.user.id, { email: data.user.email });
           }
 
-          router.push('/entries');
+          router.push('/entries/new');
           return;
         }
       }

--- a/apps/client/src/features/auth/components/login-form.tsx
+++ b/apps/client/src/features/auth/components/login-form.tsx
@@ -30,7 +30,7 @@ export function LoginForm() {
       return;
     }
 
-    router.push('/entries');
+    router.push('/entries/new');
   }
 
   return (


### PR DESCRIPTION
## 概要

#265 の対応。ルートからのリダイレクト先・オンボーディング完了時の遷移先 (`01c38a0` で `/entries/new` 化済み) と揃えて、認証直後の "デフォルト画面" を `/entries/new` に統一する。

## 変更点

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `apps/client/src/features/auth/components/login-form.tsx` | `router.push('/entries')` | `router.push('/entries/new')` |
| `apps/client/src/app/(auth)/callback/page.tsx` (PKCE flow) | `router.push('/entries')` | `router.push('/entries/new')` |
| `apps/client/src/app/(auth)/callback/page.tsx` (implicit flow) | `router.push('/entries')` | `router.push('/entries/new')` |
| `apps/client/e2e/auth.spec.ts` | `**/entries**` を待機 | `**/entries/new**` を待機・タイトルも更新 |

## 範囲外

- `signup-form.tsx` の `router.push('/entries')` は今回のスコープ外（issue が「SSOとパスワードログイン後」と明示）。サインアップ後はメール確認 or オンボーディングフロー → `/entries/new` 経由になるため UX 上の問題は無し。

## 検証

- `pnpm typecheck` ✅
- `pnpm test` ✅（既存 56 tests / 0 fail）
- `pnpm dep-cruise` ✅
- 実機確認は次回デプロイ後にお願いします。

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)