### PR TITLE
fix(client): onboarding で作った question を直後の editor で選択可能にする (#272)

### DIFF
--- a/apps/client/src/app/(protected)/entries/new/page.tsx
+++ b/apps/client/src/app/(protected)/entries/new/page.tsx
@@ -9,16 +9,21 @@ import { useActiveQuestions } from '@/features/entry-questions/hooks/use-entry-q
 
 export default function NewEntryPage() {
   const { api, auth, loading } = useAuth();
-  const activeQuestions = useActiveQuestions(api, loading);
   const runTransition = useSaveTransition();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const questionIdParam = searchParams.get('questionId');
+
+  // Passing questionIdParam as refetchKey ensures the active-questions list refreshes
+  // when this page is already mounted and the URL changes (e.g. onboarding adds a question
+  // and redirects with ?questionId=...).
+  const activeQuestions = useActiveQuestions(api, loading, questionIdParam ?? undefined);
 
   // Pre-link question from query param (e.g. /entries/new?questionId=xxx)
-  const initialLinkedIds = useMemo(() => {
-    const qId = searchParams.get('questionId');
-    return qId ? [qId] : [];
-  }, [searchParams]);
+  const initialLinkedIds = useMemo(
+    () => (questionIdParam ? [questionIdParam] : []),
+    [questionIdParam],
+  );
 
   async function handleLinkQuestion(entryId: string, questionId: string) {
     if (!api) return;

--- a/apps/client/src/app/(protected)/layout.tsx
+++ b/apps/client/src/app/(protected)/layout.tsx
@@ -19,8 +19,11 @@ export default function ProtectedLayout({ children }: { children: React.ReactNod
 
   const handleOnboardingComplete = useCallback(
     async (result: OnboardingResult) => {
-      await complete(result);
-      router.push('/entries/new');
+      const { questionId } = await complete(result);
+      // Pass questionId so it pre-links AND triggers a refetch even when
+      // /entries/new is already mounted (post-login redirect lands here first).
+      const target = questionId ? `/entries/new?questionId=${questionId}` : '/entries/new';
+      router.push(target);
     },
     [complete, router],
   );

--- a/apps/client/src/features/entry-questions/hooks/use-entry-questions.ts
+++ b/apps/client/src/features/entry-questions/hooks/use-entry-questions.ts
@@ -8,19 +8,40 @@ interface LinkedQuestion {
   currentText: string | null;
 }
 
-export function useActiveQuestions(api: ApiClient | null, authLoading: boolean) {
+/**
+ * @param refetchKey Optional value that, when changed, forces a re-fetch.
+ *   Used by NewEntryPage to refresh after onboarding adds a new question
+ *   while the page is already mounted (URL changes but the page does not remount).
+ */
+export function useActiveQuestions(
+  api: ApiClient | null,
+  authLoading: boolean,
+  refetchKey?: string,
+) {
   const [activeQuestions, setActiveQuestions] = useState<LinkedQuestion[]>([]);
 
   useEffect(() => {
     if (authLoading || !api) return;
+    let cancelled = false;
 
-    api.fetch('/api/v1/questions').then(async (res) => {
+    // refetchKey is appended as a no-op query so that changing it (e.g. ?questionId=...)
+    // both forces this effect to re-run AND defeats any incidental HTTP cache.
+    const url = refetchKey
+      ? `/api/v1/questions?refetchKey=${encodeURIComponent(refetchKey)}`
+      : '/api/v1/questions';
+
+    api.fetch(url).then(async (res) => {
+      if (cancelled) return;
       if (res.ok) {
         const data: LinkedQuestion[] = await res.json();
-        setActiveQuestions(data);
+        if (!cancelled) setActiveQuestions(data);
       }
     });
-  }, [api, authLoading]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, authLoading, refetchKey]);
 
   return activeQuestions;
 }

--- a/apps/client/src/features/onboarding/hooks/use-onboarding.ts
+++ b/apps/client/src/features/onboarding/hooks/use-onboarding.ts
@@ -4,10 +4,15 @@ import { useCallback, useEffect, useState } from 'react';
 import type { ApiClient } from '@/lib/api';
 import type { OnboardingResult } from '../types';
 
+interface OnboardingCompleteResult {
+  /** ID of the question created during onboarding, or null if none */
+  questionId: string | null;
+}
+
 interface UseOnboardingResult {
   shouldShow: boolean;
   loading: boolean;
-  complete: (result: OnboardingResult) => Promise<void>;
+  complete: (result: OnboardingResult) => Promise<OnboardingCompleteResult>;
 }
 
 export function useOnboarding(api: ApiClient | null): UseOnboardingResult {
@@ -37,14 +42,19 @@ export function useOnboarding(api: ApiClient | null): UseOnboardingResult {
   }, [api]);
 
   const complete = useCallback(
-    async (result: OnboardingResult) => {
-      if (!api) return;
+    async (result: OnboardingResult): Promise<OnboardingCompleteResult> => {
+      if (!api) return { questionId: null };
 
+      let questionId: string | null = null;
       if (result.firstQuestion) {
-        await api.fetch('/api/v1/questions', {
+        const res = await api.fetch('/api/v1/questions', {
           method: 'POST',
           body: JSON.stringify({ string: result.firstQuestion }),
         });
+        if (res.ok) {
+          const data = (await res.json()) as { id?: string };
+          questionId = data.id ?? null;
+        }
       }
 
       await api.fetch('/api/v1/users/me/onboarding', {
@@ -53,6 +63,7 @@ export function useOnboarding(api: ApiClient | null): UseOnboardingResult {
       });
 
       setShouldShow(false);
+      return { questionId };
     },
     [api],
   );

--- a/apps/client/test/features/entry-questions/hooks/use-entry-questions.test.ts
+++ b/apps/client/test/features/entry-questions/hooks/use-entry-questions.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActiveQuestions } from '@/features/entry-questions/hooks/use-entry-questions';
+import type { ApiClient } from '@/lib/api';
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  // @type-assertion-allowed: minimal Response stub for test
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 500,
+  } as Response;
+}
+
+function createApiStub(): ApiClient & { fetch: ReturnType<typeof vi.fn> } {
+  const fetch = vi.fn();
+  return {
+    baseUrl: '',
+    headers: {},
+    fetch,
+  };
+}
+
+describe('useActiveQuestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('authLoading が true のあいだは fetch しない', () => {
+    const api = createApiStub();
+    renderHook(() => useActiveQuestions(api, true));
+    expect(api.fetch).not.toHaveBeenCalled();
+  });
+
+  it('api が null のときは fetch しない', () => {
+    const { result } = renderHook(() => useActiveQuestions(null, false));
+    expect(result.current).toEqual([]);
+  });
+
+  it('api と authLoading が揃ったら GET /api/v1/questions を呼んで結果を返す', async () => {
+    const api = createApiStub();
+    api.fetch.mockResolvedValueOnce(mockResponse(true, [{ id: 'q1', currentText: 'なぜ?' }]));
+
+    const { result } = renderHook(() => useActiveQuestions(api, false));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0]).toEqual({ id: 'q1', currentText: 'なぜ?' });
+    expect(api.fetch).toHaveBeenCalledWith('/api/v1/questions');
+  });
+
+  it('refetchKey が変わったら再 fetch する (URL にも refetchKey を付ける)', async () => {
+    const api = createApiStub();
+    api.fetch
+      .mockResolvedValueOnce(mockResponse(true, []))
+      .mockResolvedValueOnce(mockResponse(true, [{ id: 'q1', currentText: 'あとから追加された' }]));
+
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string | undefined }) => useActiveQuestions(api, false, key),
+      { initialProps: { key: undefined as string | undefined } },
+    );
+
+    await waitFor(() => {
+      expect(api.fetch).toHaveBeenCalledTimes(1);
+    });
+    expect(api.fetch).toHaveBeenNthCalledWith(1, '/api/v1/questions');
+    expect(result.current).toEqual([]);
+
+    rerender({ key: 'q1' });
+
+    await waitFor(() => {
+      expect(api.fetch).toHaveBeenCalledTimes(2);
+    });
+    expect(api.fetch).toHaveBeenNthCalledWith(2, '/api/v1/questions?refetchKey=q1');
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0].id).toBe('q1');
+  });
+});

