### PR TITLE
feat(admin): 特定ユーザー・問いに対する発酵強制発火デバッグツール (#290)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,10 @@ DISCORD_WEBHOOK_URL=
 # API key — https://resend.com/api-keys
 RESEND_API_KEY=
 # Sender identity. Requires verified domain in Resend dashboard.
-EMAIL_FROM=Oryzae <noreply@oryzae.ephemere.io>
+# `mail.oryzae.ephemere.io` is the dedicated email-sending subdomain (Route53で
+# アプリ本体の `oryzae.ephemere.io` と分離して登録)。Resend Domains に同サブ
+# ドメインを verify した上でこの値を使う。
+EMAIL_FROM=Oryzae <noreply@mail.oryzae.ephemere.io>
 # Set to "false" to disable email sending (e.g. in dev). Default: enabled when RESEND_API_KEY is set.
 EMAIL_ENABLED=true
 

--- a/apps/admin/src/app/(protected)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(protected)/users/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { FireFermentationPanel } from '@/features/users/components/fire-fermentation-panel';
 import { UserEntryList } from '@/features/users/components/user-entry-list';
 import { UserFermentationHistory } from '@/features/users/components/user-fermentation-history';
 import { UserFermentationReadiness } from '@/features/users/components/user-fermentation-readiness';
@@ -16,11 +17,12 @@ import { useUserDetail } from '@/features/users/hooks/use-user-detail';
 export default function UserDetailPage() {
   const params = useParams();
   const userId = typeof params.id === 'string' ? params.id : '';
-  const { data, loading, error } = useUserDetail(userId);
+  const { data, loading, error, refresh: refreshUserDetail } = useUserDetail(userId);
   const {
     data: readiness,
     loading: readinessLoading,
     error: readinessError,
+    refresh: refreshReadiness,
   } = useFermentationReadiness(userId);
 
   if (loading) {
@@ -58,6 +60,18 @@ export default function UserDetailPage() {
         readiness={readiness}
         loading={readinessLoading}
         error={readinessError}
+      />
+
+      <FireFermentationPanel
+        userId={userId}
+        questions={data.questions
+          .filter((q) => !q.isArchived)
+          .map((q) => ({ id: q.id, text: q.text }))}
+        onCompleted={() => {
+          // 発火後に履歴と readiness をリフレッシュ
+          refreshUserDetail();
+          refreshReadiness();
+        }}
       />
 
       <WritingHeatmap entryDates={data.entryDates} />

--- a/apps/admin/src/app/(protected)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(protected)/users/[id]/page.tsx
@@ -25,11 +25,14 @@ export default function UserDetailPage() {
     refresh: refreshReadiness,
   } = useFermentationReadiness(userId);
 
-  if (loading) {
-    return <p className="text-sm text-muted-foreground py-8 text-center">Loading...</p>;
-  }
-
-  if (error || !data) {
+  // 初回ロードのみ全画面 Loading / Error を出す。
+  // refresh (例: FireFermentationPanel が onCompleted で呼ぶ) 中はページごと
+  // アンマウントすると panel の result state が消えてしまうため、データが既に
+  // あるときは stale-while-revalidate でそのまま描画を続ける (issue #290 フォロー)。
+  if (!data) {
+    if (loading) {
+      return <p className="text-sm text-muted-foreground py-8 text-center">Loading...</p>;
+    }
     return (
       <div className="space-y-4">
         <Link href="/users">

--- a/apps/admin/src/features/users/components/fire-fermentation-panel.tsx
+++ b/apps/admin/src/features/users/components/fire-fermentation-panel.tsx
@@ -18,10 +18,36 @@ interface Props {
 
 type LanguageChoice = 'auto' | 'ja' | 'en';
 
+// emailSent=false のときにユーザー向けに reason を翻訳する。
+// server 側の DigestSendResult.reason に対応 (issue #290 フォロー)。
+function formatEmailReason(result: {
+  emailReason?: string;
+  emailFailure?: { error: string };
+}): string {
+  if (result.emailFailure) return `送信失敗: ${result.emailFailure.error}`;
+  switch (result.emailReason) {
+    case 'skipped-by-request':
+      return 'スキップ (skipEmail=true)';
+    case 'no-verified-email':
+      return 'メール未認証 (email_confirmed_at=null)';
+    case 'no-api-key':
+      return 'RESEND_API_KEY 未設定';
+    case 'disabled':
+      return 'EMAIL_ENABLED=false';
+    case 'no-titles':
+      return 'タイトル無し (内部状態の異常)';
+    default:
+      return result.emailReason ?? '不明';
+  }
+}
+
 export function FireFermentationPanel({ userId, questions, onCompleted }: Props) {
   const [questionId, setQuestionId] = useState<string>(''); // '' = 全 active 問い
   const [language, setLanguage] = useState<LanguageChoice>('auto');
   const [skipEmail, setSkipEmail] = useState(false);
+  // issue #290 フォロー: 自分の test アカウント (email_confirmed_at が null) にも
+  // 送りたいときに ON。通常フローでは未検証メールにはスパム防止のため送らない。
+  const [forceUnverified, setForceUnverified] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const { fire, loading, error, result, reset } = useFireFermentation();
 
@@ -40,6 +66,7 @@ export function FireFermentationPanel({ userId, questions, onCompleted }: Props)
       questionId: questionId || undefined,
       language: language === 'auto' ? undefined : language,
       skipEmail: skipEmail || undefined,
+      forceUnverified: forceUnverified || undefined,
     });
     if (ok) onCompleted?.();
   };
@@ -115,6 +142,20 @@ export function FireFermentationPanel({ userId, questions, onCompleted }: Props)
         <span>メール送信をスキップ (LLM 出力だけ確認したいとき)</span>
       </label>
 
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={forceUnverified}
+          onChange={(e) => {
+            setForceUnverified(e.target.checked);
+            handleChange();
+          }}
+          disabled={loading || skipEmail}
+          className="h-3.5 w-3.5 rounded border-input"
+        />
+        <span>未認証メールにも送信 (email_confirmed_at が null でも送る — test 用)</span>
+      </label>
+
       <Button
         variant={confirming ? 'destructive' : 'default'}
         size="sm"
@@ -135,7 +176,7 @@ export function FireFermentationPanel({ userId, questions, onCompleted }: Props)
         <div className="space-y-1 rounded-md bg-muted/50 px-3 py-2 text-xs">
           <div className="font-mono text-muted-foreground">
             fired: {result.fired.length} · email:{' '}
-            {result.emailSent ? '送信済' : skipEmail ? 'スキップ' : '送信せず'}
+            {result.emailSent ? '✅ 送信済' : `❌ 送信されず (${formatEmailReason(result)})`}
           </div>
           <ul className="space-y-0.5 font-mono">
             {result.fired.map((f) => (
@@ -147,6 +188,22 @@ export function FireFermentationPanel({ userId, questions, onCompleted }: Props)
           </ul>
           {result.emailFailure && (
             <div className="text-destructive">email error: {result.emailFailure.error}</div>
+          )}
+          {result.emailSent === false && result.emailReason === 'no-verified-email' && (
+            <div className="text-muted-foreground">
+              💡 ヒント: ユーザーの email_confirmed_at が null。「未認証メールにも送信」を ON
+              にすると送れます。
+            </div>
+          )}
+          {result.emailSent === false && result.emailReason === 'no-api-key' && (
+            <div className="text-muted-foreground">
+              💡 ヒント: server の RESEND_API_KEY 環境変数が設定されていません。
+            </div>
+          )}
+          {result.emailSent === false && result.emailReason === 'disabled' && (
+            <div className="text-muted-foreground">
+              💡 ヒント: server の EMAIL_ENABLED=false (dev opt-out) になっています。
+            </div>
           )}
         </div>
       )}

--- a/apps/admin/src/features/users/components/fire-fermentation-panel.tsx
+++ b/apps/admin/src/features/users/components/fire-fermentation-panel.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Flame } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useFireFermentation } from '../hooks/use-fire-fermentation';
+
+// issue #290: 特定ユーザー / 問いに対する発酵強制発火 (admin デバッグ用)。
+// 条件ゲートをバイパスするため、本番ユーザーへの誤実行を防ぐ「2 段階クリック」を採用。
+
+interface Props {
+  userId: string;
+  // active questions のみ。空配列のときはパネル全体を非表示にする。
+  questions: Array<{ id: string; text: string }>;
+  // 発火後にユーザー詳細をリフレッシュさせるためのコールバック (任意)。
+  onCompleted?: () => void;
+}
+
+type LanguageChoice = 'auto' | 'ja' | 'en';
+
+export function FireFermentationPanel({ userId, questions, onCompleted }: Props) {
+  const [questionId, setQuestionId] = useState<string>(''); // '' = 全 active 問い
+  const [language, setLanguage] = useState<LanguageChoice>('auto');
+  const [skipEmail, setSkipEmail] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const { fire, loading, error, result, reset } = useFireFermentation();
+
+  if (questions.length === 0) {
+    return null;
+  }
+
+  const handleRun = async () => {
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+    setConfirming(false);
+    const ok = await fire({
+      userId,
+      questionId: questionId || undefined,
+      language: language === 'auto' ? undefined : language,
+      skipEmail: skipEmail || undefined,
+    });
+    if (ok) onCompleted?.();
+  };
+
+  const handleChange = () => {
+    // 入力を変えたら確認状態をリセット
+    setConfirming(false);
+    if (error || result) reset();
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-border/40 bg-card px-3 py-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          発酵を強制発火 (デバッグ用)
+        </h4>
+        <span className="text-[10px] text-muted-foreground">条件ゲートをバイパス</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 text-xs">
+          <span className="text-muted-foreground">問い</span>
+          <select
+            value={questionId}
+            onChange={(e) => {
+              setQuestionId(e.target.value);
+              handleChange();
+            }}
+            disabled={loading}
+            className="h-8 rounded-md border border-input bg-transparent px-2 text-xs"
+          >
+            <option value="">全 active 問い ({questions.length} 件)</option>
+            {questions.map((q) => (
+              <option key={q.id} value={q.id}>
+                {q.text.length > 60 ? `${q.text.slice(0, 60)}…` : q.text}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-xs">
+          <span className="text-muted-foreground">言語</span>
+          <select
+            value={language}
+            onChange={(e) => {
+              const next = e.target.value;
+              if (next === 'auto' || next === 'ja' || next === 'en') {
+                setLanguage(next);
+                handleChange();
+              }
+            }}
+            disabled={loading}
+            className="h-8 rounded-md border border-input bg-transparent px-2 text-xs"
+          >
+            <option value="auto">自動 (ユーザーの user_metadata.locale)</option>
+            <option value="ja">日本語</option>
+            <option value="en">English</option>
+          </select>
+        </label>
+      </div>
+
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={skipEmail}
+          onChange={(e) => {
+            setSkipEmail(e.target.checked);
+            handleChange();
+          }}
+          disabled={loading}
+          className="h-3.5 w-3.5 rounded border-input"
+        />
+        <span>メール送信をスキップ (LLM 出力だけ確認したいとき)</span>
+      </label>
+
+      <Button
+        variant={confirming ? 'destructive' : 'default'}
+        size="sm"
+        onClick={handleRun}
+        disabled={loading}
+      >
+        <Flame className={`mr-1.5 h-3 w-3 ${loading ? 'animate-pulse' : ''}`} />
+        {loading ? '実行中...' : confirming ? '本当に発火する' : '発火'}
+      </Button>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-1 rounded-md bg-muted/50 px-3 py-2 text-xs">
+          <div className="font-mono text-muted-foreground">
+            fired: {result.fired.length} · email:{' '}
+            {result.emailSent ? '送信済' : skipEmail ? 'スキップ' : '送信せず'}
+          </div>
+          <ul className="space-y-0.5 font-mono">
+            {result.fired.map((f) => (
+              <li key={f.fermentationResultId}>
+                {f.fermentationResultId.slice(0, 8)}: {f.questionText.slice(0, 60)}
+                {f.questionText.length > 60 ? '…' : ''}
+              </li>
+            ))}
+          </ul>
+          {result.emailFailure && (
+            <div className="text-destructive">email error: {result.emailFailure.error}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/users/hooks/use-fire-fermentation.ts
+++ b/apps/admin/src/features/users/hooks/use-fire-fermentation.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+// issue #290: admin デバッグ用に特定ユーザー / 問いを強制発火する。
+// レスポンスは server 側 fireFermentationSchema + FireFermentationUsecase の出力に対応。
+interface FireFermentationResponse {
+  fired: Array<{
+    fermentationResultId: string;
+    questionId: string;
+    questionText: string;
+  }>;
+  emailSent: boolean;
+  emailFailure?: { error: string };
+}
+
+interface FireFermentationParams {
+  userId: string;
+  questionId?: string;
+  language?: 'ja' | 'en';
+  skipEmail?: boolean;
+}
+
+export function useFireFermentation() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<FireFermentationResponse | null>(null);
+
+  const fire = useCallback(async (params: FireFermentationParams): Promise<boolean> => {
+    const token = getAccessToken();
+    if (!token) return false;
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch('/api/v1/admin/fermentations/fire', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+
+    if (res.ok) {
+      const body = (await res.json()) as FireFermentationResponse;
+      setResult(body);
+      setLoading(false);
+      return true;
+    }
+
+    // server は失敗時に { error: string } を返す。可能なら本文を拾って表示する。
+    let message = '発酵プロセスの強制発火に失敗しました';
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (typeof body.error === 'string' && body.error.length > 0) message = body.error;
+    } catch {
+      // body が JSON でない (HTML / 空) 場合はデフォルト文言のまま
+    }
+    setError(message);
+    setLoading(false);
+    return false;
+  }, []);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setResult(null);
+  }, []);
+
+  return { fire, loading, error, result, reset };
+}

--- a/apps/admin/src/features/users/hooks/use-fire-fermentation.ts
+++ b/apps/admin/src/features/users/hooks/use-fire-fermentation.ts
@@ -6,6 +6,10 @@ import { getAccessToken } from '@/lib/auth';
 
 // issue #290: admin デバッグ用に特定ユーザー / 問いを強制発火する。
 // レスポンスは server 側 fireFermentationSchema + FireFermentationUsecase の出力に対応。
+//
+// emailReason は #290 フォローで追加: 「emailSent: true なのに実際は届かない」
+// ことを防ぐための診断情報。'no-verified-email' / 'no-api-key' / 'disabled' /
+// 'no-titles' / 'skipped-by-request' のいずれか (server 側 DigestSendResult)。
 interface FireFermentationResponse {
   fired: Array<{
     fermentationResultId: string;
@@ -13,6 +17,7 @@ interface FireFermentationResponse {
     questionText: string;
   }>;
   emailSent: boolean;
+  emailReason?: string;
   emailFailure?: { error: string };
 }
 
@@ -21,6 +26,10 @@ interface FireFermentationParams {
   questionId?: string;
   language?: 'ja' | 'en';
   skipEmail?: boolean;
+  // issue #290 フォロー: email_confirmed_at が null のユーザーにも送る
+  // (admin が自分の test アカウントに送りたい場面用)。通常フローでは未検証
+  // メールにはスパム防止のため送らないが、デバッグ用にバイパスを許す。
+  forceUnverified?: boolean;
 }
 
 export function useFireFermentation() {

--- a/apps/admin/test/features/users/hooks/use-fire-fermentation.test.ts
+++ b/apps/admin/test/features/users/hooks/use-fire-fermentation.test.ts
@@ -111,6 +111,31 @@ describe('useFireFermentation', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('forwards forceUnverified=true and stores emailReason from the response (issue #290 follow-up)', async () => {
+    const body = {
+      fired: [{ fermentationResultId: 'fr-1', questionId: 'q1', questionText: 'Q' }],
+      emailSent: false,
+      emailReason: 'no-verified-email',
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, status: 201, body }));
+
+    const { result } = renderHook(() => useFireFermentation());
+
+    await act(async () => {
+      await result.current.fire({ userId: 'u1', forceUnverified: true });
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/fermentations/fire',
+      expect.objectContaining({
+        body: JSON.stringify({ userId: 'u1', forceUnverified: true }),
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.result).toEqual(body);
+    });
+  });
+
   it('returns false when access token is missing', async () => {
     localStorage.removeItem('oryzae_admin_access_token');
     const { result } = renderHook(() => useFireFermentation());

--- a/apps/admin/test/features/users/hooks/use-fire-fermentation.test.ts
+++ b/apps/admin/test/features/users/hooks/use-fire-fermentation.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFireFermentation } from '@/features/users/hooks/use-fire-fermentation';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+interface MockResponseInit {
+  ok: boolean;
+  status?: number;
+  body?: unknown;
+}
+
+function mockResponse({ ok, status, body }: MockResponseInit): Response {
+  return {
+    ok,
+    status: status ?? (ok ? 200 : 400),
+    json: () => Promise.resolve(body ?? {}),
+    // @type-assertion-allowed: テスト用の最小限 Response スタブ
+  } as Response;
+}
+
+describe('useFireFermentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_admin_access_token', 'test-token');
+  });
+
+  it('POSTs to /fire with the params and stores the result on success', async () => {
+    const body = {
+      fired: [{ fermentationResultId: 'fr-1', questionId: 'q1', questionText: 'なぜ働くのか' }],
+      emailSent: true,
+    };
+    mockFetch.mockResolvedValueOnce(mockResponse({ ok: true, status: 201, body }));
+
+    const { result } = renderHook(() => useFireFermentation());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.fire({ userId: 'u1', questionId: 'q1', language: 'ja' });
+    });
+
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/fermentations/fire',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ userId: 'u1', questionId: 'q1', language: 'ja' }),
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.result).toEqual(body);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('extracts the server error message on 4xx', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 400,
+        body: { error: 'Question xyz not found or not active' },
+      }),
+    );
+
+    const { result } = renderHook(() => useFireFermentation());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.fire({ userId: 'u1', questionId: 'xyz' });
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toBe('Question xyz not found or not active');
+    expect(result.current.result).toBeNull();
+  });
+
+  it('falls back to a generic message when the response body is not parseable', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json')),
+      // @type-assertion-allowed: テスト用の最小限 Response スタブ
+    } as Response);
+
+    const { result } = renderHook(() => useFireFermentation());
+
+    await act(async () => {
+      await result.current.fire({ userId: 'u1' });
+    });
+
+    expect(result.current.error).toBe('発酵プロセスの強制発火に失敗しました');
+  });
+
+  it('reset() clears error and result', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 201, body: { fired: [], emailSent: false } }),
+    );
+
+    const { result } = renderHook(() => useFireFermentation());
+
+    await act(async () => {
+      await result.current.fire({ userId: 'u1' });
+    });
+    expect(result.current.result).not.toBeNull();
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.result).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns false when access token is missing', async () => {
+    localStorage.removeItem('oryzae_admin_access_token');
+    const { result } = renderHook(() => useFireFermentation());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.fire({ userId: 'u1' });
+    });
+
+    expect(ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/contexts/fermentation/application/usecases/fire-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/fire-fermentation.usecase.ts
@@ -1,0 +1,121 @@
+import type { EntryRepositoryGateway } from '../../../entry/domain/gateways/entry-repository.gateway.js';
+import type { Entry } from '../../../entry/domain/models/entry.js';
+import type { EntryQuestionLinkRepositoryGateway } from '../../../question/domain/gateways/entry-question-link-repository.gateway.js';
+import type { QuestionRepositoryGateway } from '../../../question/domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '../../../question/domain/gateways/question-transaction-repository.gateway.js';
+import type { FermentationRepositoryGateway } from '../../domain/gateways/fermentation-repository.gateway.js';
+import type { LlmAnalysisGateway } from '../../domain/gateways/llm-analysis.gateway.js';
+import type { FermentationLanguage } from '../../domain/services/fermentation-eligibility.service.js';
+import { RunFermentationUsecase } from './run-fermentation.usecase.js';
+
+interface FireFermentationFiredItem {
+  fermentationResultId: string;
+  questionId: string;
+  questionText: string;
+}
+
+interface FireFermentationResult {
+  fired: FireFermentationFiredItem[];
+}
+
+// issue #290: admin デバッグ用に、特定ユーザー (+ 任意で特定問い) に対して
+// 条件ゲート (文字数 / 時間 / readiness / fermentation_enabled) を **バイパス**
+// して発酵を強制発火する。
+//
+// 重要な制約:
+// - user_fermentation_state.lastRunAt / nextEligibleAt は更新しない
+//   (本番のスケジューラーに影響を与えないため)。
+// - エントリは entry_question_link で当該問いに紐付くもの全てを対象にする
+//   (fermentation_enabled=true の制約も外す = デバッグ用なので最大スコープ)。
+// - メール送信は呼び出し側 (route) の責務。本 usecase は発酵そのものに専念する。
+export class FireFermentationUsecase {
+  constructor(
+    private entryRepo: EntryRepositoryGateway,
+    private questionRepo: QuestionRepositoryGateway,
+    private questionTransactionRepo: QuestionTransactionRepositoryGateway,
+    private entryQuestionLinkRepo: EntryQuestionLinkRepositoryGateway,
+    private fermentationRepo: FermentationRepositoryGateway,
+    private llmGateway: LlmAnalysisGateway,
+    private generateId: () => string,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    // 省略時は active 問い全てに対して発火
+    questionId?: string;
+    // 省略時は 'ja' (呼び出し側で SupabaseUserLocaleResolver を使って解決推奨)
+    language?: FermentationLanguage;
+  }): Promise<FireFermentationResult> {
+    const language: FermentationLanguage = params.language ?? 'ja';
+
+    // 1. 対象問いを決定 (active のみ。questionId 指定時はその 1 つに絞る)
+    const activeQuestions = await this.questionRepo.listActiveByUserId(params.userId);
+    const targetQuestions = params.questionId
+      ? activeQuestions.filter((q) => q.id === params.questionId)
+      : activeQuestions;
+    if (params.questionId && targetQuestions.length === 0) {
+      throw new Error(
+        `Question ${params.questionId} not found or not active for user ${params.userId}`,
+      );
+    }
+    if (targetQuestions.length === 0) {
+      throw new Error(`No active questions found for user ${params.userId}`);
+    }
+
+    const runUsecase = new RunFermentationUsecase(
+      this.fermentationRepo,
+      this.llmGateway,
+      this.generateId,
+    );
+
+    const fired: FireFermentationFiredItem[] = [];
+
+    for (const question of targetQuestions) {
+      // 2. 問いに紐付くエントリ ID を取得 (fermentation_enabled の制約はバイパス)
+      const entryIds = await this.entryQuestionLinkRepo.listEntryIdsByQuestionId(question.id);
+      if (entryIds.length === 0) continue;
+
+      // 3. エントリ本体を取得 + 念のため userId 一致するもののみに絞る
+      // (entry_question_link は user_id を持たないため、別ユーザーのエントリ
+      // が混入していないかを防御的にチェック)。
+      const allEntries = await this.entryRepo.findByIds(entryIds);
+      const ownEntries = allEntries.filter((e: Entry) => e.toProps().userId === params.userId);
+      if (ownEntries.length === 0) continue;
+
+      // 4. 最新 validated transaction から問い文字列を取得
+      const transaction = await this.questionTransactionRepo.findLatestValidatedByQuestionId(
+        question.id,
+      );
+      if (!transaction) continue;
+      const questionText = transaction.toProps().string;
+
+      const runEntries = ownEntries.map((e) => {
+        const props = e.toProps();
+        return { id: props.id, content: props.content };
+      });
+
+      // 5. 発酵実行 (RunFermentationUsecase 内部で 'completed' / 'failed' の保存も完了)
+      const { id } = await runUsecase.execute({
+        userId: params.userId,
+        questionId: question.id,
+        questionText,
+        entries: runEntries,
+        language,
+      });
+
+      fired.push({
+        fermentationResultId: id,
+        questionId: question.id,
+        questionText,
+      });
+    }
+
+    if (fired.length === 0) {
+      throw new Error(
+        'No fermentations were fired (no linked entries or no validated transaction for any active question)',
+      );
+    }
+
+    return { fired };
+  }
+}

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -49,11 +49,13 @@ export class ScheduledFermentationUsecase {
     private listActiveUserIds: () => Promise<string[]>,
     // issue #279: digest メールも language に応じて文言を切り替えるため、
     // ここで解決済みの language を呼び出し側に渡す。
+    // 戻り値はスケジューラーでは使わないため Promise<unknown> で受ける
+    // (issue #290 フォローで execute() が DigestSendResult を返すようになった)。
     private sendDigest: (
       userId: string,
       questionTitles: string[],
       language: FermentationLanguage,
-    ) => Promise<void>,
+    ) => Promise<unknown>,
     // 次回 X 時間生成器。テストでは固定値を注入して決定論的にする。
     private rollHours: () => number = rollRandomHours,
   ) {}

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -18,6 +18,39 @@ type DigestSendResult =
 // 送信したメールでも、受信者は常に本番に着地する想定 (vercel.app の preview
 // URL は受信者にとって意味がないため)。
 const JAR_URL = 'https://oryzae.ephemere.io/jar';
