### PR TITLE
fix(auth): Google SSO 新規ユーザーで profile が作成されない問題 (#307)

### DIFF
--- a/apps/client/src/app/(auth)/callback/page.tsx
+++ b/apps/client/src/app/(auth)/callback/page.tsx
@@ -64,7 +64,11 @@ function CallbackHandler() {
         return;
       }
 
-      // Supabase implicit flow: tokens in URL hash fragment
+      // Supabase implicit flow: tokens in URL hash fragment.
+      // Issue #307: Supabase JS のデフォルトが implicit flow のため、Google SSO 新規ユーザーは
+      // この分岐を通る。`/oauth/finalize` を叩いて profile 作成と登録枠チェックを行う
+      // （PKCE 側の `/oauth/callback` と同じ責務）。これを呼ばないと profile が永久に作られず、
+      // onboarding モーダルも出ない。
       const hash = window.location.hash;
       if (hash) {
         const params = parseHashParams(hash);
@@ -74,14 +78,26 @@ function CallbackHandler() {
         if (accessToken && refreshToken) {
           setTokens(accessToken, refreshToken);
 
-          // Verify token and get user info
+          const localeParam = searchParams.get('locale');
+          const locale = localeParam === 'ja' || localeParam === 'en' ? localeParam : undefined;
           const client = createApiClient(accessToken);
-          const meRes = await client.fetch('/api/v1/auth/me');
+          const finalizeRes = await client.fetch('/api/v1/auth/oauth/finalize', {
+            method: 'POST',
+            body: JSON.stringify({ locale }),
+          });
 
-          if (meRes.ok) {
-            const data = (await meRes.json()) as { user: { id: string; email: string } };
-            posthog.identify(data.user.id, { email: data.user.email });
+          if (!finalizeRes.ok) {
+            const body = (await finalizeRes.json().catch(() => ({}))) as { error?: string };
+            if (finalizeRes.status === 409 && body.error === 'capacity_reached') {
+              setError(tErr('capacity_reached'));
+              return;
+            }
+            setError(t('error_auth_failed'));
+            return;
           }
+
+          const data = (await finalizeRes.json()) as { user: { id: string; email: string } };
+          posthog.identify(data.user.id, { email: data.user.email });
 
           router.push('/entries/new');
           return;

--- a/apps/server/src/contexts/shared/presentation/helpers/ensure-oauth-profile.ts
+++ b/apps/server/src/contexts/shared/presentation/helpers/ensure-oauth-profile.ts
@@ -1,0 +1,118 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+
+/**
+ * OAuth サインインの「profile が無ければ作る」共通処理。
+ *
+ * 同一ロジックを `/oauth/callback` (PKCE flow) と `/oauth/finalize` (implicit flow)
+ * の両方が呼ぶ。Issue #307 の原因はサーバ側 Supabase クライアントが implicit flow
+ * デフォルトのため、callback 側だけに profile 作成があり SSO 新規ユーザーの
+ * profile が永久に作られなかったこと。両 flow をこの helper に束ねて防ぐ。
+ *
+ * shared 層は user context を import できない（dep-cruise: shared-context-independence）
+ * ため、capacity 上限 env の読みと profiles 件数取得は inline で実装する。
+ */
+
+const DEFAULT_LIMIT = 100;
+
+interface EnsureOAuthProfileSuccess {
+  status: 'ok';
+  profile: { nickname: string; avatarUrl: string | null };
+  /** 今回の呼び出しで profile を新規作成したか */
+  created: boolean;
+}
+
+interface EnsureOAuthProfileCapacity {
+  status: 'capacity_reached';
+  limit: number;
+}
+
+type EnsureOAuthProfileResult = EnsureOAuthProfileSuccess | EnsureOAuthProfileCapacity;
+
+/**
+ * Supabase user_metadata からニックネームを生成する。
+ *
+ * - `full_name` があれば空白を `_` に変換し 30 文字で切る
+ * - 無ければ `user_<uuid8>` にフォールバック
+ */
+export function computeOAuthNickname(user: User): string {
+  const meta = user.user_metadata ?? {};
+  if (typeof meta.full_name === 'string' && meta.full_name.trim().length > 0) {
+    return meta.full_name.replace(/\s+/g, '_').slice(0, 30);
+  }
+  return `user_${user.id.slice(0, 8)}`;
+}
+
+export function extractOAuthAvatarUrl(user: User): string | null {
+  const meta = user.user_metadata ?? {};
+  return typeof meta.avatar_url === 'string' ? meta.avatar_url : null;
+}
+
+/**
+ * MAX_USER_COUNT を解決する。空・非数値・0以下なら 100 にフォールバック。
+ *
+ * 同等関数が `user/application/config/signup-cap.ts` にあるが shared 層からは
+ * import できないため重複している（Issue #300 で意図的に分離した経緯）。
+ */
+export function resolveMaxUserCountForOAuth(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.MAX_USER_COUNT;
+  if (!raw) return DEFAULT_LIMIT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return parsed;
+}
+
+/**
+ * 認証済み OAuth ユーザーに対して profile 行を idempotent に保証する。
+ *
+ * - profile が既にあれば現状を返す
+ * - 無ければ Research Preview 上限を確認のうえ insert
+ * - 上限超過なら `auth.users` 行を巻き戻し削除して 409 用の結果を返す
+ *
+ * @param serviceSupabase  service-role クライアント（profiles への直接書き込みが必要なので RLS バイパス）
+ * @param user             auth.users から取得済みのユーザー
+ * @param maxUserCount     Research Preview 登録枠の上限
+ */
+export async function ensureOAuthProfile(
+  serviceSupabase: SupabaseClient,
+  user: User,
+  maxUserCount: number,
+): Promise<EnsureOAuthProfileResult> {
+  const { data: existing } = await serviceSupabase
+    .from('profiles')
+    .select('nickname, avatar_url')
+    .eq('id', user.id)
+    .single();
+
+  if (existing) {
+    return {
+      status: 'ok',
+      profile: { nickname: existing.nickname, avatarUrl: existing.avatar_url ?? null },
+      created: false,
+    };
+  }
+
+  const { count } = await serviceSupabase
+    .from('profiles')
+    .select('id', { count: 'exact', head: true });
+
+  if ((count ?? 0) >= maxUserCount) {
+    // たった今 auth に作成された user を巻き戻して整合性を保つ
+    await serviceSupabase.auth.admin.deleteUser(user.id);
+    return { status: 'capacity_reached', limit: maxUserCount };
+  }
+
+  const nickname = computeOAuthNickname(user);
+  const avatarUrl = extractOAuthAvatarUrl(user);
+
+  await serviceSupabase.from('profiles').insert({
+    id: user.id,
+    nickname,
+    avatar_url: avatarUrl,
+  });
+
+  return {
+    status: 'ok',
+    profile: { nickname, avatarUrl },
+    created: true,
+  };
+}

--- a/apps/server/src/contexts/shared/presentation/routes/auth.ts
+++ b/apps/server/src/contexts/shared/presentation/routes/auth.ts
@@ -3,6 +3,7 @@ import {
   changePasswordSchema,
   loginSchema,
   oauthCallbackSchema,
+  oauthFinalizeSchema,
   oauthInitSchema,
   profileUpdateSchema,
   verifyOtpSchema,
@@ -11,6 +12,10 @@ import { createClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { getSupabaseClient } from '../../infrastructure/supabase-client.js';
+import {
+  ensureOAuthProfile,
+  resolveMaxUserCountForOAuth,
+} from '../helpers/ensure-oauth-profile.js';
 
 function getSupabaseAuthClient() {
   const url = process.env.SUPABASE_URL;
@@ -152,17 +157,19 @@ export const authRoutes = new Hono()
     return c.json({ url: data.url });
   })
   .post('/oauth/callback', async (c) => {
+    // PKCE flow 用エンドポイント。`?code=` がクエリにある場合のクライアントが叩く。
+    // Issue #307: Supabase JS のデフォルトが implicit flow のため通常はここを通らず、
+    // implicit flow 用の `/oauth/finalize` を経由する。両者は ensureOAuthProfile で
+    // profile 作成ロジックを共有する。
     const body = oauthCallbackSchema.parse(await c.req.json());
-    const { code } = body;
     const supabase = getSupabaseAuthClient();
 
-    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    const { data, error } = await supabase.auth.exchangeCodeForSession(body.code);
 
     if (error) {
       return c.json({ error: error.message }, 400);
     }
 
-    // Ensure profile exists for OAuth users
     const serviceSupabase = getSupabaseClient();
 
     // 初回 OAuth サインイン時は user_metadata.locale が未設定。
@@ -174,71 +181,74 @@ export const authRoutes = new Hono()
       });
     }
 
-    const { data: profile } = await serviceSupabase
-      .from('profiles')
-      .select('nickname, avatar_url')
-      .eq('id', data.user.id)
-      .single();
-
-    if (!profile) {
-      // Issue #300: Research Preview の登録枠チェック (OAuth 経由の新規ユーザーも対象)
-      // shared 層からは user/application 層を import できないため、必要最小限の
-      // 件数取得と env 解決をここに inline で書く。policy 本体のテストは
-      // apps/server/test/contexts/user/domain/policies/ にある。
-      const { count } = await serviceSupabase
-        .from('profiles')
-        .select('id', { count: 'exact', head: true });
-      const rawMax = process.env.MAX_USER_COUNT;
-      const parsedMax = rawMax ? Number.parseInt(rawMax, 10) : Number.NaN;
-      const limit = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 100;
-      if ((count ?? 0) >= limit) {
-        // たった今 exchangeCodeForSession で作成された auth.users を削除して整合性を保つ
-        await serviceSupabase.auth.admin.deleteUser(data.user.id);
-        return c.json({ error: 'capacity_reached', limit }, 409);
-      }
-
-      // Auto-create profile for OAuth users
-      const meta = data.user.user_metadata ?? {};
-      const nickname =
-        typeof meta.full_name === 'string'
-          ? meta.full_name.replace(/\s+/g, '_').slice(0, 30)
-          : `user_${data.user.id.slice(0, 8)}`;
-      const avatarUrl = typeof meta.avatar_url === 'string' ? meta.avatar_url : null;
-
-      await serviceSupabase.from('profiles').insert({
-        id: data.user.id,
-        nickname,
-        avatar_url: avatarUrl,
-      });
-
-      return c.json({
-        user: {
-          id: data.user.id,
-          email: data.user.email,
-          nickname,
-          avatarUrl,
-          providers: getProviders(data.user),
-        },
-        session: {
-          accessToken: data.session.access_token,
-          refreshToken: data.session.refresh_token,
-          expiresAt: data.session.expires_at,
-        },
-      });
+    const result = await ensureOAuthProfile(
+      serviceSupabase,
+      data.user,
+      resolveMaxUserCountForOAuth(),
+    );
+    if (result.status === 'capacity_reached') {
+      return c.json({ error: 'capacity_reached', limit: result.limit }, 409);
     }
 
     return c.json({
       user: {
         id: data.user.id,
         email: data.user.email,
-        nickname: profile.nickname,
-        avatarUrl: profile.avatar_url,
+        nickname: result.profile.nickname,
+        avatarUrl: result.profile.avatarUrl,
         providers: getProviders(data.user),
       },
       session: {
         accessToken: data.session.access_token,
         refreshToken: data.session.refresh_token,
         expiresAt: data.session.expires_at,
+      },
+    });
+  })
+  .post('/oauth/finalize', async (c) => {
+    // Issue #307: implicit OAuth flow 仕上げエンドポイント。
+    //
+    // Supabase JS の `signInWithOAuth` がデフォルトで implicit flow を使うため、
+    // Google からの redirect は `?code=` ではなく `#access_token=...` でトークンを返す。
+    // クライアントはそのトークンで Bearer 認証してここを叩き、サーバ側で
+    // profile 作成 + 登録枠チェックを行う（/oauth/callback と同じ責務）。
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return c.json({ error: 'Missing token' }, 401);
+    }
+
+    const supabase = createUserSupabase(authHeader);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    const body = oauthFinalizeSchema.parse(await c.req.json().catch(() => ({})));
+
+    const serviceSupabase = getSupabaseClient();
+
+    if (body.locale && !user.user_metadata?.locale) {
+      await serviceSupabase.auth.admin.updateUserById(user.id, {
+        user_metadata: { ...user.user_metadata, locale: body.locale },
+      });
+    }
+
+    const result = await ensureOAuthProfile(serviceSupabase, user, resolveMaxUserCountForOAuth());
+    if (result.status === 'capacity_reached') {
+      return c.json({ error: 'capacity_reached', limit: result.limit }, 409);
+    }
+
+    return c.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        nickname: result.profile.nickname,
+        avatarUrl: result.profile.avatarUrl,
+        providers: getProviders(user),
       },
     });
   })

