### PR TITLE
fix(client): login/signup の OS ダークモード崩れを修正 (#303)

### DIFF
--- a/apps/client/src/app/globals.css
+++ b/apps/client/src/app/globals.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+/* Tailwind v4 の `dark:` バリアントを `[data-theme="dark"]` に束ねる。
+ * 既定だと `prefers-color-scheme: dark` を見るため、ThemeProvider が data-theme を
+ * 制御している本アプリと判定がズレ、auth ページ等で背景は light なのに input/links だけ
+ * dark スタイルが当たって読めなくなる事象が起きる (Issue #303)。 */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 :root {
   --bg: #f9f8f4;
   --fg: #2d2d2d;


### PR DESCRIPTION
Closes #303

## 症状

OS が dark mode の状態でログイン/サインアップ画面を開くと、フォームの背景が真っ黒、周辺の Link テキストが白字になりライトな本体背景の上で読めなくなる。

## 原因

`globals.css` は `[data-theme=\"dark\"]` でテーマトークン (`--bg` / `--fg` 等) を切り替えているが、Tailwind v4 の `dark:` バリアントは既定で `@media (prefers-color-scheme: dark)` を判定基準にしている。

`ThemeProvider` は `(protected)/layout.tsx` だけにラップされていて `(auth)` 配下では設定されない。そのため OS が dark の auth ページでは:

- `<html>` に `data-theme` が無く `[data-theme=\"dark\"]` の CSS 変数は light のまま
- でも `dark:bg-zinc-900` や `dark:text-zinc-100` などは prefers-color-scheme でアクティブ
- → 背景はクリーム、input は黒、リンクは白という不整合

ユーザーが手動で light にトグルしている時 (data-theme=light, OS=dark) にも同じズレが起きる潜在バグだった。

## 修正

`apps/client/src/app/globals.css` 冒頭で Tailwind v4 の `@custom-variant` を使い `dark:` を `[data-theme=\"dark\"]` セレクタにバインド。アプリ全体のダーク判定を `data-theme` 一本に統一する。

```css
@custom-variant dark (&:where([data-theme=\"dark\"], [data-theme=\"dark\"] *));
```

これにより:

- auth ページ (ThemeProvider 無し) → 常にライト表示で readable
- protected ページで OS が dark → `ThemeProvider` が初期化時に `data-theme=\"dark\"` を貼る → 従来どおりダーク表示
- protected ページで手動 light + OS dark → ライト表示で正しく統一

なお `apps/admin` は既に `@custom-variant dark (&:is(.dark *))` を宣言済みで影響なし。

## 検証

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (新規警告なし)
- `pnpm test` ✅
- `pnpm dep-cruise` ✅
- Chrome DevTools MCP で OS=dark を emulate して /login と /signup を開き、ライト背景＋ダークテキストで全要素 readable を確認
- 同セッションで `data-theme=\"dark\"` を JS で貼って /signup のダーク表示が一貫していること (body bg `rgb(26,26,26)`, fg `rgb(204,204,204)`, input dark, submit button light w/ dark text) を確認

### Before (issue #303 添付画像)
本体背景はクリーム、input は黒、\"Sign up\" リンクは白 → 読めない

### After (OS=dark, auth page)
![after](https://github.com/ephemere-io/oryzae/blob/fix/303-auth-darkmode-broken/.tmp/screenshots/303-signup-os-dark-after-fix.png?raw=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)