+const SUPPORT_URL = 'https://oryzae.ephemere.io/support';
+const PRIVACY_URL = 'https://oryzae.ephemere.io/privacy';
+const CONTACT_EMAIL = 'oryzae@ephemere.io';
+
+// 自動送信メールの体裁を整えるフッター。本文末尾の URL から区切り線で視覚的
+// に分け、自動配信である旨 + サポート / プライバシー / 連絡先 / 運営者を
+// 1 ブロックで提示する (issue #290 フォロー)。
+const FOOTER_JA = [
+  '',
+  '',
+  '———',
+  'このメールは Oryzae の発酵プロセス完了時に自動配信しています。',
+  '',
+  `ヘルプ・FAQ: ${SUPPORT_URL}`,
+  `プライバシーポリシー: ${PRIVACY_URL}`,
+  `お問い合わせ: ${CONTACT_EMAIL}`,
+  '',
+  '— Oryzae / Ferment Media Research',
+].join('\n');
+
+const FOOTER_EN = [
+  '',
+  '',
+  '———',
+  'This is an automatic notification from Oryzae,',
+  'sent when the fermentation process completes.',
+  '',
+  `Help & FAQ: ${SUPPORT_URL}`,
+  `Privacy: ${PRIVACY_URL}`,
+  `Contact: ${CONTACT_EMAIL}`,
+  '',
+  '— Oryzae / Ferment Media Research',
+].join('\n');
 
 // issue #279: ユーザー言語に合わせて subject / body を切り替える。
 const COPY: Record<
