### PR TITLE
feat(client): 英語ロケールのデフォルト書字方向を横書きにする (#269)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type EditorStatus,
@@ -97,12 +97,13 @@ export function EntryEditor({
   onSaveTransition,
 }: EntryEditorProps) {
   const t = useTranslations('editor');
+  const locale = useLocale();
   // For existing entries, split first line as title
   const parsed = entryId ? splitTitleBody(initialContent) : { title: '', body: initialContent };
   const [title, setTitle] = useState(initialTitle ?? parsed.title);
   const [content, setContent] = useState(entryId ? parsed.body : initialContent);
   const [savedContent, setSavedContent] = useState(entryId ? parsed.body : initialContent);
-  const [settings, updateSettings] = useEditorSettings();
+  const [settings, updateSettings] = useEditorSettings(locale);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [saveModalMode, setSaveModalMode] = useState<'save' | 'pickle'>('save');

--- a/apps/client/src/features/entries/hooks/use-editor-settings.ts
+++ b/apps/client/src/features/entries/hooks/use-editor-settings.ts
@@ -83,8 +83,11 @@ function writeStoredFocusMode(value: boolean): void {
   }
 }
 
-function getInitialSettings(): EditorSettings {
+function getInitialSettings(locale: string | undefined): EditorSettings {
   const next: EditorSettings = { ...DEFAULT_SETTINGS };
+  // 英語ロケールでサインアップ／利用しているユーザーは横書きをデフォルトにする (issue #269)
+  // 縦書きは日本語ジャーナリングを念頭にした既定値で、英語話者には不自然なため。
+  if (locale === 'en') next.writingMode = 'horizontal';
   const fontSize = readStoredFontSize();
   if (fontSize !== null) next.fontSize = fontSize;
   const lineHeight = readStoredLineHeight();
@@ -94,8 +97,10 @@ function getInitialSettings(): EditorSettings {
   return next;
 }
 
-export function useEditorSettings(): [EditorSettings, (patch: Partial<EditorSettings>) => void] {
-  const [settings, setSettings] = useState<EditorSettings>(getInitialSettings);
+export function useEditorSettings(
+  locale?: string,
+): [EditorSettings, (patch: Partial<EditorSettings>) => void] {
+  const [settings, setSettings] = useState<EditorSettings>(() => getInitialSettings(locale));
 
   const updateSettings = useCallback((patch: Partial<EditorSettings>) => {
     if (typeof patch.fontSize === 'number') {

--- a/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
+++ b/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
@@ -21,6 +21,24 @@ describe('useEditorSettings', () => {
     expect(result.current[0]).toEqual(DEFAULT_SETTINGS);
   });
 
+  it('defaults writingMode to vertical for ja locale', () => {
+    const { result } = renderHook(() => useEditorSettings('ja'));
+    expect(result.current[0].writingMode).toBe('vertical');
+  });
+
+  it('defaults writingMode to horizontal for en locale (issue #269)', () => {
+    const { result } = renderHook(() => useEditorSettings('en'));
+    expect(result.current[0].writingMode).toBe('horizontal');
+    // 他のフィールドは DEFAULT_SETTINGS のまま
+    expect(result.current[0].fontSize).toBe(DEFAULT_SETTINGS.fontSize);
+    expect(result.current[0].lineHeight).toBe(DEFAULT_SETTINGS.lineHeight);
+  });
+
+  it('falls back to DEFAULT_SETTINGS.writingMode when locale is undefined', () => {
+    const { result } = renderHook(() => useEditorSettings(undefined));
+    expect(result.current[0].writingMode).toBe(DEFAULT_SETTINGS.writingMode);
+  });
+
   it('initializes fontSize from localStorage when stored', () => {
     window.localStorage.setItem(FONT_SIZE_KEY, '16');
     const { result } = renderHook(() => useEditorSettings());


### PR DESCRIPTION
## Why

Closes #269.

ジャーナリングエディタは縦書き (`vertical-rl`) をデフォルトにしているが、これは日本語前提の既定値で、英語でサインアップしたユーザーには不自然。エントリ作成時から横書きで開けるようにする。

## What

`useEditorSettings(locale?)` にロケールを受け取らせ、`getInitialSettings(locale)` で初期値を決める:

| locale | `writingMode` 初期値 |
|---|---|
| `'ja'` | `'vertical'`（従来通り）|
| `'en'` | `'horizontal'`（新規）|
| `undefined` | `DEFAULT_SETTINGS.writingMode` (= `'vertical'`) |

呼び出し側 (`entry-editor.tsx`) は `useLocale()` で `next-intl` のロケールを取って渡す。Cookie `NEXT_LOCALE` ベースのロケールはサインアップ時に Supabase `user_metadata.locale` と同値で初期化されるため、issue 文言「英語でサインアップしたユーザー」と整合する。

## Design notes

- **永続化はしない**: `writingMode` は元から localStorage に保存されない仕様。毎回ロケールから決まる。ユーザーがツールバーで切り替える運用は維持（その場限りの選好を上書き保存はしない、というこれまでの設計を踏襲）。
- **API 形**: hook をプロバイダ依存にせず、ロケールを引数で受け取る形にした。テストで `NextIntlProvider` ラッパが不要になり、既存テストも素のまま動く。

## Tests

- `vitest` 19/19 pass（既存 16 + 新規 3 ケース）
  - `defaults writingMode to vertical for ja locale`
  - `defaults writingMode to horizontal for en locale (issue #269)`
  - `falls back to DEFAULT_SETTINGS.writingMode when locale is undefined`
- `pnpm typecheck` ✅
- `pnpm lint` ✅（変更ファイル由来の警告 0）
- `pnpm dep-cruise` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)