--- a/apps/server/test/contexts/shared/auth-schemas.test.ts
+++ b/apps/server/test/contexts/shared/auth-schemas.test.ts
@@ -2,6 +2,7 @@ import {
   emailOtpTypeSchema,
   localeSchema,
   oauthCallbackSchema,
+  oauthFinalizeSchema,
   oauthInitSchema,
   signupSchema,
   verifyOtpSchema,
@@ -55,6 +56,21 @@ describe('oauthCallbackSchema', () => {
     const parsed = oauthCallbackSchema.parse({ code: 'abc', locale: 'ja' });
     expect(parsed.code).toBe('abc');
     expect(parsed.locale).toBe('ja');
+  });
+});
+
+describe('oauthFinalizeSchema', () => {
+  it('accepts empty body (locale optional)', () => {
+    expect(oauthFinalizeSchema.parse({}).locale).toBeUndefined();
+  });
+
+  it('accepts ja/en locale', () => {
+    expect(oauthFinalizeSchema.parse({ locale: 'ja' }).locale).toBe('ja');
+    expect(oauthFinalizeSchema.parse({ locale: 'en' }).locale).toBe('en');
+  });
+
+  it('rejects unsupported locale', () => {
+    expect(() => oauthFinalizeSchema.parse({ locale: 'fr' })).toThrow();
   });
 });
 