@@ -29,21 +62,21 @@ const COPY: Record<
   }
 > = {
   ja: {
-    subject: '瓶のなかで、ことばが醸されました',
+    subject: '[Oryzae] 瓶のなかで、ことばが醸されました',
     singleBody: (title) =>
-      `あなたが「${title}」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}`,
+      `あなたが「${title}」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}${FOOTER_JA}`,
     multiBody: (titles) => {
       const list = titles.map((t) => `・${t}`).join('\n');
-      return `あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n${list}\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}`;
+      return `あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n${list}\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}${FOOTER_JA}`;
     },
   },
   en: {
-    subject: 'Something has fermented in your jar',
+    subject: '[Oryzae] Something has fermented in your jar',
     singleBody: (title) =>
-      `The microbes in your jar have slowly read what you wrote about "${title}", and fermented it into a response.\n\nLook in whenever you have a moment.\n${JAR_URL}`,
+      `The microbes in your jar have slowly read what you wrote about "${title}", and fermented it into a response.\n\nLook in whenever you have a moment.\n${JAR_URL}${FOOTER_EN}`,
     multiBody: (titles) => {
       const list = titles.map((t) => `- ${t}`).join('\n');
-      return `The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n${list}\n\nLook in whenever you have a moment.\n${JAR_URL}`;
+      return `The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n${list}\n\nLook in whenever you have a moment.\n${JAR_URL}${FOOTER_EN}`;
     },
   },
 };

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -29,21 +29,21 @@ const COPY: Record<
   }
 > = {
   ja: {
-    subject: 'あなたの瓶の発酵が進みました',
+    subject: '瓶のなかで、ことばが醸されました',
     singleBody: (title) =>
-      `${title}についてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n${JAR_URL}`,
+      `あなたが「${title}」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}`,
     multiBody: (titles) => {
       const list = titles.map((t) => `・${t}`).join('\n');
-      return `以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n${list}\n\n${JAR_URL}`;
+      return `あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n${list}\n\n気が向いたときに、瓶を覗いてみてください。\n${JAR_URL}`;
     },
   },
   en: {
-    subject: 'Your jar has fermented further',
+    subject: 'Something has fermented in your jar',
     singleBody: (title) =>
-      `Oryzae's microbes have responded to what you wrote about "${title}".\n${JAR_URL}`,
+      `The microbes in your jar have slowly read what you wrote about "${title}", and fermented it into a response.\n\nLook in whenever you have a moment.\n${JAR_URL}`,
     multiBody: (titles) => {
       const list = titles.map((t) => `- ${t}`).join('\n');
-      return `Oryzae's microbes have responded to what you wrote about the following questions:\n\n${list}\n\n${JAR_URL}`;
+      return `The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n${list}\n\nLook in whenever you have a moment.\n${JAR_URL}`;
     },
   },
 };

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -14,7 +14,10 @@ type DigestSendResult =
   | { sent: true }
   | { sent: false; reason: 'no-titles' | 'no-verified-email' | 'disabled' | 'no-api-key' };
 
