### PR TITLE
fix(fermentation): メール送信失敗の可観測性を確保 (#288)

### DIFF
--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -22,6 +22,8 @@ interface ScheduledFermentationResult {
   succeeded: number;
   failed: number;
   errors: Array<{ userId: string; questionId: string; error: string }>;
+  // issue #288: メール送信失敗を上位 (admin / Discord 通知) に伝えるため集計する。
+  emailFailures: Array<{ userId: string; error: string }>;
 }
 
 // 発酵プロセス自動発火 (issue #268)。
@@ -64,6 +66,7 @@ export class ScheduledFermentationUsecase {
       succeeded: 0,
       failed: 0,
       errors: [],
+      emailFailures: [],
     };
 
     const userIds = await this.listActiveUserIds();
@@ -176,11 +179,20 @@ export class ScheduledFermentationUsecase {
     }
 
     for (const [userId, titles] of successfulTitlesByUser) {
+      const lang = languageByUser.get(userId) ?? 'ja';
       try {
-        const lang = languageByUser.get(userId) ?? 'ja';
         await this.sendDigest(userId, titles, lang);
-      } catch {
-        // Notification failure must not break the scheduled job.
+      } catch (error) {
+        // 設計思想: メール送信失敗は発酵ジョブ全体を止めない (issue #268)。
+        // ただし黙殺せず、result に集計してログを出して上位の Discord 通知 / admin
+        // 監視で発見できるようにする (issue #288)。
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        console.error('[ScheduledFermentationUsecase] digest email failed', {
+          userId,
+          titleCount: titles.length,
+          error: message,
+        });
+        result.emailFailures.push({ userId, error: message });
       }
     }
 

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -50,7 +50,15 @@ export class SendFermentationDigestUsecase {
     if (uniqueTitles.length === 0) return;
 
     const email = await this.resolveVerifiedEmail(params.userId);
-    if (!email) return;
+    if (!email) {
+      // 未検証メール / メール未登録ユーザーはサイレントスキップで構わないが、
+      // サポート問い合わせで切り分けられるよう warn だけ残す (issue #288)。
+      console.warn('[SendFermentationDigestUsecase] skipped — verified email not found', {
+        userId: params.userId,
+        titleCount: uniqueTitles.length,
+      });
+      return;
+    }
 
     const language: FermentationLanguage = params.language ?? 'ja';
     const copy = COPY[language];

--- a/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
@@ -3,16 +3,31 @@ import type {
   SendEmailParams,
 } from '../../domain/gateways/email-notifier.gateway.js';
 
+// Resend 経由で発酵 digest メールを送る実装。
+// graceful degradation (失敗してもジョブ全体を止めない) は呼び出し元の責務とし、
+// この層では「失敗はログ + throw」 を徹底する (issue #288)。サイレントスキップで
+// メールが届かないまま誰も気付けない、という旧実装の問題に対処するため。
 export class ResendEmailNotifier implements EmailNotifier {
   async send(params: SendEmailParams): Promise<void> {
     const apiKey = process.env.RESEND_API_KEY;
     const from = process.env.EMAIL_FROM ?? 'Oryzae <noreply@oryzae.ephemere.io>';
     const enabled = process.env.EMAIL_ENABLED !== 'false';
 
-    if (!enabled || !apiKey) return;
+    // EMAIL_ENABLED=false は dev 環境向けの意図的なオフ。
+    if (!enabled) return;
 
+    // 本番で API キーが抜けている場合はサイレントにせず、warn でミスを発見できるように。
+    if (!apiKey) {
+      console.warn('[ResendEmailNotifier] RESEND_API_KEY not set — skipping email send', {
+        to: params.to,
+        subject: params.subject,
+      });
+      return;
+    }
+
+    let response: Response;
     try {
-      await fetch('https://api.resend.com/emails', {
+      response = await fetch('https://api.resend.com/emails', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${apiKey}`,
@@ -25,8 +40,25 @@ export class ResendEmailNotifier implements EmailNotifier {
           text: params.bodyText,
         }),
       });
-    } catch {
-      // Silently ignore — notification failure must not break the app.
+    } catch (error) {
+      // Network error (DNS, TLS, abort, etc.).
+      console.error('[ResendEmailNotifier] fetch failed', {
+        to: params.to,
+        subject: params.subject,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      console.error('[ResendEmailNotifier] Resend API returned non-2xx', {
+        to: params.to,
+        subject: params.subject,
+        status: response.status,
+        body: body.slice(0, 500),
+      });
+      throw new Error(`Resend API returned ${response.status}: ${body.slice(0, 200)}`);
     }
   }
 }

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -442,8 +442,8 @@ export const adminFermentations = new Hono<Env>()
 
     const result = await usecase.execute(now);
 
-    // Notify Discord if there were failures
-    if (result.failed > 0) {
+    // Notify Discord if there were failures (issue #288: メール失敗もカバー)
+    if (result.failed > 0 || result.emailFailures.length > 0) {
       notifyDiscord({
         title: 'スケジュール発酵 — 失敗あり',
         color: COLORS.WARNING,
@@ -451,11 +451,20 @@ export const adminFermentations = new Hono<Env>()
           { name: '評価時刻', value: now.toISOString(), inline: true },
           { name: '対象ユーザー', value: String(result.totalUsers), inline: true },
           { name: '成功', value: String(result.succeeded), inline: true },
-          { name: '失敗', value: String(result.failed), inline: true },
+          { name: '発酵失敗', value: String(result.failed), inline: true },
+          { name: 'メール失敗', value: String(result.emailFailures.length), inline: true },
           {
-            name: 'エラー詳細',
+            name: '発酵エラー詳細',
             value:
               result.errors
+                .slice(0, 3)
+                .map((e) => `${e.userId.slice(0, 8)}: ${e.error.slice(0, 80)}`)
+                .join('\n') || '-',
+          },
+          {
+            name: 'メールエラー詳細',
+            value:
+              result.emailFailures
                 .slice(0, 3)
                 .map((e) => `${e.userId.slice(0, 8)}: ${e.error.slice(0, 80)}`)
                 .join('\n') || '-',
@@ -561,8 +570,13 @@ export const adminFermentations = new Hono<Env>()
     );
     digestUsecase
       .execute({ userId: fermentation.user_id, questionTitles: [questionText], language })
-      .catch(() => {
-        // Notification failure must not break retry response.
+      .catch((error: unknown) => {
+        // Notification failure must not break retry response (issue #288: ただしログは残す)。
+        console.error('[admin-fermentations] retry digest email failed', {
+          userId: fermentation.user_id,
+          fermentationId: fermentation.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
 
     return c.json({ id: result.id }, 201);

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -593,7 +593,7 @@ describe('ScheduledFermentationUsecase (issue #268: 自動発火条件)', () => 
     expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'ja' }));
   });
 
-  it('digest 失敗が cron 全体を壊さない', async () => {
+  it('digest 失敗が cron 全体を壊さず、emailFailures に集計される (issue #288)', async () => {
     const entry = makeEntry('user-1', 'e1');
     const question = makeQuestion('user-1', 'q1');
     const transaction = makeQuestionTransaction('q1', 'Q');
@@ -612,6 +612,7 @@ describe('ScheduledFermentationUsecase (issue #268: 自動発火条件)', () => 
     vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
 
     const sendDigest = vi.fn().mockRejectedValue(new Error('email down'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const usecase = buildUsecase({
       entryRepo,
@@ -626,6 +627,13 @@ describe('ScheduledFermentationUsecase (issue #268: 自動発火条件)', () => 
 
     expect(result.succeeded).toBe(1);
     expect(sendDigest).toHaveBeenCalledOnce();
+    // 旧実装ではメール失敗が黙殺されて結果から消えていた (issue #288)
+    expect(result.emailFailures).toEqual([{ userId: 'user-1', error: 'email down' }]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[ScheduledFermentationUsecase] digest email failed',
+      expect.objectContaining({ userId: 'user-1', error: 'email down' }),
+    );
+    errorSpy.mockRestore();
   });
 
   it('アクティブユーザーがいない場合、副作用なし', async () => {

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -18,15 +18,21 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).not.toHaveBeenCalled();
   });
 
-  it('no-ops when resolver returns null (unverified or missing email)', async () => {
+  it('no-ops + warns when resolver returns null (unverified / missing email, issue #288)', async () => {
     const notifier = mockNotifier();
     const resolve = vi.fn().mockResolvedValue(null);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const usecase = new SendFermentationDigestUsecase(notifier, resolve);
 
     await usecase.execute({ userId: 'u1', questionTitles: ['Q1'] });
 
     expect(resolve).toHaveBeenCalledWith('u1');
     expect(notifier.send).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[SendFermentationDigestUsecase] skipped — verified email not found',
+      expect.objectContaining({ userId: 'u1', titleCount: 1 }),
+    );
+    warnSpy.mockRestore();
   });
 
   it('sends single-title body in the original issue wording', async () => {

--- a/apps/server/test/contexts/fermentation/infrastructure/email/resend-email-notifier.test.ts
+++ b/apps/server/test/contexts/fermentation/infrastructure/email/resend-email-notifier.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResendEmailNotifier } from '@/contexts/fermentation/infrastructure/email/resend-email-notifier.js';
+
+const PARAMS = {
+  to: 'user@example.com',
+  subject: 'Subject',
+  bodyText: 'Body',
+};
+
+describe('ResendEmailNotifier (issue #288: failure observability)', () => {
+  const originalEnv = { ...process.env };
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    fetchSpy.mockReset();
+    errorSpy.mockClear();
+    warnSpy.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('sends to Resend with the configured api key + EMAIL_FROM and resolves on 2xx', async () => {
+    process.env.RESEND_API_KEY = 'rk_test';
+    process.env.EMAIL_FROM = 'Oryzae <noreply@example.com>';
+    delete process.env.EMAIL_ENABLED;
+    fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const notifier = new ResendEmailNotifier();
+    await notifier.send(PARAMS);
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init?.method).toBe('POST');
+    // HeadersInit は object | array | Headers のユニオンなので Headers でラップして取り出す
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer rk_test');
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body).toEqual({
+      from: 'Oryzae <noreply@example.com>',
+      to: ['user@example.com'],
+      subject: 'Subject',
+      text: 'Body',
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws AND logs error when Resend returns non-2xx', async () => {
+    process.env.RESEND_API_KEY = 'rk_test';
+    delete process.env.EMAIL_ENABLED;
+    fetchSpy.mockResolvedValueOnce(
+      new Response('{"name":"validation_error","message":"Invalid `to`"}', { status: 422 }),
+    );
+
+    const notifier = new ResendEmailNotifier();
+    await expect(notifier.send(PARAMS)).rejects.toThrow(/422/);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [, payload] = errorSpy.mock.calls[0];
+    expect(payload).toMatchObject({
+      to: 'user@example.com',
+      status: 422,
+    });
+  });
+
+  it('throws AND logs error when fetch itself rejects (network error)', async () => {
+    process.env.RESEND_API_KEY = 'rk_test';
+    delete process.env.EMAIL_ENABLED;
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    const notifier = new ResendEmailNotifier();
+    await expect(notifier.send(PARAMS)).rejects.toThrow('ECONNRESET');
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [, payload] = errorSpy.mock.calls[0];
+    expect(payload).toMatchObject({ to: 'user@example.com', error: 'ECONNRESET' });
+  });
+
+  it('skips silently (no fetch, no log) when EMAIL_ENABLED=false (dev opt-out)', async () => {
+    process.env.RESEND_API_KEY = 'rk_test';
+    process.env.EMAIL_ENABLED = 'false';
+
+    const notifier = new ResendEmailNotifier();
+    await notifier.send(PARAMS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns and skips (no throw) when RESEND_API_KEY is missing', async () => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.EMAIL_ENABLED;
+
+    const notifier = new ResendEmailNotifier();
+    await notifier.send(PARAMS);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain('RESEND_API_KEY not set');
+  });
+});


### PR DESCRIPTION
## 概要

Closes #288

発酵 digest メール送信フローを調査したところ、**送信失敗が完全に黙殺**されており、本番でユーザーにメールが届かなくても誰も気付けない状態だった。失敗を「見える」ようにする。

## 修正内容

### 1. `ResendEmailNotifier` (`apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts`)

- `response.ok` を検証 → 4xx/5xx は `console.error` ログ + throw
- `fetch` の network error も `console.error` + throw
- `RESEND_API_KEY` 未設定時は `console.warn`（本番ミス検知）
- `EMAIL_ENABLED=false` のサイレントオフは維持（dev 用）

graceful degradation は呼び出し元の責務として明確化。

### 2. `SendFermentationDigestUsecase`

未検証メール / メール未登録ユーザーをサイレントスキップしていたが、`console.warn(userId, titleCount)` だけ残すように。動作（no-op）は変えない。サポート問い合わせ時の切り分けを容易に。

### 3. `ScheduledFermentationUsecase`

- 結果型に `emailFailures: Array<{ userId, error }>` を追加
- catch 節で握りつぶさず集計 + `console.error`
- **発酵ジョブ全体は止めない設計思想 (#268) は維持**

### 4. `admin-fermentations.ts`

- `/trigger-scheduled`: Discord 通知の発火条件に `emailFailures > 0` を追加。embed に「メール失敗」件数とエラー抜粋を表示
- `/retry`: fire-and-forget の `.catch()` でログを残す

## テスト

| ファイル | 内容 |
|---|---|
| `resend-email-notifier.test.ts` (新規) | 5 ケース: 2xx 成功 / 非 2xx 時 throw + log / fetch reject 時 throw + log / `EMAIL_ENABLED=false` でサイレント / API キー無しで warn |
| `scheduled-fermentation.usecase.test.ts` | 既存「digest 失敗が cron 全体を壊さない」を拡張し、`emailFailures` 集計と `console.error` 呼び出しを検証 |
| `send-fermentation-digest.usecase.test.ts` | resolver null 時の warn ログを検証 |

## チェック

```
pnpm typecheck    ✅
pnpm test         ✅ (server: 260 / admin: 60 / client: passed)
pnpm dep-cruise   ✅
pnpm knip         ✅
```

`pnpm lint` には事前から存在する `apps/client/` の a11y/perf 警告がありますが、本 PR の変更箇所 (server) ではゼロ。

## 設計思想の維持

- 「メール失敗で発酵ジョブ全体を落とさない」(#268) は変更なし
- 失敗を **見えるようにする** ことが今回の目的（自動リトライまでは入れない）
- `as` キャスト規約遵守、`any` なし、ガードレールに違反していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)