--- a/apps/server/test/contexts/shared/presentation/helpers/ensure-oauth-profile.test.ts
+++ b/apps/server/test/contexts/shared/presentation/helpers/ensure-oauth-profile.test.ts
@@ -1,0 +1,191 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  computeOAuthNickname,
+  ensureOAuthProfile,
+  extractOAuthAvatarUrl,
+  resolveMaxUserCountForOAuth,
+} from '@/contexts/shared/presentation/helpers/ensure-oauth-profile.js';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  // @type-assertion-allowed: テスト用に User の必要部分だけを満たすスタブを構築する。
+  // SupabaseClient.auth.getUser() の返す User 型は内部フィールド多数で全て埋めると冗長。
+  return {
+    id: 'user_id_01234567',
+    user_metadata: {},
+    ...overrides,
+  } as unknown as User;
+}
+
+interface MockOpts {
+  existingProfile?: { nickname: string; avatar_url: string | null } | null;
+  profileCount?: number;
+}
+
+interface MockHandles {
+  client: SupabaseClient;
+  insert: ReturnType<typeof vi.fn>;
+  deleteUser: ReturnType<typeof vi.fn>;
+  from: ReturnType<typeof vi.fn>;
+}
+
+function makeServiceSupabaseMock({
+  existingProfile = null,
+  profileCount = 0,
+}: MockOpts): MockHandles {
+  const insert = vi.fn().mockResolvedValue({ data: null, error: null });
+  const deleteUser = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  const select = vi.fn((_cols: string, options?: { count?: string; head?: boolean }) => {
+    if (options?.count === 'exact') {
+      // count クエリ: そのまま await される
+      return Promise.resolve({ count: profileCount, data: null, error: null });
+    }
+    // 通常 select: query builder を返す
+    return {
+      eq: () => ({
+        single: () =>
+          Promise.resolve({
+            data: existingProfile,
+            error: existingProfile ? null : { code: 'PGRST116', message: 'no rows' },
+          }),
+      }),
+    };
+  });
+
+  const from = vi.fn(() => ({ select, insert }));
+
+  // @type-assertion-allowed: SupabaseClient は内部多数のメソッドを持つが
+  // ensureOAuthProfile が触る .from() と .auth.admin.deleteUser() だけ実装する。
+  const client = {
+    from,
+    auth: { admin: { deleteUser } },
+  } as unknown as SupabaseClient;
+
+  return { client, insert, deleteUser, from };
+}
+
+describe('computeOAuthNickname', () => {
+  it('full_name の空白を _ に変換', () => {
+    expect(
+      computeOAuthNickname(makeUser({ user_metadata: { full_name: 'Yoshitaka Nakajima' } })),
+    ).toBe('Yoshitaka_Nakajima');
+  });
+
+  it('全角・複数空白も _ に変換', () => {
+    expect(computeOAuthNickname(makeUser({ user_metadata: { full_name: 'a  b   c' } }))).toBe(
+      'a_b_c',
+    );
+  });
+
+  it('full_name が無ければ user_<id8> にフォールバック', () => {
+    expect(computeOAuthNickname(makeUser({ id: 'abcdef1234567890', user_metadata: {} }))).toBe(
+      'user_abcdef12',
+    );
+  });
+
+  it('full_name が空文字でもフォールバック', () => {
+    expect(
+      computeOAuthNickname(
+        makeUser({ id: 'abcdef1234567890', user_metadata: { full_name: '   ' } }),
+      ),
+    ).toBe('user_abcdef12');
+  });
+
+  it('30 文字で切る', () => {
+    const long = 'a'.repeat(40);
+    expect(computeOAuthNickname(makeUser({ user_metadata: { full_name: long } }))).toHaveLength(30);
+  });
+});
+
+describe('extractOAuthAvatarUrl', () => {
+  it('avatar_url が文字列ならそのまま返す', () => {
+    expect(
+      extractOAuthAvatarUrl(makeUser({ user_metadata: { avatar_url: 'https://x/a.png' } })),
+    ).toBe('https://x/a.png');
+  });
+
+  it('avatar_url 無しなら null', () => {
+    expect(extractOAuthAvatarUrl(makeUser({ user_metadata: {} }))).toBeNull();
+  });
+
+  it('avatar_url が文字列以外なら null', () => {
+    expect(extractOAuthAvatarUrl(makeUser({ user_metadata: { avatar_url: 123 } }))).toBeNull();
+  });
+});
+
+describe('resolveMaxUserCountForOAuth', () => {
+  it('未設定なら 100', () => {
+    expect(resolveMaxUserCountForOAuth({})).toBe(100);
+  });
+  it('正の整数文字列をパース', () => {
+    expect(resolveMaxUserCountForOAuth({ MAX_USER_COUNT: '250' })).toBe(250);
+  });
+  it('非数値・0以下は 100', () => {
+    expect(resolveMaxUserCountForOAuth({ MAX_USER_COUNT: 'abc' })).toBe(100);
+    expect(resolveMaxUserCountForOAuth({ MAX_USER_COUNT: '0' })).toBe(100);
+    expect(resolveMaxUserCountForOAuth({ MAX_USER_COUNT: '-5' })).toBe(100);
+  });
+});
+
+describe('ensureOAuthProfile', () => {
+  it('既存 profile があれば created: false で返す', async () => {
+    const { client, insert, deleteUser } = makeServiceSupabaseMock({
+      existingProfile: { nickname: 'existing_user', avatar_url: 'https://x/a.png' },
+    });
+    const result = await ensureOAuthProfile(client, makeUser(), 100);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.created).toBe(false);
+      expect(result.profile).toEqual({ nickname: 'existing_user', avatarUrl: 'https://x/a.png' });
+    }
+    expect(insert).not.toHaveBeenCalled();
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('profile 無 & 枠余りなら user_metadata から作成', async () => {
+    const { client, insert, deleteUser } = makeServiceSupabaseMock({
+      existingProfile: null,
+      profileCount: 5,
+    });
+    const user = makeUser({
+      id: 'new_user_uuid_long',
+      user_metadata: { full_name: 'New User', avatar_url: 'https://g/p.jpg' },
+    });
+    const result = await ensureOAuthProfile(client, user, 100);
+
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.created).toBe(true);
+      expect(result.profile).toEqual({ nickname: 'New_User', avatarUrl: 'https://g/p.jpg' });
+    }
+    expect(insert).toHaveBeenCalledWith({
+      id: 'new_user_uuid_long',
+      nickname: 'New_User',
+      avatar_url: 'https://g/p.jpg',
+    });
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('profile 無 & 枠超過なら auth.users を巻き戻し capacity_reached', async () => {
+    const { client, insert, deleteUser } = makeServiceSupabaseMock({
+      existingProfile: null,
+      profileCount: 100,
+    });
+    const user = makeUser({ id: 'late_user_id' });
+    const result = await ensureOAuthProfile(client, user, 100);
+
+    expect(result.status).toBe('capacity_reached');
+    if (result.status === 'capacity_reached') {
+      expect(result.limit).toBe(100);
+    }
+    expect(deleteUser).toHaveBeenCalledWith('late_user_id');
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('profileCount === limit は capacity_reached（境界値）', async () => {
+    const { client } = makeServiceSupabaseMock({ existingProfile: null, profileCount: 50 });
+    const result = await ensureOAuthProfile(client, makeUser(), 50);
+    expect(result.status).toBe('capacity_reached');
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export {
   localeSchema,
   loginSchema,
   oauthCallbackSchema,
+  oauthFinalizeSchema,
   oauthInitSchema,
   profileUpdateSchema,
   questionStringSchema,

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -48,6 +48,18 @@ export const oauthCallbackSchema = z.object({
 });
 
 /**
+ * Implicit OAuth flow の仕上げ用ペイロード。
+ *
+ * Supabase の `flowType: 'implicit'` (デフォルト) では Google からの redirect が
+ * URL fragment にトークンを返す。クライアントはそのトークンで Bearer 認証して
+ * このエンドポイントを叩き、サーバ側で profile 作成と Research Preview 登録枠
+ * チェックを行う。詳細は Issue #307。
+ */
+export const oauthFinalizeSchema = z.object({
+  locale: localeSchema.optional(),
+});
+
+/**
  * Supabase Auth のメール確認系トークンタイプ。
  * Microsoft (Outlook) は差出人ドメインとリンク先ドメインが乖離していると
  * メールをサイレントに破棄する。{{ .ConfirmationURL }} だと supabase.co を


### PR DESCRIPTION
Closes #307

## 症状

- Google SSO で新規アカウント登録すると onboarding モーダルが出ない
- `/entries/new` に直接遷移し、コンソールに `/api/v1/users/me: 404 Failed to load resource` が出る

## 原因

`apps/server/src/contexts/shared/presentation/routes/auth.ts` の \`getSupabaseAuthClient()\` が \`flowType\` を指定せず \`createClient(url, anonKey)\` を呼んでおり、\`@supabase/auth-js@2.105.1\` の \`GoTrueClient.js:24\` で **\`flowType: 'implicit'\` がデフォルト**。

そのため Google からの redirect は \`?code=\` ではなく URL fragment にトークンが乗って戻る。クライアント \`callback/page.tsx\` の implicit-flow 分岐は \`/api/v1/auth/me\` を verify 目的で叩くだけで、profile 作成 + Research Preview 登録枠チェックを行う \`/oauth/callback\` には到達しない。結果、SSO 新規ユーザーの profile が永久に作られず、\`useOnboarding\` フックは \`/api/v1/users/me\` の 404 で静かに失敗して onboarding が出ない。

実害: 5/12 時点で過去 7 日間の Google SSO 新規 4 名全員に profile が無い状態だった（SQL で backfill 済み: Han_Long_Dominique_Chen / Yoshitaka_Nakajima / 久保彩 / 上妻優生）。

## 修正

### サーバ
- **新ヘルパー** \`apps/server/src/contexts/shared/presentation/helpers/ensure-oauth-profile.ts\`
  - \`ensureOAuthProfile(serviceSupabase, user, maxUserCount)\` — profile を idempotent に保証。無ければ user_metadata から nickname/avatar を生成して insert、上限超過なら auth.users を巻き戻して \`capacity_reached\` を返す
  - \`computeOAuthNickname\` / \`extractOAuthAvatarUrl\` / \`resolveMaxUserCountForOAuth\` は単体テスト 14 件付き
- **新エンドポイント** \`POST /api/v1/auth/oauth/finalize\`
  - Bearer token で認証した OAuth ユーザーに対し \`ensureOAuthProfile\` を呼ぶ。capacity 超過は 409
- **既存** \`POST /api/v1/auth/oauth/callback\` (PKCE flow) も同じヘルパー経由にリファクタ。重複していた inline 実装を削除

### クライアント
- \`apps/client/src/app/(auth)/callback/page.tsx\` の implicit-flow 分岐を \`/api/v1/auth/oauth/finalize\` に差し替え。409 \`capacity_reached\` も PKCE 側と同じハンドリング

### shared
- \`oauthFinalizeSchema\` 追加（locale optional）

## 検証

- typecheck / lint / test (331 server + 70 client/admin) / dep-cruise / knip 全 green
- 既存 affected user 4 名に SQL で profile を backfill 済み（\`onboarding_completed=false\`、次回ログイン時に onboarding 表示）
- ローカルで dev server を起動し、新エンドポイントが 401 \`Missing token\` / \`Invalid token\` を期待通り返すことを確認
- 本物の Google SSO サインアップフロー検証は提出者の手元で実施予定

## 互換性

- PKCE flow ( \`?code=\` ) を使う既存導線は変わらず動く（共有ヘルパーで挙動同一）
- 既存 profile を持つユーザーの SSO ログインは \`ensureOAuthProfile\` が \`created: false\` で抜けるので影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)