-const JAR_URL = 'https://oryzae-client.vercel.app/jar';
+// メール内リンクは本番ドメイン (LP / アプリ本体) を指す。preview / dev で
+// 送信したメールでも、受信者は常に本番に着地する想定 (vercel.app の preview
+// URL は受信者にとって意味がないため)。
+const JAR_URL = 'https://oryzae.ephemere.io/jar';
 
 // issue #279: ユーザー言語に合わせて subject / body を切り替える。
 const COPY: Record<

--- a/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.ts
@@ -1,6 +1,19 @@
 import type { EmailNotifier } from '../../domain/gateways/email-notifier.gateway.js';
 import type { FermentationLanguage } from '../../domain/services/fermentation-eligibility.service.js';
 
+// issue #290 フォロー: 「emailSent=true なのに実際は送られていない」事故を
+// 防ぐため、execute() は「送った / なぜ送らなかったか」を返す。
+// 呼び出し側 (cron / admin /fire / retry) はこの情報をログ・レスポンスに使う。
+//
+// reason の意味:
+// - 'no-titles': dedupe 後に問いタイトルが 0 件 (普通は呼び出し側で防ぐ)
+// - 'no-verified-email': 解決した email が null (Supabase Auth で email_confirmed_at 未設定 等)
+// - 'disabled': EMAIL_ENABLED=false (dev 環境向け)
+// - 'no-api-key': RESEND_API_KEY 未設定 (本番環境ミス検知用)
+type DigestSendResult =
+  | { sent: true }
+  | { sent: false; reason: 'no-titles' | 'no-verified-email' | 'disabled' | 'no-api-key' };
+
 const JAR_URL = 'https://oryzae-client.vercel.app/jar';
 
 // issue #279: ユーザー言語に合わせて subject / body を切り替える。
@@ -43,11 +56,11 @@ export class SendFermentationDigestUsecase {
     questionTitles: string[];
     // 未指定時は 'ja' (#268 と同じデフォルト)。
     language?: FermentationLanguage;
-  }): Promise<void> {
+  }): Promise<DigestSendResult> {
     const uniqueTitles = Array.from(
       new Set(params.questionTitles.map((t) => t.trim()).filter((t) => t.length > 0)),
     );
-    if (uniqueTitles.length === 0) return;
+    if (uniqueTitles.length === 0) return { sent: false, reason: 'no-titles' };
 
     const email = await this.resolveVerifiedEmail(params.userId);
     if (!email) {
@@ -57,13 +70,13 @@ export class SendFermentationDigestUsecase {
         userId: params.userId,
         titleCount: uniqueTitles.length,
       });
-      return;
+      return { sent: false, reason: 'no-verified-email' };
     }
 
     const language: FermentationLanguage = params.language ?? 'ja';
     const copy = COPY[language];
     const bodyText =
       uniqueTitles.length === 1 ? copy.singleBody(uniqueTitles[0]) : copy.multiBody(uniqueTitles);
-    await this.emailNotifier.send({ to: email, subject: copy.subject, bodyText });
+    return await this.emailNotifier.send({ to: email, subject: copy.subject, bodyText });
   }
 }

--- a/apps/server/src/contexts/fermentation/domain/gateways/email-notifier.gateway.ts
+++ b/apps/server/src/contexts/fermentation/domain/gateways/email-notifier.gateway.ts
@@ -4,6 +4,13 @@ export interface SendEmailParams {
   bodyText: string;
 }
 
+// issue #290 フォロー: 「emailSent=true なのに実際は送られていない」事故 を防ぐため、
+// 「送信した / しなかった (なぜ)」を診断情報として返す。実 API エラーは引き続き
+// throw する (graceful degradation は呼び出し側の責務)。
+export type NotifierSendResult =
+  | { sent: true }
+  | { sent: false; reason: 'disabled' | 'no-api-key' };
+
 export interface EmailNotifier {
-  send(params: SendEmailParams): Promise<void>;
+  send(params: SendEmailParams): Promise<NotifierSendResult>;
 }

