### PR TITLE
fix(auth): サインアップ確認メールの redirect 先を現在の origin に追従

### DIFF
--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -146,9 +146,14 @@ export function useAuth() {
     locale?: 'ja' | 'en' | 'zh' | 'ko',
   ): Promise<string | null> {
     const client = createApiClient();
+    // Supabase の確認メールに埋め込む redirect 先を、フォームが置かれている origin に
+    // 揃える。Vercel preview ではこれを送らないとダッシュボード設定の本番 Site URL に
+    // 戻ってしまい、preview 環境での新規サインアップ動作確認ができない。
+    const emailRedirectTo =
+      typeof window !== 'undefined' ? `${window.location.origin}/auth/confirm` : undefined;
     const res = await client.fetch('/api/v1/auth/signup', {
       method: 'POST',
-      body: JSON.stringify({ nickname, email, password, locale }),
+      body: JSON.stringify({ nickname, email, password, locale, emailRedirectTo }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error: string };

--- a/apps/server/src/contexts/user/presentation/routes/signup.ts
+++ b/apps/server/src/contexts/user/presentation/routes/signup.ts
@@ -66,6 +66,10 @@ export const signupRoutes = new Hono()
 
     // Create auth user.
     // locale は Supabase 確認メールテンプレートの `{{ .Data.locale }}` で参照される。
+    // emailRedirectTo は確認メール内の `{{ .RedirectTo }}` に展開され、Vercel preview など
+    // 本番外の環境からのサインアップでも確認リンクが当該環境に戻れるようにする。
+    // (ダッシュボード側で "Additional Redirect URLs" にプレビュー URL の許可、
+    // テンプレートで {{ .SiteURL }} ではなく {{ .RedirectTo }} を使う設定が必要)
     const supabase = getSupabaseAuthClient();
     const locale: LocaleCode = body.locale ?? 'ja';
     const { data, error } = await supabase.auth.signUp({
@@ -73,6 +77,7 @@ export const signupRoutes = new Hono()
       password: body.password,
       options: {
         data: { locale },
+        ...(body.emailRedirectTo ? { emailRedirectTo: body.emailRedirectTo } : {}),
       },
     });
 

--- a/apps/server/test/contexts/shared/auth-schemas.test.ts
+++ b/apps/server/test/contexts/shared/auth-schemas.test.ts
@@ -41,6 +41,22 @@ describe('signupSchema locale field', () => {
   it('rejects unsupported locale', () => {
     expect(() => signupSchema.parse({ ...base, locale: 'de' })).toThrow();
   });
+
+  it('emailRedirectTo を受け付ける (Vercel preview などからの origin 上書き用)', () => {
+    const parsed = signupSchema.parse({
+      ...base,
+      emailRedirectTo: 'https://oryzae-preview.vercel.app/auth/confirm',
+    });
+    expect(parsed.emailRedirectTo).toBe('https://oryzae-preview.vercel.app/auth/confirm');
+  });
+
+  it('emailRedirectTo は省略可 (本番では Supabase 側 Site URL に委ねる)', () => {
+    expect(signupSchema.parse(base).emailRedirectTo).toBeUndefined();
+  });
+
+  it('emailRedirectTo は URL でない場合は reject', () => {
+    expect(() => signupSchema.parse({ ...base, emailRedirectTo: 'not-a-url' })).toThrow();
+  });
 });
 
 describe('oauthInitSchema', () => {

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -39,6 +39,14 @@ export const signupSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6),
   locale: localeSchema.optional(),
+  /**
+   * Supabase の確認メールに埋め込む redirect 先 (`{{ .RedirectTo }}`)。
+   * Vercel preview など本番外の環境からサインアップしたとき、ダッシュボード設定の
+   * Site URL ではなく、実際にサインアップフォームが置かれていた origin に
+   * 戻ってきて確認フローを完了させるためにクライアントから明示的に送る。
+   * 通常 `${window.location.origin}/auth/confirm` を渡す。
+   */
+  emailRedirectTo: z.string().url().optional(),
 });
 
 export const oauthInitSchema = z.object({


### PR DESCRIPTION
## 課題

Vercel preview 環境で新規サインアップした際、Supabase の確認メール内のリンクがダッシュボード設定の Site URL（本番 URL）に固定されており、preview 環境上で新規ユーザーのオンボーディング動作を確認できなかった。

## 変更内容

- **`packages/shared/src/schemas.ts`**: `signupSchema` に optional な `emailRedirectTo: z.string().url()` を追加
- **`apps/client/src/features/auth/hooks/use-auth.ts`**: signup 呼び出し時に `${window.location.origin}/auth/confirm` を `emailRedirectTo` として送信
- **`apps/server/src/contexts/user/presentation/routes/signup.ts`**: 受信した `emailRedirectTo` を `supabase.auth.signUp({ options: { emailRedirectTo } })` に転送

これにより Supabase は確認メール内 `{{ .RedirectTo }}` テンプレ変数を当該 origin（本番 / preview 各々）で展開する。

## ⚠️ コード外で必要な Supabase ダッシュボード作業

1. **Email Templates → Confirm signup**:
   `<a href=\"{{ .ConfirmationURL }}\">` を 3 箇所すべて以下に置換:
   ```
   {{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup&next=/entries/new
   ```
   これにより `/auth/confirm` ページが期待する `token_hash` / `type` / `next` クエリ形式で着地する。

2. **Authentication → URL Configuration → Redirect URLs**:
   preview 用パターンを許可リストに追加:
   ```
   https://*.vercel.app/auth/confirm
   https://*.vercel.app/auth/confirm?**
   ```
   これがないと Supabase は `emailRedirectTo` を黙って Site URL に差し替えるため、preview への redirect が機能しない。

## テスト

- `signupSchema`: `emailRedirectTo` の許容・URL バリデーション・省略の 3 ケース追加 (server tests: 337 → 340)
- typecheck / lint / dep-cruise / knip 全 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)