--- a/apps/client/test/features/onboarding/hooks/use-onboarding.test.ts
+++ b/apps/client/test/features/onboarding/hooks/use-onboarding.test.ts
@@ -62,7 +62,7 @@ describe('useOnboarding', () => {
     const api = createApiStub();
     api.fetch
       .mockResolvedValueOnce(mockResponse(true, { onboardingCompleted: false }))
-      .mockResolvedValueOnce(mockResponse(true, {}))
+      .mockResolvedValueOnce(mockResponse(true, { id: 'new-q-id' }))
       .mockResolvedValueOnce(mockResponse(true, { onboardingCompleted: true }));
 
     const { result } = renderHook(() => useOnboarding(api));
@@ -70,8 +70,9 @@ describe('useOnboarding', () => {
       expect(result.current.loading).toBe(false);
     });
 
+    let completeResult: { questionId: string | null } | undefined;
     await act(async () => {
-      await result.current.complete({ skipped: false, firstQuestion: 'なぜ?' });
+      completeResult = await result.current.complete({ skipped: false, firstQuestion: 'なぜ?' });
     });
 
     expect(api.fetch).toHaveBeenNthCalledWith(2, '/api/v1/questions', {
@@ -83,6 +84,7 @@ describe('useOnboarding', () => {
       body: JSON.stringify({ completed: true }),
     });
     expect(result.current.shouldShow).toBe(false);
+    expect(completeResult).toEqual({ questionId: 'new-q-id' });
   });
 
   it('complete は firstQuestion が null のとき POST /questions を呼ばない', async () => {
@@ -96,12 +98,38 @@ describe('useOnboarding', () => {
       expect(result.current.loading).toBe(false);
     });
 
+    let completeResult: { questionId: string | null } | undefined;
     await act(async () => {
-      await result.current.complete({ skipped: true, firstQuestion: null });
+      completeResult = await result.current.complete({ skipped: true, firstQuestion: null });
     });
 
     expect(api.fetch).toHaveBeenCalledTimes(2);
     expect(api.fetch).toHaveBeenNthCalledWith(2, '/api/v1/users/me/onboarding', {
+      method: 'PATCH',
+      body: JSON.stringify({ completed: true }),
+    });
+    expect(completeResult).toEqual({ questionId: null });
+  });
+
+  it('complete は POST /questions が失敗した場合でも PATCH を続行し questionId は null', async () => {
+    const api = createApiStub();
+    api.fetch
+      .mockResolvedValueOnce(mockResponse(true, { onboardingCompleted: false }))
+      .mockResolvedValueOnce(mockResponse(false, { error: 'boom' }))
+      .mockResolvedValueOnce(mockResponse(true, {}));
+
+    const { result } = renderHook(() => useOnboarding(api));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let completeResult: { questionId: string | null } | undefined;
+    await act(async () => {
+      completeResult = await result.current.complete({ skipped: false, firstQuestion: 'なぜ?' });
+    });
+
+    expect(completeResult).toEqual({ questionId: null });
+    expect(api.fetch).toHaveBeenNthCalledWith(3, '/api/v1/users/me/onboarding', {
       method: 'PATCH',
       body: JSON.stringify({ completed: true }),
     });


### PR DESCRIPTION
Closes #272

## 症状

Onboarding で「最初の問い」を入力して完了 → editor (`/entries/new`) に遷移した直後、その問いが質問選択 dropdown に出てこない。Jar 画面に行ってローディング完了を待ってから戻ると出てくる。

## 根本原因

`ProtectedLayout` のログイン後リダイレクト先が `/entries/new` のため、ユーザーが onboarding をやっている時点で **NewEntryPage は既に mount 済み**。完了時の `router.push('/entries/new')` は同じパスへの遷移なので NewEntryPage は remount せず、`useActiveQuestions` の `useEffect` も deps `[api, authLoading]` に変化が無いので再 fetch されない。

Jar に行って戻ると NewEntryPage が remount → 再 fetch されるので見える。

## 修正

| ファイル | 変更 |
|---|---|
| `features/onboarding/hooks/use-onboarding.ts` | `complete()` が POST `/api/v1/questions` のレスポンスから `questionId` を返す。POST 失敗時は `null` を返して PATCH `/onboarding` は続行 |
| `app/(protected)/layout.tsx` | `?questionId=<id>` 付きで `router.push` |
| `features/entry-questions/hooks/use-entry-questions.ts` | `useActiveQuestions` に `refetchKey?: string` を追加。URL に `?refetchKey=` として付与（biome の `useExhaustiveDependencies` を満たす + 偶発的な HTTP cache も回避）。effect cleanup で stale state ガードを追加 |
| `app/(protected)/entries/new/page.tsx` | `searchParams.get('questionId')` を `refetchKey` に渡す |

## 副次効果

- 既存の `initialLinkedIds` 機構（`?questionId=` で pre-link する仕組み）が onboarding 経由で初めて活用される。dropdown で選び直す手間が消えて、onboarding で書いた問いが editor で自動的にリンクされた状態になる
- POST 失敗の握りつぶしを軽減（`res.ok` チェックを追加）

## テスト

- `use-onboarding.test.ts`: `complete()` の戻り値検証 + POST 失敗時のフォールバックを追加
- `use-entry-questions.test.ts`: 新規。`useActiveQuestions` の基本動作 + `refetchKey` 変化での再 fetch を検証
- pnpm test: 115/115 passed
- pnpm typecheck / lint / dep-cruise / knip: ✓

## QA

実機 (Chrome DevTools MCP) では本番ユーザーの `users.onboarding_completed` を弄る必要があり今回は未実施。レビューア側で再現確認したい場合、Supabase の `users` テーブルで自分の `onboarding_completed = false` に戻すか新規アカウントで onboarding を流してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)