--- a/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
@@ -16,7 +16,10 @@ import type {
 export class ResendEmailNotifier implements EmailNotifier {
   async send(params: SendEmailParams): Promise<NotifierSendResult> {
     const apiKey = process.env.RESEND_API_KEY;
-    const from = process.env.EMAIL_FROM ?? 'Oryzae <noreply@oryzae.ephemere.io>';
+    // Resend 送信専用サブドメインは `mail.oryzae.ephemere.io` (Route53 で
+    // 明示的にメール送信用と分離してある)。アプリ本体の `oryzae.ephemere.io`
+    // とは別概念なので混同しないこと。
+    const from = process.env.EMAIL_FROM ?? 'Oryzae <noreply@mail.oryzae.ephemere.io>';
     const enabled = process.env.EMAIL_ENABLED !== 'false';
 
     // EMAIL_ENABLED=false は dev 環境向けの意図的なオフ。

--- a/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/resend-email-notifier.ts
@@ -1,5 +1,6 @@
 import type {
   EmailNotifier,
+  NotifierSendResult,
   SendEmailParams,
 } from '../../domain/gateways/email-notifier.gateway.js';
 
@@ -7,14 +8,19 @@ import type {
 // graceful degradation (失敗してもジョブ全体を止めない) は呼び出し元の責務とし、
 // この層では「失敗はログ + throw」 を徹底する (issue #288)。サイレントスキップで
 // メールが届かないまま誰も気付けない、という旧実装の問題に対処するため。
+//
+// issue #290 フォロー: 戻り値で「送ったか / なぜ送らなかったか」を返す。
+// `EMAIL_ENABLED=false` や `RESEND_API_KEY` 抜けは throw ではなく
+// `{ sent: false, reason }` で返し、呼び出し元 (admin /fire 等) が
+// レスポンスに反映できるようにする。
 export class ResendEmailNotifier implements EmailNotifier {
-  async send(params: SendEmailParams): Promise<void> {
+  async send(params: SendEmailParams): Promise<NotifierSendResult> {
     const apiKey = process.env.RESEND_API_KEY;
     const from = process.env.EMAIL_FROM ?? 'Oryzae <noreply@oryzae.ephemere.io>';
     const enabled = process.env.EMAIL_ENABLED !== 'false';
 
     // EMAIL_ENABLED=false は dev 環境向けの意図的なオフ。
-    if (!enabled) return;
+    if (!enabled) return { sent: false, reason: 'disabled' };
 
     // 本番で API キーが抜けている場合はサイレントにせず、warn でミスを発見できるように。
     if (!apiKey) {
@@ -22,7 +28,7 @@ export class ResendEmailNotifier implements EmailNotifier {
         to: params.to,
         subject: params.subject,
       });
-      return;
+      return { sent: false, reason: 'no-api-key' };
     }
 
     let response: Response;
@@ -60,5 +66,7 @@ export class ResendEmailNotifier implements EmailNotifier {
       });
       throw new Error(`Resend API returned ${response.status}: ${body.slice(0, 200)}`);
     }
+
+    return { sent: true };
   }
 }

--- a/apps/server/src/contexts/fermentation/infrastructure/email/supabase-verified-email-resolver.ts
+++ b/apps/server/src/contexts/fermentation/infrastructure/email/supabase-verified-email-resolver.ts
@@ -11,3 +11,17 @@ export function createSupabaseVerifiedEmailResolver(
     return user.email;
   };
 }
+
+// issue #290 フォロー: admin デバッグ用に「未検証メールにも送信したい」場面で
+// 使う resolver。本番のスケジューラー / 通常フローでは使わない。
+// email_confirmed_at の制約だけ外し、email 自体が存在しないユーザーは null。
+export function createSupabaseAnyEmailResolver(
+  supabase: SupabaseClient,
+): (userId: string) => Promise<string | null> {
+  return async (userId: string): Promise<string | null> => {
+    const { data } = await supabase.auth.admin.getUserById(userId);
+    const user = data?.user;
+    if (!user?.email) return null;
+    return user.email;
+  };
+}

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -14,7 +14,10 @@ import { ScheduledFermentationUsecase } from '../../application/usecases/schedul
 import { SendFermentationDigestUsecase } from '../../application/usecases/send-fermentation-digest.usecase.js';
 import { SupabaseUserLocaleResolver } from '../../infrastructure/auth/supabase-user-locale-resolver.js';
 import { ResendEmailNotifier } from '../../infrastructure/email/resend-email-notifier.js';
-import { createSupabaseVerifiedEmailResolver } from '../../infrastructure/email/supabase-verified-email-resolver.js';
+import {
+  createSupabaseAnyEmailResolver,
+  createSupabaseVerifiedEmailResolver,
+} from '../../infrastructure/email/supabase-verified-email-resolver.js';
 import { VercelAiAnalysisGateway } from '../../infrastructure/llm/vercel-ai-analysis.gateway.js';
 import { SupabaseFermentationRepository } from '../../infrastructure/repositories/supabase-fermentation.repository.js';
 import { SupabaseUserFermentationStateRepository } from '../../infrastructure/repositories/supabase-user-fermentation-state.repository.js';
@@ -37,6 +40,10 @@ const fireFermentationSchema = z.object({
   language: z.enum(['ja', 'en']).optional(),
   // true ならメール送信を抑制 (LLM 出力の検証だけしたい場面用)
   skipEmail: z.boolean().optional(),
+  // true なら email_confirmed_at が null のユーザーにも送る (admin デバッグ専用)。
+  // 通常フローでは未検証メールにはスパム防止のため送らない設計だが、
+  // 自分の test アカウントに対して動作確認したい場面で必要。
+  forceUnverified: z.boolean().optional(),
 });
 
 function dateKeyToSimulatedNow(dateKey: string): Date {
@@ -518,20 +525,34 @@ export const adminFermentations = new Hono<Env>()
     }
 
     // メール送信は呼び出し側 (このルート) の責務。skipEmail=true ならスキップ。
+    // issue #290 フォロー: digestUsecase の戻り値を使って「送ったか / なぜ送ら
+    // なかったか」を正直にレスポンスする (旧実装は execute() が void で return
+    // しても emailSent=true を立てていて、未検証メールユーザーで誤検出を起こす)。
     let emailSent = false;
+    let emailReason: string | undefined;
     let emailFailure: { error: string } | undefined;
-    if (!body.skipEmail) {
-      const digestUsecase = new SendFermentationDigestUsecase(
-        new ResendEmailNotifier(),
-        createSupabaseVerifiedEmailResolver(supabase),
-      );
+    if (body.skipEmail) {
+      emailReason = 'skipped-by-request';
+    } else {
+      const resolver = body.forceUnverified
+        ? createSupabaseAnyEmailResolver(supabase)
+        : createSupabaseVerifiedEmailResolver(supabase);
+      const digestUsecase = new SendFermentationDigestUsecase(new ResendEmailNotifier(), resolver);
       try {
-        await digestUsecase.execute({
+        const result = await digestUsecase.execute({
           userId: body.userId,
           questionTitles: fired.map((f) => f.questionText),
           language,
         });
-        emailSent = true;
+        emailSent = result.sent;
+        if (!result.sent) {
+          emailReason = result.reason;
+          console.warn('[admin-fermentations] /fire email not sent', {
+            userId: body.userId,
+            reason: result.reason,
+            forceUnverified: body.forceUnverified ?? false,
+          });
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
         emailFailure = { error: message };
@@ -543,7 +564,7 @@ export const adminFermentations = new Hono<Env>()
       }
     }
 
-    return c.json({ fired, emailSent, emailFailure }, 201);
+    return c.json({ fired, emailSent, emailReason, emailFailure }, 201);
   })
   .get('/readiness/:userId', async (c) => {
     // issue #268: admin ダッシュボードでユーザーの発火条件をその時点で表示する。

--- a/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
+++ b/apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts
@@ -7,6 +7,7 @@ import { SupabaseEntryQuestionLinkRepository } from '../../../question/infrastru
 import { SupabaseQuestionRepository } from '../../../question/infrastructure/repositories/supabase-question.repository.js';
 import { SupabaseQuestionTransactionRepository } from '../../../question/infrastructure/repositories/supabase-question-transaction.repository.js';
 import { COLORS, notifyDiscord } from '../../../shared/infrastructure/discord-notify.js';
+import { FireFermentationUsecase } from '../../application/usecases/fire-fermentation.usecase.js';
 import { GetFermentationReadinessUsecase } from '../../application/usecases/get-fermentation-readiness.usecase.js';
 import { RunFermentationUsecase } from '../../application/usecases/run-fermentation.usecase.js';
 import { ScheduledFermentationUsecase } from '../../application/usecases/scheduled-fermentation.usecase.js';
@@ -26,6 +27,16 @@ const triggerScheduledSchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'dateKey must be in YYYY-MM-DD format')
     .optional(),
+});
+
+// issue #290: admin デバッグ用に、特定ユーザー (+ 任意で特定問い) を強制発火する。
+const fireFermentationSchema = z.object({
+  userId: z.string().min(1),
+  questionId: z.string().min(1).optional(),
+  // 省略時はサーバー側でユーザーの user_metadata.locale を解決する
+  language: z.enum(['ja', 'en']).optional(),
+  // true ならメール送信を抑制 (LLM 出力の検証だけしたい場面用)
+  skipEmail: z.boolean().optional(),
 });
 
 function dateKeyToSimulatedNow(dateKey: string): Date {
@@ -474,6 +485,65 @@ export const adminFermentations = new Hono<Env>()
     }
 
     return c.json({ now: now.toISOString(), ...result });
+  })
+  .post('/fire', async (c) => {
+    // issue #290: 特定ユーザー / 特定問いに対する発酵強制発火 (admin デバッグ用)。
+    // 条件ゲートをバイパスし、user_fermentation_state は更新しない。
+    const supabase = c.get('adminSupabase');
+    const body = fireFermentationSchema.parse(await c.req.json());
+
+    const localeResolver = new SupabaseUserLocaleResolver(supabase);
+    const language = body.language ?? (await localeResolver.resolve(body.userId));
+
+    const usecase = new FireFermentationUsecase(
+      new SupabaseEntryRepository(supabase),
+      new SupabaseQuestionRepository(supabase),
+      new SupabaseQuestionTransactionRepository(supabase),
+      new SupabaseEntryQuestionLinkRepository(supabase),
+      new SupabaseFermentationRepository(supabase),
+      new VercelAiAnalysisGateway(),
+      () => crypto.randomUUID(),
+    );
+
+    let fired: Awaited<ReturnType<typeof usecase.execute>>['fired'];
+    try {
+      ({ fired } = await usecase.execute({
+        userId: body.userId,
+        questionId: body.questionId,
+        language,
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return c.json({ error: message }, 400);
+    }
+
+    // メール送信は呼び出し側 (このルート) の責務。skipEmail=true ならスキップ。
+    let emailSent = false;
+    let emailFailure: { error: string } | undefined;
+    if (!body.skipEmail) {
+      const digestUsecase = new SendFermentationDigestUsecase(
+        new ResendEmailNotifier(),
+        createSupabaseVerifiedEmailResolver(supabase),
+      );
+      try {
+        await digestUsecase.execute({
+          userId: body.userId,
+          questionTitles: fired.map((f) => f.questionText),
+          language,
+        });
+        emailSent = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        emailFailure = { error: message };
+        console.error('[admin-fermentations] /fire digest email failed', {
+          userId: body.userId,
+          firedCount: fired.length,
+          error: message,
+        });
+      }
+    }
+
+    return c.json({ fired, emailSent, emailFailure }, 201);
   })
   .get('/readiness/:userId', async (c) => {
     // issue #268: admin ダッシュボードでユーザーの発火条件をその時点で表示する。

--- a/apps/server/test/contexts/fermentation/application/usecases/fire-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/fire-fermentation.usecase.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EntryRepositoryGateway } from '@/contexts/entry/domain/gateways/entry-repository.gateway.js';
+import { Entry } from '@/contexts/entry/domain/models/entry.js';
+import { FireFermentationUsecase } from '@/contexts/fermentation/application/usecases/fire-fermentation.usecase.js';
+import type { FermentationRepositoryGateway } from '@/contexts/fermentation/domain/gateways/fermentation-repository.gateway.js';
+import type { LlmAnalysisGateway } from '@/contexts/fermentation/domain/gateways/llm-analysis.gateway.js';
+import type { EntryQuestionLinkRepositoryGateway } from '@/contexts/question/domain/gateways/entry-question-link-repository.gateway.js';
+import type { QuestionRepositoryGateway } from '@/contexts/question/domain/gateways/question-repository.gateway.js';
+import type { QuestionTransactionRepositoryGateway } from '@/contexts/question/domain/gateways/question-transaction-repository.gateway.js';
+import { Question } from '@/contexts/question/domain/models/question.js';
+import { QuestionTransaction } from '@/contexts/question/domain/models/question-transaction.js';
+
+const generateId = () => 'test-id';
+
+function makeEntry(
+  userId: string,
+  id: string,
+  fermentationEnabled = true,
+  content = `Entry ${id}`,
+): Entry {
+  return Entry.fromProps({
+    id,
+    userId,
+    content,
+    mediaUrls: [],
+    fermentationEnabled,
+    createdAt: '2026-05-04T10:00:00.000Z',
+    updatedAt: '2026-05-04T10:00:00.000Z',
+  });
+}
+
+function makeQuestion(userId: string, id: string, isArchived = false): Question {
+  return Question.fromProps({
+    id,
+    userId,
+    isArchived,
+    isValidatedByUser: true,
+    isProposedByOryzae: false,
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+  });
+}
+
+function makeTransaction(questionId: string, text: string): QuestionTransaction {
+  return QuestionTransaction.fromProps({
+    id: 'qt-1',
+    questionId,
+    string: text,
+    questionVersion: 1,
+    isValidatedByUser: true,
+    isProposedByOryzae: false,
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+  });
+}
+
+function mockEntryRepo(): EntryRepositoryGateway {
+  return {
+    findById: vi.fn(),
+    findByIds: vi.fn().mockResolvedValue([]),
+    listByUserId: vi.fn(),
+    listByUserIdAndDate: vi.fn(),
+    listFermentationEnabledByUserIdAndDate: vi.fn(),
+    listFermentationEnabledByUserIdSince: vi.fn(),
+    countCharsByUserIdSince: vi.fn(),
+    listByUserIdAndWeek: vi.fn(),
+    searchByUserId: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function mockQuestionRepo(): QuestionRepositoryGateway {
+  return {
+    findById: vi.fn(),
+    listActiveByUserId: vi.fn().mockResolvedValue([]),
+    listAllByUserId: vi.fn(),
+    listPendingByUserId: vi.fn(),
+    countActiveByUserId: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function mockQtRepo(): QuestionTransactionRepositoryGateway {
+  return {
+    listByQuestionId: vi.fn(),
+    findLatestByQuestionId: vi.fn(),
+    findLatestValidatedByQuestionId: vi.fn().mockResolvedValue(null),
+    findLatestUnvalidatedByQuestionId: vi.fn(),
+    append: vi.fn(),
+    save: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function mockLinkRepo(): EntryQuestionLinkRepositoryGateway {
+  return {
+    link: vi.fn(),
+    unlink: vi.fn(),
+    listQuestionIdsByEntryId: vi.fn(),
+    listEntryIdsByQuestionId: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function mockFermentationRepo(): FermentationRepositoryGateway {
+  return {
+    findById: vi.fn(),
+    listByUserId: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    saveScannedEntries: vi.fn(),
+    saveWorksheet: vi.fn(),
+    saveSnippets: vi.fn(),
+    saveLetter: vi.fn(),
+    saveKeywords: vi.fn(),
+  };
+}
+
+function mockLlm(): LlmAnalysisGateway {
+  return {
+    analyze: vi.fn().mockResolvedValue({
+      output: {
+        worksheetMarkdown: 'ws',
+        resultDiagramMarkdown: 'rd',
+        snippets: [],
+        letterBody: 'letter',
+        keywords: [],
+      },
+      generationId: 'gen-1',
+    }),
+  };
+}
+
+interface BuildArgs {
+  entryRepo?: EntryRepositoryGateway;
+  questionRepo?: QuestionRepositoryGateway;
+  qtRepo?: QuestionTransactionRepositoryGateway;
+  linkRepo?: EntryQuestionLinkRepositoryGateway;
+  fermentationRepo?: FermentationRepositoryGateway;
+  llm?: LlmAnalysisGateway;
+}
+
+function buildUsecase(args: BuildArgs = {}): FireFermentationUsecase {
+  return new FireFermentationUsecase(
+    args.entryRepo ?? mockEntryRepo(),
+    args.questionRepo ?? mockQuestionRepo(),
+    args.qtRepo ?? mockQtRepo(),
+    args.linkRepo ?? mockLinkRepo(),
+    args.fermentationRepo ?? mockFermentationRepo(),
+    args.llm ?? mockLlm(),
+    generateId,
+  );
+}
+
+describe('FireFermentationUsecase (issue #290: admin debug fire)', () => {
+  it('fires for all active questions when questionId is omitted', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const q2 = makeQuestion('u1', 'q2');
+    const t1 = makeTransaction('q1', 'Q1 text');
+    const t2 = makeTransaction('q2', 'Q2 text');
+    const entry = makeEntry('u1', 'e1');
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1, q2]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockImplementation(async (id) =>
+      id === 'q1' ? t1 : t2,
+    );
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([entry]);
+
+    const llm = mockLlm();
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo, llm });
+
+    const result = await usecase.execute({ userId: 'u1' });
+
+    expect(result.fired).toHaveLength(2);
+    expect(result.fired.map((f) => f.questionId)).toEqual(['q1', 'q2']);
+    expect(result.fired.map((f) => f.questionText)).toEqual(['Q1 text', 'Q2 text']);
+    expect(llm.analyze).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires only the specified questionId when provided', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const q2 = makeQuestion('u1', 'q2');
+    const t2 = makeTransaction('q2', 'Q2 text');
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1, q2]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(t2);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([makeEntry('u1', 'e1')]);
+
+    const llm = mockLlm();
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo, llm });
+
+    const result = await usecase.execute({ userId: 'u1', questionId: 'q2' });
+
+    expect(result.fired).toHaveLength(1);
+    expect(result.fired[0].questionId).toBe('q2');
+    expect(llm.analyze).toHaveBeenCalledOnce();
+    expect(qtRepo.findLatestValidatedByQuestionId).toHaveBeenCalledWith('q2');
+  });
+
+  it('throws when questionId is specified but not active for the user', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1]);
+
+    const usecase = buildUsecase({ questionRepo });
+
+    await expect(usecase.execute({ userId: 'u1', questionId: 'q-other' })).rejects.toThrow(
+      /not found or not active/,
+    );
+  });
+
+  it('throws when user has no active questions at all', async () => {
+    const usecase = buildUsecase();
+    await expect(usecase.execute({ userId: 'u1' })).rejects.toThrow(/No active questions found/);
+  });
+
+  it('bypasses fermentation_enabled flag (entries with enabled=false are still used)', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const t1 = makeTransaction('q1', 'Q1 text');
+    const disabledEntry = makeEntry('u1', 'e-disabled', /* fermentationEnabled */ false);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(t1);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e-disabled']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([disabledEntry]);
+
+    const llm = mockLlm();
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo, llm });
+
+    const result = await usecase.execute({ userId: 'u1', questionId: 'q1' });
+
+    expect(result.fired).toHaveLength(1);
+    expect(llm.analyze).toHaveBeenCalledOnce();
+  });
+
+  it('filters out entries belonging to other users (defensive)', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const t1 = makeTransaction('q1', 'Q1 text');
+    const ownEntry = makeEntry('u1', 'e-own');
+    const foreignEntry = makeEntry('u-other', 'e-foreign');
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(t1);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e-own', 'e-foreign']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([ownEntry, foreignEntry]);
+
+    const llm = mockLlm();
+    vi.mocked(llm.analyze).mockResolvedValue({
+      output: {
+        worksheetMarkdown: 'ws',
+        resultDiagramMarkdown: 'rd',
+        snippets: [],
+        letterBody: 'letter',
+        keywords: [],
+      },
+      generationId: null,
+    });
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo, llm });
+
+    await usecase.execute({ userId: 'u1', questionId: 'q1' });
+
+    // RunFermentationUsecase に渡されたエントリは own のみ
+    const analyzeCall = vi.mocked(llm.analyze).mock.calls[0][0];
+    expect(analyzeCall.entryContent).toBe(ownEntry.toProps().content);
+  });
+
+  it('skips questions with no linked entries and throws if nothing fires', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1]);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue([]);
+
+    const usecase = buildUsecase({ questionRepo, linkRepo });
+
+    await expect(usecase.execute({ userId: 'u1' })).rejects.toThrow(/No fermentations were fired/);
+  });
+
+  it('skips questions with no validated transaction', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const q2 = makeQuestion('u1', 'q2');
+    const t2 = makeTransaction('q2', 'Q2 text');
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1, q2]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockImplementation(async (id) =>
+      id === 'q1' ? null : t2,
+    );
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([makeEntry('u1', 'e1')]);
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo });
+
+    const result = await usecase.execute({ userId: 'u1' });
+
+    expect(result.fired).toHaveLength(1);
+    expect(result.fired[0].questionId).toBe('q2');
+  });
+
+  it('passes language through to RunFermentation', async () => {
+    const q1 = makeQuestion('u1', 'q1');
+    const t1 = makeTransaction('q1', 'Q1 text');
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockResolvedValue([q1]);
+
+    const qtRepo = mockQtRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockResolvedValue(t1);
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockResolvedValue(['e1']);
+
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([makeEntry('u1', 'e1')]);
+
+    const llm = mockLlm();
+
+    const usecase = buildUsecase({ questionRepo, qtRepo, linkRepo, entryRepo, llm });
+
+    await usecase.execute({ userId: 'u1', language: 'en' });
+
+    expect(llm.analyze).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }));
+  });
+});

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -77,7 +77,7 @@ describe('SendFermentationDigestUsecase', () => {
       to: 'user@example.com',
       subject: 'あなたの瓶の発酵が進みました',
       bodyText:
-        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae-client.vercel.app/jar',
+        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.ephemere.io/jar',
     });
   });
 
