### PR TITLE
feat(fermentation): 発酵プロセスの生成物をユーザー言語で出力 (#279)

### DIFF
--- a/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/run-fermentation.usecase.ts
@@ -5,6 +5,7 @@ import { ExtractedSnippet } from '../../domain/models/extracted-snippet.js';
 import { FermentationResult } from '../../domain/models/fermentation-result.js';
 import { Keyword } from '../../domain/models/keyword.js';
 import { Letter } from '../../domain/models/letter.js';
+import type { FermentationLanguage } from '../../domain/services/fermentation-eligibility.service.js';
 import { LlmAnalysisError } from '../errors/fermentation.errors.js';
 
 interface RunFermentationEntry {
@@ -24,10 +25,14 @@ export class RunFermentationUsecase {
     questionId: string;
     questionText: string;
     entries: RunFermentationEntry[];
+    // 出力言語 (issue #279)。呼び出し側で UserLocaleResolver を使って解決する。
+    // 未指定時のデフォルトは 'ja' (Oryzae のメインターゲット)。
+    language?: FermentationLanguage;
   }): Promise<{ id: string }> {
     if (params.entries.length === 0) {
       throw new LlmAnalysisError('At least one entry is required');
     }
+    const language: FermentationLanguage = params.language ?? 'ja';
 
     const today = new Date().toISOString().slice(0, 10);
     const targetPeriod = today;
@@ -68,6 +73,7 @@ export class RunFermentationUsecase {
         entryContent: combinedContent,
         targetPeriod,
         userId: params.userId,
+        language,
       });
 
       // 3.5. Track generation ID for cost tracking

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -10,6 +10,7 @@ import type { UserLocaleResolverGateway } from '../../domain/gateways/user-local
 import { UserFermentationState } from '../../domain/models/user-fermentation-state.js';
 import {
   evaluateEligibility,
+  type FermentationLanguage,
   rollRandomHours,
 } from '../../domain/services/fermentation-eligibility.service.js';
 import { RunFermentationUsecase } from './run-fermentation.usecase.js';
@@ -44,7 +45,13 @@ export class ScheduledFermentationUsecase {
     private llmGateway: LlmAnalysisGateway,
     private generateId: () => string,
     private listActiveUserIds: () => Promise<string[]>,
-    private sendDigest: (userId: string, questionTitles: string[]) => Promise<void>,
+    // issue #279: digest メールも language に応じて文言を切り替えるため、
+    // ここで解決済みの language を呼び出し側に渡す。
+    private sendDigest: (
+      userId: string,
+      questionTitles: string[],
+      language: FermentationLanguage,
+    ) => Promise<void>,
     // 次回 X 時間生成器。テストでは固定値を注入して決定論的にする。
     private rollHours: () => number = rollRandomHours,
   ) {}
@@ -69,10 +76,12 @@ export class ScheduledFermentationUsecase {
     );
 
     const successfulTitlesByUser = new Map<string, string[]>();
+    const languageByUser = new Map<string, FermentationLanguage>();
 
     for (const userId of userIds) {
       // 1. ロケール解決 (失敗時は 'ja')
       const language = await this.localeResolver.resolve(userId);
+      languageByUser.set(userId, language);
 
       // 2. 既存 state を取得 (新規なら null)
       const existing = await this.userStateRepo.findByUserId(userId);
@@ -136,6 +145,7 @@ export class ScheduledFermentationUsecase {
             questionId: question.id,
             questionText,
             entries: runEntries,
+            language,
           });
           result.succeeded++;
           firedAtLeastOne = true;
@@ -167,7 +177,8 @@ export class ScheduledFermentationUsecase {
 
     for (const [userId, titles] of successfulTitlesByUser) {
       try {
-        await this.sendDigest(userId, titles);
+        const lang = languageByUser.get(userId) ?? 'ja';
+        await this.sendDigest(userId, titles, lang);
       } catch {
         // Notification failure must not break the scheduled job.
       }

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -1,7 +1,36 @@
 import type { EmailNotifier } from '../../domain/gateways/email-notifier.gateway.js';
+import type { FermentationLanguage } from '../../domain/services/fermentation-eligibility.service.js';
 
-const SUBJECT = 'あなたの瓶の発酵が進みました';
 const JAR_URL = 'https://oryzae-client.vercel.app/jar';
+
+// issue #279: ユーザー言語に合わせて subject / body を切り替える。
+const COPY: Record<
+  FermentationLanguage,
+  {
+    subject: string;
+    singleBody: (title: string) => string;
+    multiBody: (titles: string[]) => string;
+  }
+> = {
+  ja: {
+    subject: 'あなたの瓶の発酵が進みました',
+    singleBody: (title) =>
+      `${title}についてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n${JAR_URL}`,
+    multiBody: (titles) => {
+      const list = titles.map((t) => `・${t}`).join('\n');
+      return `以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n${list}\n\n${JAR_URL}`;
+    },
+  },
+  en: {
+    subject: 'Your jar has fermented further',
+    singleBody: (title) =>
+      `Oryzae's microbes have responded to what you wrote about "${title}".\n${JAR_URL}`,
+    multiBody: (titles) => {
+      const list = titles.map((t) => `- ${t}`).join('\n');
+      return `Oryzae's microbes have responded to what you wrote about the following questions:\n\n${list}\n\n${JAR_URL}`;
+    },
+  },
+};
 
 export class SendFermentationDigestUsecase {
   constructor(
@@ -9,7 +38,12 @@ export class SendFermentationDigestUsecase {
     private resolveVerifiedEmail: (userId: string) => Promise<string | null>,
   ) {}
 
-  async execute(params: { userId: string; questionTitles: string[] }): Promise<void> {
+  async execute(params: {
+    userId: string;
+    questionTitles: string[];
+    // 未指定時は 'ja' (#268 と同じデフォルト)。
+    language?: FermentationLanguage;
+  }): Promise<void> {
     const uniqueTitles = Array.from(
       new Set(params.questionTitles.map((t) => t.trim()).filter((t) => t.length > 0)),
     );
@@ -18,15 +52,10 @@ export class SendFermentationDigestUsecase {
     const email = await this.resolveVerifiedEmail(params.userId);
     if (!email) return;
 
-    const bodyText = composeBody(uniqueTitles);
-    await this.emailNotifier.send({ to: email, subject: SUBJECT, bodyText });
+    const language: FermentationLanguage = params.language ?? 'ja';
+    const copy = COPY[language];
+    const bodyText =
+      uniqueTitles.length === 1 ? copy.singleBody(uniqueTitles[0]) : copy.multiBody(uniqueTitles);
+    await this.emailNotifier.send({ to: email, subject: copy.subject, bodyText });
   }
-}
-
-function composeBody(titles: string[]): string {
-  if (titles.length === 1) {
-    return `${titles[0]}についてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n${JAR_URL}`;
-  }
-  const list = titles.map((t) => `・${t}`).join('\n');
-  return `以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n${list}\n\n${JAR_URL}`;
 }

--- a/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/llm-analysis.gateway.ts
@@ -1,3 +1,5 @@
+import type { FermentationLanguage } from '../services/fermentation-eligibility.service.js';
+
 interface FermentationOutput {
   worksheetMarkdown: string;
   resultDiagramMarkdown: string;
@@ -28,5 +30,8 @@ export interface LlmAnalysisGateway {
     entryContent: string;
     targetPeriod: string;
     userId: string;
+    // 出力言語 (issue #279)。M-GTA 分析の system prompt と output schema description を切り替える。
+    // 解決失敗時は呼び出し側で 'ja' に倒すこと (#268 の方針を踏襲)。
+    language: FermentationLanguage;
   }): Promise<LlmAnalysisResult>;
 }

--- a/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.ts
@@ -4,44 +4,82 @@ import type {
   LlmAnalysisGateway,
   LlmAnalysisResult,
 } from '../../domain/gateways/llm-analysis.gateway.js';
+import type { FermentationLanguage } from '../../domain/services/fermentation-eligibility.service.js';
 
-const fermentationSchema = z.object({
-  worksheetMarkdown: z
-    .string()
-    .describe('M-GTA分析ワークシート（Markdown形式）。概念名・定義・具体例・理論的メモを含む'),
-  resultDiagramMarkdown: z.string().describe('結果図とストーリーライン（Markdown形式）'),
-  snippets: z
-    .array(
-      z.object({
-        type: z.enum(['new_perspective', 'deepen', 'core']).describe('切片の種類'),
-        text: z.string().describe('原文からの引用テキスト'),
-        sourceDate: z.string().describe('出典日付'),
-        reason: z.string().describe('この切片を選んだ理由'),
-      }),
-    )
-    .describe('日記から抽出した3つの切片'),
-  letterBody: z
-    .string()
-    .describe(
+// issue #279: 出力言語ごとの schema description / prompt 文言。
+// snippet type のラベル (new_perspective/deepen/core) はキーは固定、語訳のみ言語別。
+const SCHEMA_LABELS = {
+  ja: {
+    worksheet: 'M-GTA分析ワークシート（Markdown形式）。概念名・定義・具体例・理論的メモを含む',
+    resultDiagram: '結果図とストーリーライン（Markdown形式）',
+    snippets: '日記から抽出した3つの切片',
+    snippetType: '切片の種類',
+    snippetText: '原文からの引用テキスト',
+    snippetSourceDate: '出典日付',
+    snippetReason: 'この切片を選んだ理由',
+    letter:
       '500字程度の観察メモ。乳酸菌が日記に取り付き第三者視点で淡々と解釈した記録。要約ではなく言い換えで書く',
-    ),
-  keywords: z
-    .array(
-      z.object({
-        keyword: z.string().describe('短い詩的キーワード'),
-        description: z.string().describe('キーワードの説明'),
-      }),
-    )
-    .describe('3〜5個の詩的キーワード'),
-});
+    keyword: '短い詩的キーワード',
+    keywordDescription: 'キーワードの説明',
+    keywords: '3〜5個の詩的キーワード',
+  },
+  en: {
+    worksheet:
+      'M-GTA analysis worksheet (Markdown). Includes concept names, definitions, concrete examples, and theoretical memos.',
+    resultDiagram: 'Result diagram and storyline (Markdown).',
+    snippets: 'Three snippets extracted from the journal entries.',
+    snippetType: 'Snippet category.',
+    snippetText: 'Verbatim quote from the source text.',
+    snippetSourceDate: 'Date of the source entry.',
+    snippetReason: 'Why this snippet was selected.',
+    letter:
+      'About 100 words. Observation note written by lactic-acid bacteria clinging to the journal, interpreting it from a third-person perspective. Paraphrase, do not summarize.',
+    keyword: 'A short, poetic keyword or phrase.',
+    keywordDescription: 'Brief description of the keyword.',
+    keywords: 'Three to five poetic keywords or phrases.',
+  },
+} as const satisfies Record<FermentationLanguage, Record<string, string>>;
 
-function buildPrompt(params: {
+function buildSchema(language: FermentationLanguage) {
+  const L = SCHEMA_LABELS[language];
+  return z.object({
+    worksheetMarkdown: z.string().describe(L.worksheet),
+    resultDiagramMarkdown: z.string().describe(L.resultDiagram),
+    snippets: z
+      .array(
+        z.object({
+          type: z.enum(['new_perspective', 'deepen', 'core']).describe(L.snippetType),
+          text: z.string().describe(L.snippetText),
+          sourceDate: z.string().describe(L.snippetSourceDate),
+          reason: z.string().describe(L.snippetReason),
+        }),
+      )
+      .describe(L.snippets),
+    letterBody: z.string().describe(L.letter),
+    keywords: z
+      .array(
+        z.object({
+          keyword: z.string().describe(L.keyword),
+          description: z.string().describe(L.keywordDescription),
+        }),
+      )
+      .describe(L.keywords),
+  });
+}
+
+interface PromptParams {
   question: string;
   entryContent: string;
   targetPeriod: string;
-}): string {
+}
+
+function buildPromptJa(params: PromptParams): string {
   return `あなたは Oryzae の発酵分析エンジンです。
 ユーザーの日記エントリを、修正版グラウンデッド・セオリー・アプローチ（M-GTA）で分析してください。
+
+## 言語
+
+すべての出力 (worksheetMarkdown / resultDiagramMarkdown / snippets / letterBody / keywords) を日本語で生成すること。
 
 ## 入力情報
 
@@ -60,6 +98,7 @@ ${params.entryContent}
 - 各概念に定義・具体例・理論的メモを付与
 - 概念間の関係をカテゴリーにまとめ、ストーリーラインを記述
 - 切片を3種類（new_perspective=新視点・deepen=深化・core=核心）抽出
+- 切片の引用テキストは原文（日本語）のまま用いる。要約や翻訳はしない
 
 ### ステップ2「乳酸菌」：観察メモの生成
 - 体裁: 日記にたまたま取り付いた乳酸菌が、勝手に解釈を書き留めた観察メモ
@@ -83,22 +122,85 @@ ${params.entryContent}
 - 問いに固着しない、より広い視座を喚起するもの`;
 }
 
+function buildPromptEn(params: PromptParams): string {
+  return `You are Oryzae's fermentation analysis engine.
+Analyze the user's journal entries using Modified Grounded Theory Approach (M-GTA).
+
+## Language
+
+Generate every output field (worksheetMarkdown, resultDiagramMarkdown, snippets, letterBody, keywords) in natural English suited to a self-reflective journaler. Do not produce machine-translated Japanese.
+
+## Input
+
+**Question:** ${params.question}
+**Target period:** ${params.targetPeriod}
+
+**Journal entries:**
+---
+${params.entryContent}
+---
+
+## Three analysis steps
+
+### Step 1 "Koji mold": decomposing the journal
+- Following M-GTA, extract 2–3 concepts that relate to the question.
+- For each concept, attach a definition, concrete examples, and a theoretical memo.
+- Group the relationships between concepts into categories and write a storyline.
+- Extract three snippets, one of each type: new_perspective, deepen, core.
+- Quote snippet text verbatim from the entries (in the original language). Do not summarize or translate the quoted text.
+
+### Step 2 "Lactic acid bacteria": the observation note
+- Frame: a colony of lactic-acid bacteria that happened to settle on the journal and jotted down its own interpretation as an observation note.
+- This is NOT a letter to the writer. Do not address them, do not console them. Observe and interpret as a detached third party.
+- About 100 words (≈500 Japanese characters worth of substance). Do not summarize — paraphrase the human's activity from the bacteria's vantage point.
+- Tone: calm, observational. No emotional empathy. Record the patterns and structures you notice.
+- The writer should experience being read by an outside, non-human observer.
+
+#### Forbidden phrasing (do not use; if you add to this list, follow the same spirit)
+- "I empathize" / "I feel for you" / similar empathetic statements
+- "I sense potential" / "promising" framings
+- "we" / "our" used to include the writer
+- Second-person address ("you", "your") that targets the writer as recipient
+
+#### Preferred rephrasings
+- "our X" → "the human's X" (use detached third-person collectives)
+
+### Step 3 "Yeast": keyword generation
+- Generate 3–5 short, poetic keywords or phrases.
+- Evoke a broader perspective rather than fixating on the question itself.`;
+}
+
+function buildPrompt(params: PromptParams, language: FermentationLanguage): string {
+  return language === 'en' ? buildPromptEn(params) : buildPromptJa(params);
+}
+
+// テストから参照するため export。
+export const __INTERNAL = { buildPrompt, buildSchema, SCHEMA_LABELS };
+
 export class VercelAiAnalysisGateway implements LlmAnalysisGateway {
   async analyze(params: {
     question: string;
     entryContent: string;
     targetPeriod: string;
     userId: string;
+    language: FermentationLanguage;
   }): Promise<LlmAnalysisResult> {
     const { object, usage, providerMetadata } = await generateObject({
       model: gateway('anthropic/claude-sonnet-4-20250514'),
-      prompt: buildPrompt(params),
-      schema: fermentationSchema,
+      prompt: buildPrompt(
+        {
+          question: params.question,
+          entryContent: params.entryContent,
+          targetPeriod: params.targetPeriod,
+        },
+        params.language,
+      ),
+      schema: buildSchema(params.language),
       maxOutputTokens: 16000,
       providerOptions: {
         gateway: {
           user: params.userId,
-          tags: ['fermentation'],
+          tags: ['fermentation', `lang:${params.language}`],
         },
       },
     });

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -436,7 +436,8 @@ export const adminFermentations = new Hono<Env>()
       llmGateway,
       () => crypto.randomUUID(),
       listActiveUserIds,
-      (userId, titles) => digestUsecase.execute({ userId, questionTitles: titles }),
+      (userId, titles, language) =>
+        digestUsecase.execute({ userId, questionTitles: titles, language }),
     );
 
     const result = await usecase.execute(now);
@@ -541,11 +542,16 @@ export const adminFermentations = new Hono<Env>()
     const llmGateway = new VercelAiAnalysisGateway();
     const usecase = new RunFermentationUsecase(repo, llmGateway, () => crypto.randomUUID());
 
+    // issue #279: 元 fermentation の所有者ロケールで再実行する。
+    const localeResolver = new SupabaseUserLocaleResolver(supabase);
+    const language = await localeResolver.resolve(fermentation.user_id);
+
     const result = await usecase.execute({
       userId: fermentation.user_id,
       questionId: fermentation.question_id,
       questionText,
       entries,
+      language,
     });
 
     // 5. Send digest email (fire-and-forget)
@@ -554,7 +560,7 @@ export const adminFermentations = new Hono<Env>()
       createSupabaseVerifiedEmailResolver(supabase),
     );
     digestUsecase
-      .execute({ userId: fermentation.user_id, questionTitles: [questionText] })
+      .execute({ userId: fermentation.user_id, questionTitles: [questionText], language })
       .catch(() => {
         // Notification failure must not break retry response.
       });

--- a/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/cron-fermentation.ts
@@ -70,7 +70,8 @@ export const cronFermentation = new Hono()
       llmGateway,
       generateId,
       listActiveUserIds,
-      (userId, titles) => digestUsecase.execute({ userId, questionTitles: titles }),
+      (userId, titles, language) =>
+        digestUsecase.execute({ userId, questionTitles: titles, language }),
     );
 
     // issue #268 以降、発火条件はユーザー単位の状態 (lastRunAt + 文字数 + ランダム X 時間)

--- a/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/fermentations.ts
@@ -7,6 +7,7 @@ import { GetFermentationResultUsecase } from '../../application/usecases/get-fer
 import { ListFermentationResultsUsecase } from '../../application/usecases/list-fermentation-results.usecase.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
 import { SendFermentationDigestUsecase } from '../../application/usecases/send-fermentation-digest.usecase.js';
+import { SupabaseUserLocaleResolver } from '../../infrastructure/auth/supabase-user-locale-resolver.js';
 import { ResendEmailNotifier } from '../../infrastructure/email/resend-email-notifier.js';
 import { createSupabaseVerifiedEmailResolver } from '../../infrastructure/email/supabase-verified-email-resolver.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
@@ -36,12 +37,18 @@ export const fermentations = new Hono<Env>()
     const llmGateway = new VercelAiAnalysisGateway();
     const usecase = new RunFermentationUsecase(repo, llmGateway, generateId);
 
+    // issue #279: ユーザーのロケールを解決して LLM プロンプトと digest 文言を切り替える。
+    // auth.admin.getUserById は service-role 必須なので getSupabaseClient() を使う。
+    const localeResolver = new SupabaseUserLocaleResolver(getSupabaseClient());
+    const language = await localeResolver.resolve(c.get('userId'));
+
     try {
       const result = await usecase.execute({
         userId: c.get('userId'),
         questionId: body.questionId,
         questionText: body.questionText,
         entries: [{ id: body.entryId, content: body.entryContent }],
+        language,
       });
 
       // Send digest email (fire-and-forget). Uses service-role client for auth.admin lookup.
@@ -50,7 +57,7 @@ export const fermentations = new Hono<Env>()
         createSupabaseVerifiedEmailResolver(getSupabaseClient()),
       );
       digestUsecase
-        .execute({ userId: c.get('userId'), questionTitles: [body.questionText] })
+        .execute({ userId: c.get('userId'), questionTitles: [body.questionText], language })
         .catch(() => {
           // Notification failure must not break the API response.
         });

--- a/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/run-fermentation.usecase.test.ts
@@ -61,6 +61,37 @@ describe('RunFermentationUsecase', () => {
     expect(repo.saveKeywords).toHaveBeenCalledOnce();
   });
 
+  it('defaults language to "ja" when not specified (issue #279)', async () => {
+    const repo = mockRepo();
+    const llm = mockLlm();
+    const usecase = new RunFermentationUsecase(repo, llm, generateId);
+
+    await usecase.execute({
+      userId: 'u1',
+      questionId: 'q1',
+      questionText: 'Q',
+      entries: [{ id: 'e1', content: 'c' }],
+    });
+
+    expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'ja' }));
+  });
+
+  it('forwards language="en" to the LLM gateway (issue #279)', async () => {
+    const repo = mockRepo();
+    const llm = mockLlm();
+    const usecase = new RunFermentationUsecase(repo, llm, generateId);
+
+    await usecase.execute({
+      userId: 'u1',
+      questionId: 'q1',
+      questionText: 'Q',
+      entries: [{ id: 'e1', content: 'c' }],
+      language: 'en',
+    });
+
+    expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }));
+  });
+
   it('saves all scanned entry ids when multiple entries are provided', async () => {
     const repo = mockRepo();
     const llm = mockLlm();

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -517,7 +517,80 @@ describe('ScheduledFermentationUsecase (issue #268: 自動発火条件)', () => 
     await usecase.execute(NOW);
 
     expect(sendDigest).toHaveBeenCalledOnce();
-    expect(sendDigest).toHaveBeenCalledWith('user-1', ['Q1 title', 'Q2 title']);
+    expect(sendDigest).toHaveBeenCalledWith('user-1', ['Q1 title', 'Q2 title'], 'ja');
+  });
+
+  it('issue #279: 解決した language が LLM gateway と digest 双方に伝播する', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const question = makeQuestion('user-1', 'q1');
+    const transaction = makeQuestionTransaction('q1', 'Q en');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.countCharsByUserIdSince).mockResolvedValue(2000);
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdSince).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([question]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const llm = mockLlm();
+    const sendDigest = vi.fn().mockResolvedValue(undefined);
+    const localeResolver = mockLocaleResolver('en');
+
+    const usecase = buildUsecase({
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      llm,
+      sendDigest,
+      localeResolver,
+      userIds: ['user-1'],
+    });
+
+    await usecase.execute(NOW);
+
+    expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }));
+    expect(sendDigest).toHaveBeenCalledWith('user-1', ['Q en'], 'en');
+  });
+
+  it('issue #279: ja ロケールはデフォルトとして LLM gateway に伝播する', async () => {
+    const entry = makeEntry('user-1', 'e1');
+    const question = makeQuestion('user-1', 'q1');
+    const transaction = makeQuestionTransaction('q1', 'Q ja');
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.countCharsByUserIdSince).mockResolvedValue(2000);
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdSince).mockResolvedValue([entry]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([question]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(transaction);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const llm = mockLlm();
+
+    const usecase = buildUsecase({
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      llm,
+      userIds: ['user-1'],
+    });
+
+    await usecase.execute(NOW);
+
+    expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'ja' }));
   });
 
   it('digest 失敗が cron 全体を壊さない', async () => {

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -101,4 +101,61 @@ describe('SendFermentationDigestUsecase', () => {
       'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae-client.vercel.app/jar',
     );
   });
+
+  describe('issue #279: language switching', () => {
+    it('uses English subject and single-title body when language="en"', async () => {
+      const notifier = mockNotifier();
+      const usecase = new SendFermentationDigestUsecase(
+        notifier,
+        vi.fn().mockResolvedValue('user@example.com'),
+      );
+
+      await usecase.execute({
+        userId: 'u1',
+        questionTitles: ['Why do I work?'],
+        language: 'en',
+      });
+
+      expect(notifier.send).toHaveBeenCalledWith({
+        to: 'user@example.com',
+        subject: 'Your jar has fermented further',
+        bodyText:
+          'Oryzae\'s microbes have responded to what you wrote about "Why do I work?".\nhttps://oryzae-client.vercel.app/jar',
+      });
+    });
+
+    it('uses English bullet-list body for multiple titles when language="en"', async () => {
+      const notifier = mockNotifier();
+      const usecase = new SendFermentationDigestUsecase(
+        notifier,
+        vi.fn().mockResolvedValue('user@example.com'),
+      );
+
+      await usecase.execute({
+        userId: 'u1',
+        questionTitles: ['Why do I work?', 'Who am I to my friends?'],
+        language: 'en',
+      });
+
+      const call = vi.mocked(notifier.send).mock.calls[0][0];
+      expect(call.subject).toBe('Your jar has fermented further');
+      expect(call.bodyText).toBe(
+        "Oryzae's microbes have responded to what you wrote about the following questions:\n\n- Why do I work?\n- Who am I to my friends?\n\nhttps://oryzae-client.vercel.app/jar",
+      );
+    });
+
+    it('falls back to Japanese when language is omitted', async () => {
+      const notifier = mockNotifier();
+      const usecase = new SendFermentationDigestUsecase(
+        notifier,
+        vi.fn().mockResolvedValue('user@example.com'),
+      );
+
+      await usecase.execute({ userId: 'u1', questionTitles: ['なぜ働くのか'] });
+
+      const call = vi.mocked(notifier.send).mock.calls[0][0];
+      expect(call.subject).toBe('あなたの瓶の発酵が進みました');
+      expect(call.bodyText).toContain('Oryzaeの菌たちが反応を生成しました');
+    });
+  });
 });

