### PR TITLE
feat(client): onboarding をスキップ不可にする (#305)

### DIFF
--- a/apps/client/src/features/onboarding/components/onboarding-flow.tsx
+++ b/apps/client/src/features/onboarding/components/onboarding-flow.tsx
@@ -17,39 +17,21 @@ export function OnboardingFlow({ onComplete, initialStep = 0 }: OnboardingFlowPr
   const [draft, setDraft] = useState('');
   const [open, setOpen] = useState(true);
 
-  const finish = useCallback(
-    (reason: 'complete' | 'skip') => {
-      setOpen(false);
-      onComplete({
-        skipped: reason === 'skip',
-        firstQuestion: draft.trim() || null,
-      });
-    },
-    [draft, onComplete],
-  );
+  // Issue #305: スキップ不可。必ず最初の「問い」を立ててから complete に進む。
+  const finish = useCallback(() => {
+    setOpen(false);
+    onComplete({ firstQuestion: draft.trim() || null });
+  }, [draft, onComplete]);
 
   if (!open) return null;
 
   return (
     <div className="ob-stage" role="dialog" aria-modal="true" aria-label={t('dialog_label')}>
       <div className="ob-card" key={step}>
-        {step === 0 && <StepConcept onNext={() => setStep(1)} onSkip={() => finish('skip')} />}
-        {step === 1 && (
-          <StepQuestion
-            draft={draft}
-            setDraft={setDraft}
-            onNext={() => setStep(2)}
-            onSkip={() => finish('skip')}
-          />
-        )}
-        {step === 2 && <StepEditor onNext={() => setStep(3)} onSkip={() => finish('skip')} />}
-        {step === 3 && (
-          <StepFerment
-            draft={draft}
-            onDone={() => finish('complete')}
-            onSkip={() => finish('skip')}
-          />
-        )}
+        {step === 0 && <StepConcept onNext={() => setStep(1)} />}
+        {step === 1 && <StepQuestion draft={draft} setDraft={setDraft} onNext={() => setStep(2)} />}
+        {step === 2 && <StepEditor onNext={() => setStep(3)} />}
+        {step === 3 && <StepFerment draft={draft} onDone={finish} />}
       </div>
     </div>
   );

--- a/apps/client/src/features/onboarding/components/steps.tsx
+++ b/apps/client/src/features/onboarding/components/steps.tsx
@@ -6,14 +6,11 @@ import { ConceptIllo, EditorIllo, JarIllo, QuestionIllo } from './illustrations'
 interface FooterBarProps {
   step: number;
   onNext: () => void;
-  onSkip: () => void;
   nextLabel: string;
   nextDisabled?: boolean;
-  finishing?: boolean;
 }
 
-function FooterBar({ step, onNext, onSkip, nextLabel, nextDisabled, finishing }: FooterBarProps) {
-  const t = useTranslations('onboarding');
+function FooterBar({ step, onNext, nextLabel, nextDisabled }: FooterBarProps) {
   return (
     <div className="ob-footer">
       <div
@@ -32,11 +29,6 @@ function FooterBar({ step, onNext, onSkip, nextLabel, nextDisabled, finishing }:
         ))}
       </div>
       <div className="ob-footer-actions">
-        {!finishing && (
-          <button type="button" className="ob-btn" onClick={onSkip}>
-            {t('skip')}
-          </button>
-        )}
         <button
           type="button"
           className="ob-btn ob-btn-primary"
@@ -52,10 +44,9 @@ function FooterBar({ step, onNext, onSkip, nextLabel, nextDisabled, finishing }:
 
 interface StepProps {
   onNext: () => void;
-  onSkip: () => void;
 }
 
-export function StepConcept({ onNext, onSkip }: StepProps) {
+export function StepConcept({ onNext }: StepProps) {
   const t = useTranslations('onboarding.step_concept');
   return (
     <>
@@ -75,7 +66,7 @@ export function StepConcept({ onNext, onSkip }: StepProps) {
           {t('body_2')}
         </p>
       </div>
-      <FooterBar step={0} onNext={onNext} onSkip={onSkip} nextLabel={t('next')} />
+      <FooterBar step={0} onNext={onNext} nextLabel={t('next')} />
     </>
   );
 }
@@ -85,7 +76,7 @@ interface StepQuestionProps extends StepProps {
   setDraft: (value: string) => void;
 }
 
-export function StepQuestion({ onNext, onSkip, draft, setDraft }: StepQuestionProps) {
+export function StepQuestion({ onNext, draft, setDraft }: StepQuestionProps) {
   const t = useTranslations('onboarding.step_question');
   const valid = draft.trim().length > 0 && draft.trim().length <= 64;
   return (
@@ -115,7 +106,6 @@ export function StepQuestion({ onNext, onSkip, draft, setDraft }: StepQuestionPr
       <FooterBar
         step={1}
         onNext={() => valid && onNext()}
-        onSkip={onSkip}
         nextLabel={t('next')}
         nextDisabled={!valid}
       />
@@ -123,7 +113,7 @@ export function StepQuestion({ onNext, onSkip, draft, setDraft }: StepQuestionPr
   );
 }
 
-export function StepEditor({ onNext, onSkip }: StepProps) {
+export function StepEditor({ onNext }: StepProps) {
   const t = useTranslations('onboarding.step_editor');
   return (
     <>
@@ -156,18 +146,17 @@ export function StepEditor({ onNext, onSkip }: StepProps) {
           </li>
         </ul>
       </div>
-      <FooterBar step={2} onNext={onNext} onSkip={onSkip} nextLabel={t('next')} />
+      <FooterBar step={2} onNext={onNext} nextLabel={t('next')} />
     </>
   );
 }
 
 interface StepFermentProps {
   onDone: () => void;
-  onSkip: () => void;
   draft: string;
 }
 
-export function StepFerment({ onDone, onSkip, draft }: StepFermentProps) {
+export function StepFerment({ onDone, draft }: StepFermentProps) {
   const t = useTranslations('onboarding.step_ferment');
   const trimmed = draft.trim();
   return (
@@ -186,7 +175,7 @@ export function StepFerment({ onDone, onSkip, draft }: StepFermentProps) {
           </div>
         )}
       </div>
-      <FooterBar step={3} onNext={onDone} onSkip={onSkip} nextLabel={t('next')} finishing />
+      <FooterBar step={3} onNext={onDone} nextLabel={t('next')} />
     </>
   );
 }

--- a/apps/client/src/features/onboarding/types.ts
+++ b/apps/client/src/features/onboarding/types.ts
@@ -1,4 +1,3 @@
 export interface OnboardingResult {
-  skipped: boolean;
   firstQuestion: string | null;
 }

--- a/apps/client/test/features/onboarding/components/onboarding-flow.test.tsx
+++ b/apps/client/test/features/onboarding/components/onboarding-flow.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OnboardingFlow } from '@/features/onboarding/components/onboarding-flow';
+import jaMessages from '@/i18n/messages/ja.json';
+
+function renderFlow(onComplete: ReturnType<typeof vi.fn>, initialStep = 0) {
+  render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <OnboardingFlow onComplete={onComplete} initialStep={initialStep} />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('OnboardingFlow', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('スキップボタンを全ステップで描画しない (Issue #305)', () => {
+    for (const step of [0, 1, 2, 3]) {
+      renderFlow(vi.fn(), step);
+      expect(screen.queryByRole('button', { name: jaMessages.onboarding.skip })).toBeNull();
+      cleanup();
+    }
+  });
+
+  it('最初の問いを入力するまでステップ2に進めない', () => {
+    renderFlow(vi.fn(), 1);
+    const nextBtn = screen.getByRole('button', {
+      name: jaMessages.onboarding.step_question.next,
+    });
+    if (!(nextBtn instanceof HTMLButtonElement)) {
+      throw new Error('next button should be a button element');
+    }
+    expect(nextBtn.disabled).toBe(true);
+  });
+
+  it('入力済みなら最終ステップから onComplete が firstQuestion 付きで呼ばれる', () => {
+    const onComplete = vi.fn();
+    renderFlow(onComplete, 1);
+
+    const input = screen.getByPlaceholderText(jaMessages.onboarding.step_question.placeholder);
+    fireEvent.change(input, { target: { value: 'なぜ?' } });
+    fireEvent.click(screen.getByRole('button', { name: jaMessages.onboarding.step_question.next }));
+    fireEvent.click(screen.getByRole('button', { name: jaMessages.onboarding.step_editor.next }));
+    fireEvent.click(screen.getByRole('button', { name: jaMessages.onboarding.step_ferment.next }));
+
+    expect(onComplete).toHaveBeenCalledWith({ firstQuestion: 'なぜ?' });
+  });
+});

--- a/apps/client/test/features/onboarding/hooks/use-onboarding.test.ts
+++ b/apps/client/test/features/onboarding/hooks/use-onboarding.test.ts
@@ -72,7 +72,7 @@ describe('useOnboarding', () => {
 
     let completeResult: { questionId: string | null } | undefined;
     await act(async () => {
-      completeResult = await result.current.complete({ skipped: false, firstQuestion: 'なぜ?' });
+      completeResult = await result.current.complete({ firstQuestion: 'なぜ?' });
     });
 
     expect(api.fetch).toHaveBeenNthCalledWith(2, '/api/v1/questions', {
@@ -100,7 +100,7 @@ describe('useOnboarding', () => {
 
     let completeResult: { questionId: string | null } | undefined;
     await act(async () => {
-      completeResult = await result.current.complete({ skipped: true, firstQuestion: null });
+      completeResult = await result.current.complete({ firstQuestion: null });
     });
 
     expect(api.fetch).toHaveBeenCalledTimes(2);
@@ -125,7 +125,7 @@ describe('useOnboarding', () => {
 
     let completeResult: { questionId: string | null } | undefined;
     await act(async () => {
-      completeResult = await result.current.complete({ skipped: false, firstQuestion: 'なぜ?' });
+      completeResult = await result.current.complete({ firstQuestion: 'なぜ?' });
     });
 
     expect(completeResult).toEqual({ questionId: null });


### PR DESCRIPTION
Closes #305

## 背景

必ず最初の「問い」を立ててもらうため、onboarding フローからスキップボタンを取り除く。

## 変更点

- `FooterBar` の "Skip" ボタンと関連 props (`onSkip`, `finishing`) を削除
- `OnboardingFlow.finish` の `'complete' | 'skip'` 分岐を廃止し、常に `firstQuestion` のみを `onComplete` に渡す
- `OnboardingResult.skipped` フィールドも未使用なので削除
- `use-onboarding.test.ts` を新シグネチャに追随
- 新規 `onboarding-flow.test.tsx`:
  - 全 4 ステップでスキップボタンが描画されないことを assert（Issue #305 のリグレッションガード）
  - Step 2 の Next ボタンが空入力では disabled
  - 入力済みで完走すると `onComplete({ firstQuestion: '...' })` が呼ばれる

i18n の `onboarding.skip` キーは Google Sheets SSoT 側の整理に任せるため JSON 直編集は控える（参照箇所が消えただけで害はない）。

## 確認

### ガードレール
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ 152/152 (client)
- `pnpm dep-cruise` ✅
- `pnpm knip` ✅

### 実機 QA (Chrome DevTools MCP)
test 用 supabase ユーザーの `onboarding_completed` を `false` に倒して 4 ステップを通し撮影。スキップボタンはどのステップにも存在しないことを確認。
- `.tmp/screenshots/305-onboarding-step1-concept.png` — Welcome
- `.tmp/screenshots/305-onboarding-step2-question-empty.png` — Question (Next disabled)
- `.tmp/screenshots/305-onboarding-step2-question-filled.png` — Question 入力後 (Next 有効)
- `.tmp/screenshots/305-onboarding-step3-editor.png` — Editor
- `.tmp/screenshots/305-onboarding-step4-ferment.png` — Jar & Fermentation (recap)

完走後 modal が閉じ、`/entries/new` にリダイレクト + `onboarding_completed=true` を確認。

## 既知の別件

QA 中に **`POST /api/v1/questions 400`** を観測。原因は `create-question.usecase.ts:23` の `activeCount >= 3` 上限ルール。今回テストに使ったユーザーがすでに 3 件のアクティブ問いを保有していたため。本 PR の変更（client 側 UI）とは無関係（API 呼び出しコードは触っていない）。実運用の新規ユーザー（問い 0 件）では発生しないはずだが、silent failure が UX として弱い点は別 issue でフォロー予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)