@@ -96,7 +96,7 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae-client.vercel.app/jar',
+      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae.ephemere.io/jar',
     );
   });
 
@@ -132,7 +132,7 @@ describe('SendFermentationDigestUsecase', () => {
 
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae-client.vercel.app/jar',
+      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.ephemere.io/jar',
     );
   });
 
@@ -154,7 +154,7 @@ describe('SendFermentationDigestUsecase', () => {
         to: 'user@example.com',
         subject: 'Your jar has fermented further',
         bodyText:
-          'Oryzae\'s microbes have responded to what you wrote about "Why do I work?".\nhttps://oryzae-client.vercel.app/jar',
+          'Oryzae\'s microbes have responded to what you wrote about "Why do I work?".\nhttps://oryzae.ephemere.io/jar',
       });
     });
 
@@ -174,7 +174,7 @@ describe('SendFermentationDigestUsecase', () => {
       const call = vi.mocked(notifier.send).mock.calls[0][0];
       expect(call.subject).toBe('Your jar has fermented further');
       expect(call.bodyText).toBe(
-        "Oryzae's microbes have responded to what you wrote about the following questions:\n\n- Why do I work?\n- Who am I to my friends?\n\nhttps://oryzae-client.vercel.app/jar",
+        "Oryzae's microbes have responded to what you wrote about the following questions:\n\n- Why do I work?\n- Who am I to my friends?\n\nhttps://oryzae.ephemere.io/jar",
       );
     });
 

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -75,9 +75,9 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     expect(notifier.send).toHaveBeenCalledWith({
       to: 'user@example.com',
-      subject: 'あなたの瓶の発酵が進みました',
+      subject: '瓶のなかで、ことばが醸されました',
       bodyText:
-        'なぜ働くのかについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.ephemere.io/jar',
+        'あなたが「なぜ働くのか」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
     });
   });
 