--- a/apps/server/test/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.test.ts
+++ b/apps/server/test/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { __INTERNAL } from '@/contexts/fermentation/infrastructure/llm/vercel-ai-analysis.gateway.js';
+
+// issue #279: ja/en でプロンプトと schema description が切り替わることを担保する。
+// 実 LLM 呼び出しはモックされた application 層からは見えないので、
+// infrastructure 内部の buildPrompt/buildSchema を直接検証する。
+describe('VercelAiAnalysisGateway prompts (issue #279)', () => {
+  const sampleInput = {
+    question: 'Why do I write?',
+    entryContent: 'Today I wrote because I felt restless.',
+    targetPeriod: '2026-05-06',
+  };
+
+  describe('buildPrompt', () => {
+    it('emits a Japanese prompt when language="ja"', () => {
+      const prompt = __INTERNAL.buildPrompt(sampleInput, 'ja');
+      expect(prompt).toContain('Oryzae の発酵分析エンジン');
+      expect(prompt).toContain('日本語で生成');
+      expect(prompt).toContain('M-GTA');
+      expect(prompt).toContain('「コウジカビ」');
+      expect(prompt).toContain('「乳酸菌」');
+      expect(prompt).toContain('「酵母」');
+      // English-only sentinel must not appear in the ja branch.
+      expect(prompt).not.toContain("Oryzae's fermentation analysis engine");
+    });
+
+    it('emits an English prompt when language="en"', () => {
+      const prompt = __INTERNAL.buildPrompt(sampleInput, 'en');
+      expect(prompt).toContain("Oryzae's fermentation analysis engine");
+      expect(prompt).toContain('Generate every output field');
+      expect(prompt).toContain('Modified Grounded Theory Approach');
+      expect(prompt).toContain('Koji mold');
+      expect(prompt).toContain('Lactic acid bacteria');
+      expect(prompt).toContain('Yeast');
+      // ja-only sentinels must not bleed into the en prompt.
+      expect(prompt).not.toContain('日本語で生成');
+      expect(prompt).not.toContain('「コウジカビ」');
+    });
+
+    it('embeds the question, entry content, and target period in both languages', () => {
+      for (const lang of ['ja', 'en'] as const) {
+        const prompt = __INTERNAL.buildPrompt(sampleInput, lang);
+        expect(prompt).toContain(sampleInput.question);
+        expect(prompt).toContain(sampleInput.entryContent);
+        expect(prompt).toContain(sampleInput.targetPeriod);
+      }
+    });
+
+    it('keeps verbatim-quote instruction in both branches (snippet text must stay in source language)', () => {
+      expect(__INTERNAL.buildPrompt(sampleInput, 'ja')).toContain('原文');
+      expect(__INTERNAL.buildPrompt(sampleInput, 'en')).toContain('verbatim');
+    });
+  });
+
+  describe('buildSchema descriptions', () => {
+    it('localizes the worksheet description per language', () => {
+      const ja = __INTERNAL.SCHEMA_LABELS.ja.worksheet;
+      const en = __INTERNAL.SCHEMA_LABELS.en.worksheet;
+      expect(ja).toContain('M-GTA分析ワークシート');
+      expect(en).toContain('M-GTA analysis worksheet');
+      expect(ja).not.toEqual(en);
+    });
+
+    it('localizes the letter description per language', () => {
+      const ja = __INTERNAL.SCHEMA_LABELS.ja.letter;
+      const en = __INTERNAL.SCHEMA_LABELS.en.letter;
+      expect(ja).toContain('観察メモ');
+      expect(en.toLowerCase()).toContain('observation note');
+    });
+
+    it('produces a valid Zod schema for both languages', () => {
+      const validOutput = {
+        worksheetMarkdown: '# Worksheet',
+        resultDiagramMarkdown: '# Diagram',
+        snippets: [{ type: 'core', text: 't', sourceDate: '2026-05-06', reason: 'r' }],
+        letterBody: 'observation',
+        keywords: [{ keyword: 'k', description: 'd' }],
+      };
+      expect(__INTERNAL.buildSchema('ja').safeParse(validOutput).success).toBe(true);
+      expect(__INTERNAL.buildSchema('en').safeParse(validOutput).success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #279

#268 で整備した `SupabaseUserLocaleResolver` 経由の locale 解決を LLM プロンプト・スキーマ説明・digest メールに繋ぎ込み、英語ユーザーには英語で letter / keywords / snippets / worksheet / digest を返せるようにする。

## 変更概要

| layer | 変更 |
| --- | --- |
| domain | `LlmAnalysisGateway.analyze` 引数に `language: FermentationLanguage` を追加 |
| infrastructure | `vercel-ai-analysis.gateway.ts` の system prompt と schema description を ja/en に分岐。引用テキストは原文ママ。`tags: ['fermentation', 'lang:<ja\|en>']` |
| application | `RunFermentationUsecase` / `ScheduledFermentationUsecase` / `SendFermentationDigestUsecase` で language を引き回し |
| presentation | `fermentations.ts` (POST /) と `admin-fermentations.ts` retry で `SupabaseUserLocaleResolver` を使って解決。cron / trigger-scheduled の digest callback を `(userId, titles, language)` に更新 |

## テスト

- `pnpm typecheck` ✅ (server / shared / client / admin)
- `pnpm --filter @oryzae/server test` ✅ (51 files / 255 tests)
- `pnpm dep-cruise` ✅ / `pnpm knip` ✅

追加・変更したテスト:
- `run-fermentation.usecase.test.ts` — 既定 `ja` / `en` 指定が gateway に伝播
- `scheduled-fermentation.usecase.test.ts` — 解決済 language が LLM gateway と digest 双方に届く / ja 既定の伝播
- `send-fermentation-digest.usecase.test.ts` — en の subject / single / multi body, ja fallback
- `vercel-ai-analysis.gateway.test.ts` (新規, infrastructure) — ja/en の prompt 文言切替と schema validity

## 受け入れ基準への対応

- [x] `user_metadata.locale = 'en'` のユーザーで発酵すると、letter / keywords / snippets / worksheet が英語で生成される (prompt + schema description で英語指示)
- [x] 既存の日本語ユーザーには影響なし (default 'ja' / 既存プロンプト文言維持)
- [ ] e2e で 1 ユーザー分、英語ロケールで実際に走らせて output を確認 — 本 PR ではユニット/契約レベルまで。リリース前に手動 e2e を実施
- [ ] admin の Fermentation 詳細ページで英語 output が崩れず表示される — Markdown レンダラはロケール非依存だが、英語 output で実機確認はリリース前に併せて実施

## フォールバック方針

ロケール解決失敗時は `'ja'` (#268 の方針を踏襲)。既存の発酵結果は再翻訳しない (作成時のロケールで固定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)