### PR TITLE
feat(admin): Observability に Resend を追加

### DIFF
--- a/apps/admin/src/app/(protected)/observability/page.tsx
+++ b/apps/admin/src/app/(protected)/observability/page.tsx
@@ -13,7 +13,7 @@ export default function ObservabilityPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-medium">Observability</h1>
-          <span className="text-sm text-muted-foreground">5 tools</span>
+          <span className="text-sm text-muted-foreground">6 tools</span>
         </div>
         <Button variant="ghost" size="icon-xs" onClick={refresh} disabled={loading}>
           <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />

--- a/apps/admin/src/features/observability/components/tool-cards.tsx
+++ b/apps/admin/src/features/observability/components/tool-cards.tsx
@@ -61,6 +61,17 @@ function buildRows(data: ObservabilitySummary): ToolRow[] {
       externalUrl: 'https://vercel.com',
     },
     {
+      id: 'resend',
+      name: 'Resend',
+      category: 'Email',
+      metric:
+        data.resend.sentCount7d !== null
+          ? `${formatMetric(data.resend.sentCount7d)} sent / ${formatMetric(data.resend.bouncedCount7d)} bounced (7d)`
+          : '-',
+      href: null,
+      externalUrl: 'https://resend.com/emails',
+    },
+    {
       id: 'upstash',
       name: 'Upstash',
       category: 'Rate Limiting',

--- a/apps/admin/src/features/observability/hooks/use-observability.ts
+++ b/apps/admin/src/features/observability/hooks/use-observability.ts
@@ -13,6 +13,7 @@ export interface ObservabilitySummary {
     creditBalance: string | null;
     creditUsed: string | null;
   };
+  resend: { sentCount7d: number | null; bouncedCount7d: number | null };
   upstash: { totalKeys: number | null };
   vercel: { latestDeployState: string | null };
 }
@@ -30,6 +31,7 @@ interface SummaryApiResponse {
     creditBalance: string | null;
     creditUsed: string | null;
   };
+  resend: { sentCount7d: number | null; bouncedCount7d: number | null };
   upstash: { totalKeys: number | null };
   vercel: { latestDeployState: string | null };
 }

--- a/apps/admin/test/features/observability/hooks/use-observability.test.ts
+++ b/apps/admin/test/features/observability/hooks/use-observability.test.ts
@@ -23,6 +23,7 @@ describe('useObservability', () => {
     const summaryBody = {
       sentry: { unresolvedCount: 3 },
       gateway: { monthlySpend: 1.5, monthlyRequests: 10, creditBalance: '8.5', creditUsed: '1.5' },
+      resend: { sentCount7d: 12, bouncedCount7d: 1 },
       upstash: { totalKeys: 42 },
       vercel: { latestDeployState: 'READY' },
     };
@@ -41,6 +42,8 @@ describe('useObservability', () => {
     expect(result.current.data?.posthog?.totalPageviews).toBe(1234);
     expect(result.current.data?.sentry.unresolvedCount).toBe(3);
     expect(result.current.data?.gateway.monthlySpend).toBe(1.5);
+    expect(result.current.data?.resend.sentCount7d).toBe(12);
+    expect(result.current.data?.resend.bouncedCount7d).toBe(1);
     expect(result.current.error).toBeNull();
   });
 

--- a/apps/server/src/contexts/shared/presentation/routes/admin-observability.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/admin-observability.ts
@@ -77,6 +77,36 @@ async function getVercelLatestDeploy(): Promise<string | null> {
   }
 }
 
+async function getResendStats(): Promise<{ sentCount: number; bouncedCount: number } | null> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch('https://api.resend.com/emails?limit=100', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (typeof body !== 'object' || body === null || !('data' in body)) return null;
+    const data = (body as { data: { created_at?: string; last_event?: string }[] }).data;
+    if (!Array.isArray(data)) return null;
+
+    const sevenDaysAgoMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    let sentCount = 0;
+    let bouncedCount = 0;
+    for (const email of data) {
+      if (!email.created_at) continue;
+      const ts = new Date(email.created_at).getTime();
+      if (Number.isNaN(ts) || ts < sevenDaysAgoMs) continue;
+      sentCount++;
+      if (email.last_event === 'bounced') bouncedCount++;
+    }
+    return { sentCount, bouncedCount };
+  } catch {
+    return null;
+  }
+}
+
 async function getUpstashKeyCount(): Promise<number | null> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -99,13 +129,14 @@ async function getUpstashKeyCount(): Promise<number | null> {
 
 export const adminObservability = new Hono<Env>()
   .get('/summary', async (c) => {
-    const [sentryCount, gatewaySpend, gatewayCredits, vercelDeploy, upstashKeys] =
+    const [sentryCount, gatewaySpend, gatewayCredits, vercelDeploy, upstashKeys, resendStats] =
       await Promise.all([
         getSentryCount(),
         getGatewaySpend(),
         getGatewayCredits(),
         getVercelLatestDeploy(),
         getUpstashKeyCount(),
+        getResendStats(),
       ]);
 
     return c.json({
@@ -118,6 +149,10 @@ export const adminObservability = new Hono<Env>()
         monthlyRequests: gatewaySpend?.requestCount ?? null,
         creditBalance: gatewayCredits?.balance ?? null,
         creditUsed: gatewayCredits?.totalUsed ?? null,
+      },
+      resend: {
+        sentCount7d: resendStats?.sentCount ?? null,
+        bouncedCount7d: resendStats?.bouncedCount ?? null,
       },
       upstash: {
         totalKeys: upstashKeys,


### PR DESCRIPTION
closes #232

## 概要

admin の Observability hub に Resend（メール送信サービス）を追加した。
直近 7 日の送信数 / bounce 数を表示し、外部の Resend ダッシュボードへ遷移できるようにする。

## 変更内容

### server
- `apps/server/.../admin-observability.ts`
  - `getResendStats()` を追加。Resend `GET /emails?limit=100` を叩き、`created_at` が直近 7 日以内のものを送信数として、`last_event === 'bounced'` を bounce 数としてカウント
  - `/summary` エンドポイントの response に `resend: { sentCount7d, bouncedCount7d }` を追加
  - `RESEND_API_KEY` 未設定時は `null` を返す（既存ツールと同じ挙動）

### admin
- `features/observability/hooks/use-observability.ts` — 型に `resend` を追加
- `features/observability/components/tool-cards.tsx` — Resend 行を AI Gateway と Upstash の間に挿入
  - metric 表示: `N sent / M bounced (7d)`
  - 外部リンク: https://resend.com/emails（詳細ページは作らない、Upstash と同じパターン）
- `app/(protected)/observability/page.tsx` — tools count `5` → `6`
- hook テスト更新

## ツール並び（変更後）

1. PostHog (Analytics)
2. Sentry (Errors)
3. AI Gateway (LLM Cost)
4. **Resend (Email)** ← new
5. Upstash (Rate Limiting)
6. Vercel (Deploys)

## チェック

- ✅ `pnpm typecheck` — 全パッケージ pass
- ✅ `pnpm test` — admin 56 / server 222 全 pass
- ✅ `pnpm dep-cruise` — 違反なし

## 補足

Resend の API には公式の集計エンドポイントが無いため、`GET /emails` (max 100 件) をクライアント側で集計している。
送信が 7 日で 100 件を超えるようになったら pagination を考慮する必要がある（現状はジャーナリングアプリで送信ボリュームは小さいので問題ない見込み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)