@@ -96,7 +96,7 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      '以下の問いについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\n\n・問い A\n・問い B\n\nhttps://oryzae.ephemere.io/jar',
+      'あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n・問い A\n・問い B\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
     );
   });
 
@@ -132,7 +132,7 @@ describe('SendFermentationDigestUsecase', () => {
 
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      'Qについてあなたが書いたテキストに、Oryzaeの菌たちが反応を生成しました。\nhttps://oryzae.ephemere.io/jar',
+      'あなたが「Q」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
     );
   });
 
@@ -152,9 +152,9 @@ describe('SendFermentationDigestUsecase', () => {
 
       expect(notifier.send).toHaveBeenCalledWith({
         to: 'user@example.com',
-        subject: 'Your jar has fermented further',
+        subject: 'Something has fermented in your jar',
         bodyText:
-          'Oryzae\'s microbes have responded to what you wrote about "Why do I work?".\nhttps://oryzae.ephemere.io/jar',
+          'The microbes in your jar have slowly read what you wrote about "Why do I work?", and fermented it into a response.\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar',
       });
     });
 
@@ -172,9 +172,9 @@ describe('SendFermentationDigestUsecase', () => {
       });
 
       const call = vi.mocked(notifier.send).mock.calls[0][0];
-      expect(call.subject).toBe('Your jar has fermented further');
+      expect(call.subject).toBe('Something has fermented in your jar');
       expect(call.bodyText).toBe(
-        "Oryzae's microbes have responded to what you wrote about the following questions:\n\n- Why do I work?\n- Who am I to my friends?\n\nhttps://oryzae.ephemere.io/jar",
+        'The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n- Why do I work?\n- Who am I to my friends?\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar',
       );
     });
 
@@ -188,8 +188,8 @@ describe('SendFermentationDigestUsecase', () => {
       await usecase.execute({ userId: 'u1', questionTitles: ['なぜ働くのか'] });
 
       const call = vi.mocked(notifier.send).mock.calls[0][0];
-      expect(call.subject).toBe('あなたの瓶の発酵が進みました');
-      expect(call.bodyText).toContain('Oryzaeの菌たちが反応を生成しました');
+      expect(call.subject).toBe('瓶のなかで、ことばが醸されました');
+      expect(call.bodyText).toContain('Oryzaeの菌たちがゆっくり読みほどき');
     });
   });
 });

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -6,6 +6,23 @@ function mockNotifier(): EmailNotifier {
   return { send: vi.fn().mockResolvedValue({ sent: true }) };
 }
 
+// Production と同じフッターを assertion で使う。実装が変わったら exact-match
+// で検出されるよう、ここは production と独立にハードコードしておく。
+const FOOTER_JA =
+  '\n\n———\nこのメールは Oryzae の発酵プロセス完了時に自動配信しています。\n\n' +
+  'ヘルプ・FAQ: https://oryzae.ephemere.io/support\n' +
+  'プライバシーポリシー: https://oryzae.ephemere.io/privacy\n' +
+  'お問い合わせ: oryzae@ephemere.io\n\n' +
+  '— Oryzae / Ferment Media Research';
+
+const FOOTER_EN =
+  '\n\n———\nThis is an automatic notification from Oryzae,\n' +
+  'sent when the fermentation process completes.\n\n' +
+  'Help & FAQ: https://oryzae.ephemere.io/support\n' +
+  'Privacy: https://oryzae.ephemere.io/privacy\n' +
+  'Contact: oryzae@ephemere.io\n\n' +
+  '— Oryzae / Ferment Media Research';
+
 describe('SendFermentationDigestUsecase', () => {
   it('returns { sent: false, reason: "no-titles" } when there are no question titles', async () => {
     const notifier = mockNotifier();
@@ -75,9 +92,10 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     expect(notifier.send).toHaveBeenCalledWith({
       to: 'user@example.com',
-      subject: '瓶のなかで、ことばが醸されました',
+      subject: '[Oryzae] 瓶のなかで、ことばが醸されました',
       bodyText:
-        'あなたが「なぜ働くのか」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
+        'あなたが「なぜ働くのか」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar' +
+        FOOTER_JA,
     });
   });
 
@@ -96,7 +114,8 @@ describe('SendFermentationDigestUsecase', () => {
     expect(notifier.send).toHaveBeenCalledOnce();
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      'あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n・問い A\n・問い B\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
+      'あなたが綴った以下の問いをめぐるテキストが、瓶のなかで応答へと醸されました。\n\n・問い A\n・問い B\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar' +
+        FOOTER_JA,
     );
   });
 
@@ -132,7 +151,8 @@ describe('SendFermentationDigestUsecase', () => {
 
     const call = vi.mocked(notifier.send).mock.calls[0][0];
     expect(call.bodyText).toBe(
-      'あなたが「Q」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar',
+      'あなたが「Q」について綴ったテキストを、Oryzaeの菌たちがゆっくり読みほどき、ひとつの応答へと醸しました。\n\n気が向いたときに、瓶を覗いてみてください。\nhttps://oryzae.ephemere.io/jar' +
+        FOOTER_JA,
     );
   });
 
@@ -152,9 +172,10 @@ describe('SendFermentationDigestUsecase', () => {
 
       expect(notifier.send).toHaveBeenCalledWith({
         to: 'user@example.com',
-        subject: 'Something has fermented in your jar',
+        subject: '[Oryzae] Something has fermented in your jar',
         bodyText:
-          'The microbes in your jar have slowly read what you wrote about "Why do I work?", and fermented it into a response.\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar',
+          'The microbes in your jar have slowly read what you wrote about "Why do I work?", and fermented it into a response.\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar' +
+          FOOTER_EN,
       });
     });
 
@@ -172,9 +193,10 @@ describe('SendFermentationDigestUsecase', () => {
       });
 
       const call = vi.mocked(notifier.send).mock.calls[0][0];
-      expect(call.subject).toBe('Something has fermented in your jar');
+      expect(call.subject).toBe('[Oryzae] Something has fermented in your jar');
       expect(call.bodyText).toBe(
-        'The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n- Why do I work?\n- Who am I to my friends?\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar',
+        'The microbes in your jar have fermented what you wrote around the following questions into responses:\n\n- Why do I work?\n- Who am I to my friends?\n\nLook in whenever you have a moment.\nhttps://oryzae.ephemere.io/jar' +
+          FOOTER_EN,
       );
     });
 
@@ -188,7 +210,7 @@ describe('SendFermentationDigestUsecase', () => {
       await usecase.execute({ userId: 'u1', questionTitles: ['なぜ働くのか'] });
 
       const call = vi.mocked(notifier.send).mock.calls[0][0];
-      expect(call.subject).toBe('瓶のなかで、ことばが醸されました');
+      expect(call.subject).toBe('[Oryzae] 瓶のなかで、ことばが醸されました');
       expect(call.bodyText).toContain('Oryzaeの菌たちがゆっくり読みほどき');
     });
   });

--- a/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/send-fermentation-digest.usecase.test.ts
@@ -3,29 +3,31 @@ import { SendFermentationDigestUsecase } from '@/contexts/fermentation/applicati
 import type { EmailNotifier } from '@/contexts/fermentation/domain/gateways/email-notifier.gateway.js';
 
 function mockNotifier(): EmailNotifier {
-  return { send: vi.fn().mockResolvedValue(undefined) };
+  return { send: vi.fn().mockResolvedValue({ sent: true }) };
 }
 
 describe('SendFermentationDigestUsecase', () => {
-  it('no-ops when there are no question titles', async () => {
+  it('returns { sent: false, reason: "no-titles" } when there are no question titles', async () => {
     const notifier = mockNotifier();
     const resolve = vi.fn().mockResolvedValue('user@example.com');
     const usecase = new SendFermentationDigestUsecase(notifier, resolve);
 
-    await usecase.execute({ userId: 'u1', questionTitles: [] });
+    const result = await usecase.execute({ userId: 'u1', questionTitles: [] });
 
+    expect(result).toEqual({ sent: false, reason: 'no-titles' });
     expect(resolve).not.toHaveBeenCalled();
     expect(notifier.send).not.toHaveBeenCalled();
   });
 
-  it('no-ops + warns when resolver returns null (unverified / missing email, issue #288)', async () => {
+  it('returns "no-verified-email" + warns when resolver returns null (issue #288 / #290)', async () => {
     const notifier = mockNotifier();
     const resolve = vi.fn().mockResolvedValue(null);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const usecase = new SendFermentationDigestUsecase(notifier, resolve);
 
-    await usecase.execute({ userId: 'u1', questionTitles: ['Q1'] });
+    const result = await usecase.execute({ userId: 'u1', questionTitles: ['Q1'] });
 
+    expect(result).toEqual({ sent: false, reason: 'no-verified-email' });
     expect(resolve).toHaveBeenCalledWith('u1');
     expect(notifier.send).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
@@ -33,6 +35,32 @@ describe('SendFermentationDigestUsecase', () => {
       expect.objectContaining({ userId: 'u1', titleCount: 1 }),
     );
     warnSpy.mockRestore();
+  });
+
+  it('forwards the notifier result (e.g. { sent: false, reason: "no-api-key" }) verbatim', async () => {
+    const notifier: EmailNotifier = {
+      send: vi.fn().mockResolvedValue({ sent: false, reason: 'no-api-key' }),
+    };
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    const result = await usecase.execute({ userId: 'u1', questionTitles: ['Q'] });
+
+    expect(result).toEqual({ sent: false, reason: 'no-api-key' });
+  });
+
+  it('returns { sent: true } when the notifier successfully sends', async () => {
+    const notifier = mockNotifier();
+    const usecase = new SendFermentationDigestUsecase(
+      notifier,
+      vi.fn().mockResolvedValue('user@example.com'),
+    );
+
+    const result = await usecase.execute({ userId: 'u1', questionTitles: ['Q'] });
+
+    expect(result).toEqual({ sent: true });
   });
 
   it('sends single-title body in the original issue wording', async () => {

--- a/apps/server/test/contexts/fermentation/infrastructure/email/resend-email-notifier.test.ts
+++ b/apps/server/test/contexts/fermentation/infrastructure/email/resend-email-notifier.test.ts
@@ -31,8 +31,9 @@ describe('ResendEmailNotifier (issue #288: failure observability)', () => {
     fetchSpy.mockResolvedValueOnce(new Response('{}', { status: 200 }));
 
     const notifier = new ResendEmailNotifier();
-    await notifier.send(PARAMS);
+    const result = await notifier.send(PARAMS);
 
+    expect(result).toEqual({ sent: true });
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://api.resend.com/emails');
@@ -80,25 +81,27 @@ describe('ResendEmailNotifier (issue #288: failure observability)', () => {
     expect(payload).toMatchObject({ to: 'user@example.com', error: 'ECONNRESET' });
   });
 
-  it('skips silently (no fetch, no log) when EMAIL_ENABLED=false (dev opt-out)', async () => {
+  it('returns { sent: false, reason: "disabled" } when EMAIL_ENABLED=false (dev opt-out)', async () => {
     process.env.RESEND_API_KEY = 'rk_test';
     process.env.EMAIL_ENABLED = 'false';
 
     const notifier = new ResendEmailNotifier();
-    await notifier.send(PARAMS);
+    const result = await notifier.send(PARAMS);
 
+    expect(result).toEqual({ sent: false, reason: 'disabled' });
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(errorSpy).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('warns and skips (no throw) when RESEND_API_KEY is missing', async () => {
+  it('returns { sent: false, reason: "no-api-key" } and warns when RESEND_API_KEY is missing', async () => {
     delete process.env.RESEND_API_KEY;
     delete process.env.EMAIL_ENABLED;
 
     const notifier = new ResendEmailNotifier();
-    await notifier.send(PARAMS);
+    const result = await notifier.send(PARAMS);
 
+    expect(result).toEqual({ sent: false, reason: 'no-api-key' });
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledOnce();
     expect(warnSpy.mock.calls[0][0]).toContain('RESEND_API_KEY not set');


### PR DESCRIPTION
## 概要

Closes #290

admin の Fermentations 画面から手動発火できるのは「trigger-scheduled (条件評価ベース)」と「retry (失敗発酵限定)」のみで、**特定ユーザーに今すぐメール付きで発酵を流したい / LLM 出力だけ即座に検証したい** といったデバッグ・サポート対応シナリオが詰まっていた。本 PR でデバッグ専用の強制発火パスを追加する。

## 動作

ユーザー詳細ページ (`/users/{id}`) の発火条件パネル直下に新パネルを追加。

- **問い select** — 空欄なら全 active 問いに対して発火、選んだ問いだけに絞ることも可
- **言語 select** — auto (= ユーザーの `user_metadata.locale` で解決) / ja / en
- **メール送信スキップ** checkbox — LLM 出力 (letter / keywords) の検証だけ行いたいときに ON
- 「発火 → 本当に発火する」の 2 段階確認ボタン

発火後は user 詳細と readiness を自動 refresh。結果領域に各 fermentation_result_id と先頭 60 文字を表示。メール送信失敗は \`emailFailure.error\` で表示する。

## 設計の重要ポイント

| 項目 | 採用方針 |
|---|---|
| 条件ゲート | **すべてバイパス** (文字数 / 時間 / readiness / fermentation_enabled) |
| user_fermentation_state | **更新しない** — 本番スケジューラー (`lastRunAt` / `nextEligibleAt` 経由) に影響を与えない |
| 認可 | 既存 adminAuthMiddleware のみ |
| 失敗の可観測性 | PR #289 と同じく \`console.error\` + レスポンス \`emailFailure\` |
| 防御チェック | entry_question_link に他ユーザーのエントリが混入していないか userId フィルタ |

## ファイル

### Server
- \`apps/server/src/contexts/fermentation/application/usecases/fire-fermentation.usecase.ts\` (新規)
- \`apps/server/src/contexts/fermentation/presentation/routes/admin-fermentations.ts\` (POST /fire 追加)

### Admin
- \`apps/admin/src/features/users/hooks/use-fire-fermentation.ts\` (新規)
- \`apps/admin/src/features/users/components/fire-fermentation-panel.tsx\` (新規)
- \`apps/admin/src/app/(protected)/users/[id]/page.tsx\` (パネル統合 + refresh 配線)

### テスト
- \`fire-fermentation.usecase.test.ts\` (9 ケース): 全 active 問い発火 / questionId 指定 / 未存在問いで throw / fermentation_enabled バイパス / 他ユーザーエントリのフィルタ / リンクなし問いスキップ / validated transaction なしスキップ / language pass-through
- \`use-fire-fermentation.test.ts\` (5 ケース): 成功 / 4xx server error 抽出 / JSON パース失敗フォールバック / reset() / トークン無し

## チェック

```
pnpm typecheck    ✅
pnpm test         ✅ (server: 269 / admin: 65)
pnpm dep-cruise   ✅
pnpm knip         ✅
```

\`as\` キャスト規約遵守 (テストの Response スタブ 1 箇所だけ \`@type-assertion-allowed\` 付き)、\`any\` なし、Feature-Sliced Architecture の依存ルール遵守。

## QA メモ

実機 QA は admin の Supabase 認証セットアップが必要なため、本 PR ではユニットテストのみで担保しています。マージ後に admin 環境で：

1. ユーザー詳細ページに「発酵を強制発火 (デバッグ用)」パネルが表示される
2. 問い select に active 問いが並ぶ (archived は除外)
3. 「発火」→「本当に発火する」→ ダイアログレスポンス表示 → 履歴 refresh
4. skipEmail=true でメールが送られないこと
5. skipEmail=false でメールが届くこと (PR #289 のログも合わせて確認)

を確認推奨。

## Out of Scope (#290 で明記)

- eligibility 条件の変更 (#268 の閾値はそのまま)
- 自動リトライ (#288 で「見える化」までは終わっている)
- 通常ユーザー向け UI (admin 専用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)