### PR TITLE
feat(entries): pickle ボタンの 4 分岐モーダル化と保存後ガイド表示 (#316)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -9,7 +9,11 @@ import {
 } from '@/features/entries/components/editor-status-bar';
 import { formatEntryDate } from '@/features/entries/components/format-entry-date';
 import { LeaveConfirmModal } from '@/features/entries/components/leave-confirm-modal';
+import { LinkQuestionNudgeModal } from '@/features/entries/components/link-question-nudge-modal';
+import { PickleConfirmModal } from '@/features/entries/components/pickle-confirm-modal';
+import { PickleNudgeModal } from '@/features/entries/components/pickle-nudge-modal';
 import { QuestionLinker } from '@/features/entries/components/question-linker';
+import { QuestionSelectModal } from '@/features/entries/components/question-select-modal';
 import { SaveTitleModal } from '@/features/entries/components/save-title-modal';
 import { SettingsDrawer } from '@/features/entries/components/settings-drawer';
 import { SnippetToolbar } from '@/features/entries/components/snippet-toolbar';
@@ -25,6 +29,7 @@ import { useFocusMode } from '@/features/entries/hooks/use-focus-mode';
 import { useGhostEffect } from '@/features/entries/hooks/use-ghost-effect';
 import { usePressureBleed } from '@/features/entries/hooks/use-pressure-bleed';
 import { useTimeInscription } from '@/features/entries/hooks/use-time-inscription';
+import { useUserMe } from '@/features/entries/hooks/use-user-me';
 import {
   useVoiceDynamics,
   type VoiceUnavailableReason,
@@ -107,6 +112,12 @@ export function EntryEditor({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [saveModalMode, setSaveModalMode] = useState<'save' | 'pickle'>('save');
+  // Issue #316: pickle 時のモーダル分岐 (タイトル有無 × 問い有無)
+  const [pickleConfirmOpen, setPickleConfirmOpen] = useState(false);
+  const [questionSelectOpen, setQuestionSelectOpen] = useState(false);
+  // Issue #316: 保存成功直後に出すガイドモーダル
+  const [pickleNudgeOpen, setPickleNudgeOpen] = useState(false);
+  const [linkQuestionNudgeOpen, setLinkQuestionNudgeOpen] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [currentEntryId, setCurrentEntryId] = useState<string | undefined>(entryId);
@@ -124,6 +135,8 @@ export function EntryEditor({
     return formatEntryDate(created, updated, t);
   });
   const { save, saving, error } = useSaveEntry(api, auth);
+  // Issue #316: 保存成功直後のナッジ表示判定に使う
+  const userMe = useUserMe(api);
   const router = useRouter();
   const sidebarWidth = SIDEBAR_WIDTH;
   const editorRef = useRef<HTMLDivElement>(null);
@@ -141,6 +154,10 @@ export function EntryEditor({
   const anyOverlayOpen =
     settingsOpen ||
     saveModalOpen ||
+    pickleConfirmOpen ||
+    questionSelectOpen ||
+    pickleNudgeOpen ||
+    linkQuestionNudgeOpen ||
     isEditingTitle ||
     statsOpen ||
     pendingNavPath !== null ||
@@ -258,6 +275,12 @@ export function EntryEditor({
       const finalContent = newTitle.trim() ? `${newTitle.trim()}\n${content}` : content;
       const targetId = currentEntryId ?? entryId;
       const isNew = !targetId;
+      // Issue #316: ナッジ判定用に、保存"前"のフラグスナップショットを取る
+      const prevHasPickled = userMe.data?.hasPickled ?? null;
+      const prevHasLinked = userMe.data?.hasLinkedQuestion ?? null;
+      const onboardingCompleted = userMe.data?.onboardingCompleted ?? false;
+      const linkedCountBeforeSave = linkedIds.size;
+      const justPickled = options.fermentationEnabled === true;
 
       const savedId = await save(
         finalContent,
@@ -271,6 +294,8 @@ export function EntryEditor({
         setSavedContent(content);
         setCurrentEntryId(savedId);
         setSaveModalOpen(false);
+        setPickleConfirmOpen(false);
+        setQuestionSelectOpen(false);
         setIsEditingTitle(false);
         setStatus('saved');
         const created = createdAtIso ? new Date(createdAtIso) : new Date();
@@ -282,6 +307,29 @@ export function EntryEditor({
         }
         setTimeout(() => setStatus('editing'), 2000);
         onSaveComplete?.(savedId, finalContent);
+
+        // Issue #316: ガイドモーダル判定 (オンボーディング完了後のみ)。
+        // 漬け込み遷移が走るケース (= 漬け込み成功) はナッジ不要、遷移先で完結。
+        if (onboardingCompleted && !justPickled) {
+          if (
+            prevHasPickled === false &&
+            linkedCountBeforeSave > 0 &&
+            !sessionStorage.getItem('oryzae:nudge:pickle:shown')
+          ) {
+            sessionStorage.setItem('oryzae:nudge:pickle:shown', '1');
+            setPickleNudgeOpen(true);
+          } else if (
+            prevHasLinked === false &&
+            linkedCountBeforeSave === 0 &&
+            !sessionStorage.getItem('oryzae:nudge:link:shown')
+          ) {
+            sessionStorage.setItem('oryzae:nudge:link:shown', '1');
+            setLinkQuestionNudgeOpen(true);
+          }
+        }
+        // 状態が変わった可能性があるので user-me を refetch (次回判定の精度向上)
+        userMe.refresh();
+
         if (
           options.fermentationEnabled &&
           onSaveTransition &&
@@ -306,6 +354,7 @@ export function EntryEditor({
       onSaveTransition,
       createdAtIso,
       t,
+      userMe,
     ],
   );
 
@@ -320,12 +369,68 @@ export function EntryEditor({
     }
   }, [content, entryId, handleSaveWithTitle, title]);
 
-  // 漬け込む is an irreversible deliberate action — always open the modal for confirmation.
+  // Issue #316: 漬け込む を押した時、エントリの状態 (タイトル有無 × 問い有無) で
+  // 表示するモーダルを 4 通りに分岐する:
+  //   - title あり × 問いあり → PickleConfirmModal (確認のみ)
+  //   - title なし × 問いあり → 既存 SaveTitleModal (タイトル編集付き)
+  //   - title あり × 問いなし → QuestionSelectModal (問い選択 → pickle)
+  //   - title なし × 問いなし → QuestionSelectModal (問い選択、本文先頭行を title として採用)
   const handlePickleClick = useCallback(() => {
     if (!content.trim()) return;
-    setSaveModalMode('pickle');
-    setSaveModalOpen(true);
-  }, [content]);
+    const hasTitle = title.trim().length > 0;
+    const hasQuestion = linkedIds.size > 0;
+
+    if (hasQuestion && hasTitle) {
+      setPickleConfirmOpen(true);
+    } else if (hasQuestion && !hasTitle) {
+      setSaveModalMode('pickle');
+      setSaveModalOpen(true);
+    } else {
+      // hasQuestion === false (title 有無に関わらず) → まず問いを決めてもらう
+      setQuestionSelectOpen(true);
+    }
+  }, [content, title, linkedIds]);
+
+  // タイトルあり×問いありケース: 漬け込み確認モーダルからの実行
+  const handlePickleConfirm = useCallback(() => {
+    handleSaveWithTitle(title, { fermentationEnabled: true });
+  }, [handleSaveWithTitle, title]);
+
+  // タイトルあり/なし × 問いなしケース: 問いを選択 (or 新規作成) してから漬け込む
+  const handleQuestionSelectAndPickle = useCallback(
+    async (args: { existingId: string | null; newQuestionText: string | null }) => {
+      let questionId = args.existingId;
+      // 新規問い作成 (POST /api/v1/questions)
+      if (!questionId && args.newQuestionText && api) {
+        const res = await api.fetch('/api/v1/questions', {
+          method: 'POST',
+          body: JSON.stringify({ string: args.newQuestionText }),
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { id?: string };
+          questionId = data.id ?? null;
+        }
+      }
+      if (!questionId) return;
+
+      // ローカル state に追加 (新規エントリの場合は handleSaveWithTitle 内で
+      // server side のリンクが行われる)
+      const nextLinked = new Set(linkedIds);
+      nextLinked.add(questionId);
+      setLinkedIds(nextLinked);
+
+      // 既存エントリの場合は即座にサーバ側でリンクする
+      const targetId = currentEntryId ?? entryId;
+      if (targetId && onLinkQuestion) {
+        await onLinkQuestion(targetId, questionId);
+      }
+
+      setQuestionSelectOpen(false);
+      // 漬け込みを実行 (タイトル未設定なら本文先頭行が title として後から解釈される)
+      handleSaveWithTitle(title, { fermentationEnabled: true });
+    },
+    [api, linkedIds, currentEntryId, entryId, onLinkQuestion, handleSaveWithTitle, title],
+  );
 
   const startTitleEdit = useCallback(() => {
     setDraftTitle(title);
@@ -917,6 +1022,37 @@ export function EntryEditor({
         open={leaveConfirmOpen}
         onCancel={cancelLeaveConfirm}
         onConfirm={confirmLeaveConfirm}
+      />
+
+      {/* Issue #316: タイトルあり × 問いあり 用の漬け込み確認モーダル */}
+      <PickleConfirmModal
+        open={pickleConfirmOpen}
+        saving={saving}
+        title={title}
+        linkedQuestionTexts={activeQuestions
+          .filter((q) => linkedIds.has(q.id) && q.currentText)
+          .map((q) => q.currentText as string)}
+        onConfirm={handlePickleConfirm}
+        onClose={() => setPickleConfirmOpen(false)}
+      />
+
+      {/* Issue #316: 問い未紐付エントリを漬け込む際の問い選択モーダル */}
+      <QuestionSelectModal
+        open={questionSelectOpen}
+        saving={saving}
+        activeQuestions={activeQuestions}
+        linkedQuestionIds={linkedIds}
+        onConfirm={handleQuestionSelectAndPickle}
+        onClose={() => setQuestionSelectOpen(false)}
+      />
+
+      {/* Issue #316: 保存後ガイド (まだ漬け込んでいない使用者向け) */}
+      <PickleNudgeModal open={pickleNudgeOpen} onClose={() => setPickleNudgeOpen(false)} />
+
+      {/* Issue #316: 保存後ガイド (まだ問いを紐付けていない使用者向け) */}
+      <LinkQuestionNudgeModal
+        open={linkQuestionNudgeOpen}
+        onClose={() => setLinkQuestionNudgeOpen(false)}
       />
     </div>
   );

--- a/apps/client/src/features/entries/components/link-question-nudge-modal.tsx
+++ b/apps/client/src/features/entries/components/link-question-nudge-modal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+interface LinkQuestionNudgeModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Issue #316: 一度もエントリに問いを紐付けたことがない使用者に、
+ * 問いを紐付けると漬け込み (発酵) が可能になることを案内する。
+ * 強制ではなく可能性の提示。
+ */
+export function LinkQuestionNudgeModal({ open, onClose }: LinkQuestionNudgeModalProps) {
+  const t = useTranslations('editor.link_question_nudge_modal');
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aria_label')}
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="w-[90%] max-w-[440px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '28px 32px' }}
+      >
+        <h3 className="mb-3 text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          {t('heading')}
+        </h3>
+        <p className="mb-5 text-xs leading-relaxed" style={{ color: 'var(--fg)' }}>
+          {t('body')}
+        </p>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-xs"
+            style={{
+              borderColor: 'var(--accent)',
+              color: 'var(--accent)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            {t('dismiss')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/pickle-confirm-modal.tsx
+++ b/apps/client/src/features/entries/components/pickle-confirm-modal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+interface PickleConfirmModalProps {
+  open: boolean;
+  saving: boolean;
+  title: string;
+  /** Linked question texts to show in the confirmation copy. */
+  linkedQuestionTexts: string[];
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Issue #316: タイトルあり × 問いあり のエントリを「漬け込む」とき、
+ * 既存の SaveTitleModal (タイトル編集付き) ではなく、瓶に漬け込むことの
+ * 確認だけを行う軽いモーダル。タイトル編集は別途 EntryEditor の
+ * インライン編集で行う想定。
+ */
+export function PickleConfirmModal({
+  open,
+  saving,
+  title,
+  linkedQuestionTexts,
+  onConfirm,
+  onClose,
+}: PickleConfirmModalProps) {
+  const t = useTranslations('editor.pickle_confirm_modal');
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aria_label')}
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="w-[90%] max-w-[400px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '28px 32px' }}
+      >
+        <h3 className="mb-3 text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          {t('heading')}
+        </h3>
+        <p className="mb-4 text-xs leading-relaxed" style={{ color: 'var(--fg)' }}>
+          {t('body', { title })}
+        </p>
+        {linkedQuestionTexts.length > 0 && (
+          <div className="mb-4 flex flex-wrap gap-1">
+            {linkedQuestionTexts.map((text) => (
+              <span
+                key={text}
+                className="inline-flex max-w-full items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+              >
+                <span className="truncate">{text}</span>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-xs"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--fg)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            {t('cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={saving}
+            className="rounded-md border px-4 py-2 text-xs text-white disabled:opacity-40"
+            style={{ backgroundColor: 'var(--accent)', borderColor: 'var(--accent)' }}
+          >
+            {saving ? t('saving') : t('confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/pickle-nudge-modal.tsx
+++ b/apps/client/src/features/entries/components/pickle-nudge-modal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+interface PickleNudgeModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Issue #316: 問いを紐付けて保存したが、まだ一度も「漬け込む」を押した
+ * ことがない使用者に、漬け込みボタンを試してみるよう案内する。
+ * 強制ではなく可能性の提示。
+ */
+export function PickleNudgeModal({ open, onClose }: PickleNudgeModalProps) {
+  const t = useTranslations('editor.pickle_nudge_modal');
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aria_label')}
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="w-[90%] max-w-[440px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '28px 32px' }}
+      >
+        <h3 className="mb-3 text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          {t('heading')}
+        </h3>
+        <p className="mb-5 text-xs leading-relaxed" style={{ color: 'var(--fg)' }}>
+          {t('body')}
+        </p>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-xs"
+            style={{
+              borderColor: 'var(--accent)',
+              color: 'var(--accent)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            {t('dismiss')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/question-select-modal.tsx
+++ b/apps/client/src/features/entries/components/question-select-modal.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useEffect, useRef, useState } from 'react';
+
+interface QuestionOption {
+  id: string;
+  currentText: string | null;
+}
+
+interface QuestionSelectModalProps {
+  open: boolean;
+  saving: boolean;
+  /** Existing active questions to pick from. */
+  activeQuestions: QuestionOption[];
+  /** Already-linked question IDs (filtered out of the picker). */
+  linkedQuestionIds: Set<string>;
+  /**
+   * Confirm handler. Either selects an existing question (existingId) or
+   * creates a new one with the given text (newQuestionText). Exactly one of
+   * the two arguments will be non-null. The caller is responsible for
+   * (1) creating the question on the server when newQuestionText is given,
+   * (2) linking it to the entry, and (3) running the pickle save.
+   */
+  onConfirm: (args: { existingId: string | null; newQuestionText: string | null }) => void;
+  onClose: () => void;
+}
+
+/**
+ * Issue #316: タイトルがあっても問いが紐付いていないエントリを「漬け込む」
+ * 際に表示する。既存の問いがあればリストから選び、なければその場で書く。
+ * 選択/入力後は呼び出し側で create+link+pickle を行う。
+ */
+export function QuestionSelectModal({
+  open,
+  saving,
+  activeQuestions,
+  linkedQuestionIds,
+  onConfirm,
+  onClose,
+}: QuestionSelectModalProps) {
+  const t = useTranslations('editor.question_select_modal');
+  const available = activeQuestions.filter((q) => !linkedQuestionIds.has(q.id));
+  const [mode, setMode] = useState<'pick' | 'create'>(available.length > 0 ? 'pick' : 'create');
+  const [selectedId, setSelectedId] = useState<string>('');
+  const [newText, setNewText] = useState('');
+  const newTextRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setMode(available.length > 0 ? 'pick' : 'create');
+    setSelectedId('');
+    setNewText('');
+    if (available.length === 0) {
+      setTimeout(() => newTextRef.current?.focus(), 50);
+    }
+  }, [open, available.length]);
+
+  if (!open) return null;
+
+  const trimmedNew = newText.trim();
+  const canConfirm = mode === 'pick' ? selectedId !== '' : trimmedNew.length > 0;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canConfirm) return;
+    if (mode === 'pick') {
+      onConfirm({ existingId: selectedId, newQuestionText: null });
+    } else {
+      onConfirm({ existingId: null, newQuestionText: trimmedNew });
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aria_label')}
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        onSubmit={handleSubmit}
+        className="w-[90%] max-w-[440px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '28px 32px' }}
+      >
+        <h3 className="mb-3 text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          {t('heading')}
+        </h3>
+        <p className="mb-4 text-xs leading-relaxed" style={{ color: 'var(--fg)' }}>
+          {t('body')}
+        </p>
+
+        {available.length > 0 && (
+          <div className="mb-3 flex gap-3 text-xs" style={{ color: 'var(--fg)' }}>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="qmode"
+                value="pick"
+                checked={mode === 'pick'}
+                onChange={() => setMode('pick')}
+              />
+              {t('mode_pick')}
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                name="qmode"
+                value="create"
+                checked={mode === 'create'}
+                onChange={() => setMode('create')}
+              />
+              {t('mode_create')}
+            </label>
+          </div>
+        )}
+
+        {mode === 'pick' && available.length > 0 ? (
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="mb-4 w-full rounded-md border px-3 py-2.5 text-sm outline-none"
+            style={{
+              backgroundColor: 'var(--bg)',
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--fg)',
+            }}
+          >
+            <option value="">{t('pick_placeholder')}</option>
+            {available.map((q) => (
+              <option key={q.id} value={q.id}>
+                {q.currentText}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            ref={newTextRef}
+            type="text"
+            value={newText}
+            onChange={(e) => setNewText(e.target.value)}
+            onKeyDown={(e) => {
+              // IME 確定の Enter で誤送信を避ける
+              if (e.key === 'Enter' && e.nativeEvent.isComposing) {
+                e.preventDefault();
+              }
+            }}
+            maxLength={64}
+            placeholder={t('create_placeholder')}
+            className="mb-4 w-full rounded-md border px-3 py-2.5 text-sm outline-none"
+            style={{
+              backgroundColor: 'var(--bg)',
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--fg)',
+            }}
+          />
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-4 py-2 text-xs"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--fg)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            {t('cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !canConfirm}
+            className="rounded-md border px-4 py-2 text-xs text-white disabled:opacity-40"
+            style={{ backgroundColor: 'var(--accent)', borderColor: 'var(--accent)' }}
+          >
+            {saving ? t('saving') : t('confirm')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/hooks/use-user-me.ts
+++ b/apps/client/src/features/entries/hooks/use-user-me.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ApiClient } from '@/lib/api';
+
+interface UserMeData {
+  id: string;
+  nickname: string;
+  avatarUrl: string | null;
+  onboardingCompleted: boolean;
+  /** 一度でも漬け込んだことがあるか (Issue #316 ガイド表示判定用) */
+  hasPickled: boolean;
+  /** 一度でもエントリに問いを紐付けたことがあるか (Issue #316 ガイド表示判定用) */
+  hasLinkedQuestion: boolean;
+}
+
+interface UseUserMeResult {
+  data: UserMeData | null;
+  loading: boolean;
+  /** 保存成功後など、フラグが変わり得るタイミングで呼ぶ */
+  refresh: () => Promise<UserMeData | null>;
+}
+
+/**
+ * Issue #316: EntryEditor の保存成功後ナッジ表示判定に必要な
+ * `hasPickled` / `hasLinkedQuestion` を含む user-me を取得する。
+ *
+ * `useOnboarding` も同じエンドポイントを叩くが、用途とライフサイクルが
+ * 異なるためフックを分けている (onboarding は app/(protected)/layout、
+ * これは entries feature 内で消費)。
+ */
+export function useUserMe(api: ApiClient | null): UseUserMeResult {
+  const [data, setData] = useState<UserMeData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const apiRef = useRef(api);
+  apiRef.current = api;
+
+  const fetchMe = useCallback(async (): Promise<UserMeData | null> => {
+    const client = apiRef.current;
+    if (!client) return null;
+    const res = await client.fetch('/api/v1/users/me');
+    if (!res.ok) return null;
+    const next = (await res.json()) as UserMeData;
+    setData(next);
+    return next;
+  }, []);
+
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchMe().finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, fetchMe]);
+
+  return { data, loading, refresh: fetchMe };
+}

--- a/apps/client/src/i18n/messages/en.json
+++ b/apps/client/src/i18n/messages/en.json
@@ -329,6 +329,38 @@
       "cancel": "Cancel",
       "saving": "Saving..."
     },
+    "pickle_confirm_modal": {
+      "aria_label": "Pickle confirmation dialog",
+      "heading": "Pickle this entry into the Jar",
+      "body": "Send \"{title}\" to the fermentation process. You can still edit the content and links afterwards.",
+      "cancel": "Cancel",
+      "confirm": "Pickle",
+      "saving": "Pickling..."
+    },
+    "question_select_modal": {
+      "aria_label": "Question selection dialog",
+      "heading": "Link a question to this entry",
+      "body": "To pickle and ferment, an entry must be linked to one question. Pick an existing question or write a new one here.",
+      "mode_pick": "Pick existing",
+      "mode_create": "Write new",
+      "pick_placeholder": "Choose a question...",
+      "create_placeholder": "Write a question (e.g. What did I notice today?)",
+      "cancel": "Cancel",
+      "confirm": "Link and pickle",
+      "saving": "Pickling..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "Pickling guidance",
+      "heading": "Try pickling this entry",
+      "body": "Entries linked to a question can move into the fermentation process when you pickle them. Press the pickle button (jar icon) anytime to try.",
+      "dismiss": "Got it"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "Question linking guidance",
+      "heading": "Try linking a question",
+      "body": "Linking a question to an entry lets you pickle it and start the fermentation process. Pick an existing question from the linker above or create a new one.",
+      "dismiss": "Got it"
+    },
     "settings": {
       "close_aria": "Close settings",
       "section_basic": "Basics",

--- a/apps/client/src/i18n/messages/ja.json
+++ b/apps/client/src/i18n/messages/ja.json
@@ -329,6 +329,38 @@
       "cancel": "キャンセル",
       "saving": "保存中..."
     },
+    "pickle_confirm_modal": {
+      "aria_label": "漬け込み確認ダイアログ",
+      "heading": "このエントリを瓶に漬け込む",
+      "body": "「{title}」を発酵プロセスに送ります。漬け込み後も内容と紐付けは編集できます。",
+      "cancel": "キャンセル",
+      "confirm": "漬け込む",
+      "saving": "漬け込み中..."
+    },
+    "question_select_modal": {
+      "aria_label": "問い選択ダイアログ",
+      "heading": "このエントリに問いを紐付ける",
+      "body": "漬け込んで発酵させるには、エントリに問いを 1 つ紐付ける必要があります。既存の問いを選ぶか、新しい問いをその場で書いてください。",
+      "mode_pick": "既存の問いから選ぶ",
+      "mode_create": "新しく書く",
+      "pick_placeholder": "問いを選択...",
+      "create_placeholder": "問いを書く (例: 今日の小さな発見は？)",
+      "cancel": "キャンセル",
+      "confirm": "紐付けて漬け込む",
+      "saving": "漬け込み中..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "漬け込みのご案内",
+      "heading": "漬け込んでみませんか",
+      "body": "問いの紐付いたエントリは、漬け込むことで発酵プロセスに進みます。漬け込みボタン (瓶のアイコン) を押すといつでも試せます。",
+      "dismiss": "わかりました"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "問い紐付けのご案内",
+      "heading": "問いを紐付けてみませんか",
+      "body": "エントリに問いを紐付けると、漬け込んで発酵プロセスに進められるようになります。エディタ上部の問いリンカーから既存の問いを選ぶか、新しく作れます。",
+      "dismiss": "わかりました"
+    },
     "settings": {
       "close_aria": "設定を閉じる",
       "section_basic": "基本設定",

--- a/apps/client/src/i18n/messages/ko.json
+++ b/apps/client/src/i18n/messages/ko.json
@@ -329,6 +329,38 @@
       "cancel": "취소",
       "saving": "저장 중..."
     },
+    "pickle_confirm_modal": {
+      "aria_label": "담그기 확인 대화상자",
+      "heading": "이 항목을 항아리에 담그기",
+      "body": "「{title}」을(를) 발효 과정으로 보냅니다. 담근 후에도 내용과 연결을 편집할 수 있습니다.",
+      "cancel": "취소",
+      "confirm": "담그기",
+      "saving": "담그는 중..."
+    },
+    "question_select_modal": {
+      "aria_label": "질문 선택 대화상자",
+      "heading": "이 항목에 질문 연결",
+      "body": "담가서 발효시키려면 항목에 질문을 하나 연결해야 합니다. 기존 질문을 고르거나 새로 작성하세요.",
+      "mode_pick": "기존에서 선택",
+      "mode_create": "새로 작성",
+      "pick_placeholder": "질문 선택...",
+      "create_placeholder": "질문을 작성하세요 (예: 오늘 작은 발견은?)",
+      "cancel": "취소",
+      "confirm": "연결 후 담그기",
+      "saving": "담그는 중..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "담그기 안내",
+      "heading": "담가 보시겠어요?",
+      "body": "질문이 연결된 항목은 담그면 발효 과정으로 진입합니다. 항아리 아이콘 버튼으로 언제든 시도해 보세요.",
+      "dismiss": "알겠습니다"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "질문 연결 안내",
+      "heading": "질문을 연결해 보시겠어요?",
+      "body": "항목에 질문을 연결하면 담가서 발효 과정으로 보낼 수 있습니다. 에디터 상단 질문 링커에서 기존 질문을 선택하거나 새로 만드세요.",
+      "dismiss": "알겠습니다"
+    },
     "settings": {
       "close_aria": "설정 닫기",
       "section_basic": "기본 설정",

--- a/apps/client/src/i18n/messages/zh.json
+++ b/apps/client/src/i18n/messages/zh.json
@@ -329,6 +329,38 @@
       "cancel": "取消",
       "saving": "保存中..."
     },
+    "pickle_confirm_modal": {
+      "aria_label": "入瓮确认对话框",
+      "heading": "将此条目放入瓮中",
+      "body": "将「{title}」送入发酵过程。入瓮之后仍可编辑内容与关联。",
+      "cancel": "取消",
+      "confirm": "入瓮",
+      "saving": "入瓮中..."
+    },
+    "question_select_modal": {
+      "aria_label": "问题选择对话框",
+      "heading": "为此条目关联一个问题",
+      "body": "要入瓮并发酵，需要给条目关联一个问题。请从已有问题中选择，或在此输入新问题。",
+      "mode_pick": "选已有",
+      "mode_create": "新建",
+      "pick_placeholder": "请选择问题...",
+      "create_placeholder": "写一个问题（例：今天的小发现是？）",
+      "cancel": "取消",
+      "confirm": "关联并入瓮",
+      "saving": "入瓮中..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "入瓮引导",
+      "heading": "试试将其入瓮？",
+      "body": "已关联问题的条目，入瓮后会进入发酵过程。随时按入瓮按钮（瓶子图标）即可尝试。",
+      "dismiss": "知道了"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "问题关联引导",
+      "heading": "试试关联一个问题？",
+      "body": "将问题关联到条目后，就可以入瓮并进入发酵过程。可在编辑器顶部的问题关联器选择已有问题，或新建一个。",
+      "dismiss": "知道了"
+    },
     "settings": {
       "close_aria": "关闭设置",
       "section_basic": "基本设置",

--- a/apps/client/test/features/entries/components/link-question-nudge-modal.test.tsx
+++ b/apps/client/test/features/entries/components/link-question-nudge-modal.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LinkQuestionNudgeModal } from '@/features/entries/components/link-question-nudge-modal';
+import jaMessages from '@/i18n/messages/ja.json';
+
+describe('LinkQuestionNudgeModal (Issue #316)', () => {
+  afterEach(() => cleanup());
+
+  function setup(open: boolean) {
+    const onClose = vi.fn();
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <LinkQuestionNudgeModal open={open} onClose={onClose} />
+      </NextIntlClientProvider>,
+    );
+    return { onClose };
+  }
+
+  it('open=false なら描画しない', () => {
+    setup(false);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('open=true で見出し / 本文 / dismiss を表示する', () => {
+    setup(true);
+    expect(screen.getByText('問いを紐付けてみませんか')).toBeTruthy();
+    expect(screen.getByText(/エントリに問いを紐付けると/)).toBeTruthy();
+    expect(screen.getByText('わかりました')).toBeTruthy();
+  });
+
+  it('「わかりました」で onClose を呼ぶ', () => {
+    const { onClose } = setup(true);
+    fireEvent.click(screen.getByText('わかりました'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/test/features/entries/components/pickle-confirm-modal.test.tsx
+++ b/apps/client/test/features/entries/components/pickle-confirm-modal.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PickleConfirmModal } from '@/features/entries/components/pickle-confirm-modal';
+import jaMessages from '@/i18n/messages/ja.json';
+
+describe('PickleConfirmModal (Issue #316)', () => {
+  afterEach(() => cleanup());
+
+  function setup(overrides: { open?: boolean; saving?: boolean } = {}) {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    const utils = render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <PickleConfirmModal
+          open={overrides.open ?? true}
+          saving={overrides.saving ?? false}
+          title="今日の発見"
+          linkedQuestionTexts={['何が嬉しかった?']}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      </NextIntlClientProvider>,
+    );
+    return { onConfirm, onClose, utils };
+  }
+
+  it('open=false なら何も描画しない', () => {
+    setup({ open: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('open=true で見出し / タイトル / 紐付き問いを表示する', () => {
+    setup();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('このエントリを瓶に漬け込む')).toBeTruthy();
+    // body にタイトルが埋め込まれている
+    expect(screen.getByText(/今日の発見/)).toBeTruthy();
+    // 紐付き問いがチップで表示される
+    expect(screen.getByText('何が嬉しかった?')).toBeTruthy();
+  });
+
+  it('「漬け込む」ボタンで onConfirm を呼ぶ', () => {
+    const { onConfirm } = setup();
+    fireEvent.click(screen.getByText('漬け込む'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('saving=true の間は確認ボタンが disabled になり saving 文言を出す', () => {
+    setup({ saving: true });
+    const button = screen.getByText('漬け込み中...').closest('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('「キャンセル」で onClose を呼ぶ', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/test/features/entries/components/pickle-nudge-modal.test.tsx
+++ b/apps/client/test/features/entries/components/pickle-nudge-modal.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PickleNudgeModal } from '@/features/entries/components/pickle-nudge-modal';
+import jaMessages from '@/i18n/messages/ja.json';
+
+describe('PickleNudgeModal (Issue #316)', () => {
+  afterEach(() => cleanup());
+
+  function setup(open: boolean) {
+    const onClose = vi.fn();
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <PickleNudgeModal open={open} onClose={onClose} />
+      </NextIntlClientProvider>,
+    );
+    return { onClose };
+  }
+
+  it('open=false なら描画しない', () => {
+    setup(false);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('open=true で見出し / 本文 / dismiss を表示する', () => {
+    setup(true);
+    expect(screen.getByText('漬け込んでみませんか')).toBeTruthy();
+    expect(screen.getByText(/問いの紐付いたエントリは/)).toBeTruthy();
+    expect(screen.getByText('わかりました')).toBeTruthy();
+  });
+
+  it('「わかりました」で onClose を呼ぶ', () => {
+    const { onClose } = setup(true);
+    fireEvent.click(screen.getByText('わかりました'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/test/features/entries/components/question-select-modal.test.tsx
+++ b/apps/client/test/features/entries/components/question-select-modal.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { QuestionSelectModal } from '@/features/entries/components/question-select-modal';
+import jaMessages from '@/i18n/messages/ja.json';
+
+describe('QuestionSelectModal (Issue #316)', () => {
+  afterEach(() => cleanup());
+
+  function setup(
+    args: {
+      open?: boolean;
+      activeQuestions?: { id: string; currentText: string | null }[];
+      linkedQuestionIds?: Set<string>;
+    } = {},
+  ) {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <QuestionSelectModal
+          open={args.open ?? true}
+          saving={false}
+          activeQuestions={
+            args.activeQuestions ?? [
+              { id: 'q1', currentText: '今日の小さな発見は？' },
+              { id: 'q2', currentText: '何にときめいた？' },
+            ]
+          }
+          linkedQuestionIds={args.linkedQuestionIds ?? new Set()}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      </NextIntlClientProvider>,
+    );
+    return { onConfirm, onClose };
+  }
+
+  it('open=false なら描画しない', () => {
+    setup({ open: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('既存の問いがあれば pick モードがデフォルトで、selectで選択して確定すると existingId を渡す', () => {
+    const { onConfirm } = setup();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'q2' } });
+    fireEvent.click(screen.getByText('紐付けて漬け込む'));
+    expect(onConfirm).toHaveBeenCalledWith({ existingId: 'q2', newQuestionText: null });
+  });
+
+  it('既存の問いが 1 つもなければ create モードで開き、入力して確定すると newQuestionText を渡す', () => {
+    const { onConfirm } = setup({ activeQuestions: [] });
+    const input = screen.getByPlaceholderText(/問いを書く/) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '今日の感謝は？' } });
+    fireEvent.click(screen.getByText('紐付けて漬け込む'));
+    expect(onConfirm).toHaveBeenCalledWith({
+      existingId: null,
+      newQuestionText: '今日の感謝は？',
+    });
+  });
+
+  it('mode_create に切り替えると新規入力欄に切り替わる', () => {
+    setup();
+    fireEvent.click(screen.getByLabelText('新しく書く'));
+    expect(screen.getByPlaceholderText(/問いを書く/)).toBeTruthy();
+  });
+
+  it('既に紐付いている問いは選択肢から除外される', () => {
+    setup({ linkedQuestionIds: new Set(['q1']) });
+    expect(screen.queryByText('今日の小さな発見は？')).toBeNull();
+    expect(screen.getByText('何にときめいた？')).toBeTruthy();
+  });
+
+  it('未選択 / 未入力のまま確定はできない (ボタン disabled)', () => {
+    const { onConfirm } = setup();
+    const button = screen.getByText('紐付けて漬け込む').closest('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('「キャンセル」で onClose を呼ぶ', () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/test/features/entries/hooks/use-user-me.test.ts
+++ b/apps/client/test/features/entries/hooks/use-user-me.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserMe } from '@/features/entries/hooks/use-user-me';
+import type { ApiClient } from '@/lib/api';
+
+function createMockApi(fetchImpl: ReturnType<typeof vi.fn>): ApiClient {
+  return {
+    baseUrl: '',
+    headers: {},
+    fetch: fetchImpl,
+  };
+}
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 400,
+  } as Response;
+}
+
+describe('useUserMe (Issue #316)', () => {
+  let apiFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiFetch = vi.fn();
+  });
+
+  it('api が null のときは fetch せず loading=true のまま', () => {
+    const { result } = renderHook(() => useUserMe(null));
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(true);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('/api/v1/users/me を叩いて data に hasPickled / hasLinkedQuestion をセットする', async () => {
+    const me = {
+      id: 'u1',
+      nickname: 'taro',
+      avatarUrl: null,
+      onboardingCompleted: true,
+      hasPickled: false,
+      hasLinkedQuestion: true,
+    };
+    apiFetch.mockResolvedValueOnce(mockResponse(true, me));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useUserMe(api));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(apiFetch).toHaveBeenCalledWith('/api/v1/users/me');
+    expect(result.current.data).toEqual(me);
+  });
+
+  it('refresh() で再 fetch して新しい値を返す', async () => {
+    const initial = {
+      id: 'u1',
+      nickname: 'taro',
+      avatarUrl: null,
+      onboardingCompleted: true,
+      hasPickled: false,
+      hasLinkedQuestion: false,
+    };
+    const updated = { ...initial, hasPickled: true };
+    apiFetch
+      .mockResolvedValueOnce(mockResponse(true, initial))
+      .mockResolvedValueOnce(mockResponse(true, updated));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useUserMe(api));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.hasPickled).toBe(false);
+
+    let refreshed: unknown = null;
+    await act(async () => {
+      refreshed = await result.current.refresh();
+    });
+    expect(refreshed).toEqual(updated);
+    expect(result.current.data?.hasPickled).toBe(true);
+  });
+
+  it('レスポンスが ok でなければ data は null のまま', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(false, {}));
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useUserMe(api));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/apps/server/src/contexts/user/application/usecases/get-user-me.usecase.ts
+++ b/apps/server/src/contexts/user/application/usecases/get-user-me.usecase.ts
@@ -1,0 +1,49 @@
+import type { UserActivityStatsRepositoryGateway } from '../../domain/gateways/user-activity-stats-repository.gateway.js';
+import type { UserProfileRepositoryGateway } from '../../domain/gateways/user-profile-repository.gateway.js';
+import { UserProfileNotFoundError } from '../errors/user.errors.js';
+
+interface UserMeView {
+  id: string;
+  nickname: string;
+  avatarUrl: string | null;
+  onboardingCompleted: boolean;
+  /** 一度でも漬け込んだエントリがあるか (Issue #316 ガイドモーダル用) */
+  hasPickled: boolean;
+  /** 一度でもエントリに問いを紐付けたことがあるか (Issue #316 ガイドモーダル用) */
+  hasLinkedQuestion: boolean;
+}
+
+/**
+ * GET /api/v1/users/me が返す View を組み立てる usecase。
+ *
+ * Issue #316 のガイドモーダル (まだ漬け込んでいない/まだ問いを紐付けていない使用者へ
+ * 案内する) は、これら 2 フラグと onboardingCompleted を客戸側で組み合わせて
+ * 表示判定する。集計は user 側 port の {@link UserActivityStatsRepositoryGateway}
+ * を介して行い、entry / question コンテキストへの参照は持たない。
+ */
+export class GetUserMeUsecase {
+  constructor(
+    private profileRepo: UserProfileRepositoryGateway,
+    private statsRepo: UserActivityStatsRepositoryGateway,
+  ) {}
+
+  async execute(userId: string): Promise<UserMeView> {
+    const profile = await this.profileRepo.findById(userId);
+    if (!profile) throw new UserProfileNotFoundError(userId);
+
+    const [hasPickled, hasLinkedQuestion] = await Promise.all([
+      this.statsRepo.hasPickled(userId),
+      this.statsRepo.hasLinkedQuestion(userId),
+    ]);
+
+    const props = profile.toProps();
+    return {
+      id: props.id,
+      nickname: props.nickname,
+      avatarUrl: props.avatarUrl,
+      onboardingCompleted: props.onboardingCompleted,
+      hasPickled,
+      hasLinkedQuestion,
+    };
+  }
+}

--- a/apps/server/src/contexts/user/domain/gateways/user-activity-stats-repository.gateway.ts
+++ b/apps/server/src/contexts/user/domain/gateways/user-activity-stats-repository.gateway.ts
@@ -1,0 +1,15 @@
+/**
+ * Issue #316: ガイドモーダル表示判定に使う、user の "これまでの活動傾向" を
+ * 1 user_id 引数で取り出すための port。
+ *
+ * 集計の元となるテーブル (entries / entry_question_links) は entry / question
+ * コンテキストの所有物だが、user 集計用 view としてここ user 側に port を
+ * 持たせ、infrastructure 実装が直接 Supabase に問い合わせる形を取る
+ * (user-context-isolation ルールにより user → 他 context への参照は不可)。
+ */
+export interface UserActivityStatsRepositoryGateway {
+  /** 指定ユーザーが一度でも fermentation_enabled=true なエントリを持つか */
+  hasPickled(userId: string): Promise<boolean>;
+  /** 指定ユーザーが一度でも entry-question リンクを持つか */
+  hasLinkedQuestion(userId: string): Promise<boolean>;
+}

--- a/apps/server/src/contexts/user/infrastructure/repositories/supabase-user-activity-stats.repository.ts
+++ b/apps/server/src/contexts/user/infrastructure/repositories/supabase-user-activity-stats.repository.ts
@@ -1,0 +1,33 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { UserActivityStatsRepositoryGateway } from '../../domain/gateways/user-activity-stats-repository.gateway.js';
+
+/**
+ * Issue #316: Supabase 実装。`entries` / `entry_question_links` テーブルに
+ * 直接問い合わせる (entry / question コンテキストの repository を経由しない)。
+ * 行が 1 件あるかだけ判定すればよいので `limit(1)` でコストを抑える。
+ */
+export class SupabaseUserActivityStatsRepository implements UserActivityStatsRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async hasPickled(userId: string): Promise<boolean> {
+    const { data, error } = await this.supabase
+      .from('entries')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('fermentation_enabled', true)
+      .limit(1);
+    if (error) throw error;
+    return (data ?? []).length > 0;
+  }
+
+  async hasLinkedQuestion(userId: string): Promise<boolean> {
+    // entry_question_links.entry_id → entries.user_id を inner join で絞り込む
+    const { data, error } = await this.supabase
+      .from('entry_question_links')
+      .select('entry_id, entries!inner(user_id)')
+      .eq('entries.user_id', userId)
+      .limit(1);
+    if (error) throw error;
+    return (data ?? []).length > 0;
+  }
+}

--- a/apps/server/src/contexts/user/presentation/routes/user-me.ts
+++ b/apps/server/src/contexts/user/presentation/routes/user-me.ts
@@ -1,7 +1,10 @@
 import { completeOnboardingSchema } from '@oryzae/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
+import { UserProfileNotFoundError } from '../../application/errors/user.errors.js';
 import { CompleteOnboardingUsecase } from '../../application/usecases/complete-onboarding.usecase.js';
+import { GetUserMeUsecase } from '../../application/usecases/get-user-me.usecase.js';
+import { SupabaseUserActivityStatsRepository } from '../../infrastructure/repositories/supabase-user-activity-stats.repository.js';
 import { SupabaseUserProfileRepository } from '../../infrastructure/repositories/supabase-user-profile.repository.js';
 
 type Env = {
@@ -15,20 +18,20 @@ export const userMe = new Hono<Env>()
   .get('/', async (c) => {
     const userId = c.get('userId');
     const supabase = c.get('supabase');
-    const profileRepo = new SupabaseUserProfileRepository(supabase);
+    const usecase = new GetUserMeUsecase(
+      new SupabaseUserProfileRepository(supabase),
+      new SupabaseUserActivityStatsRepository(supabase),
+    );
 
-    const profile = await profileRepo.findById(userId);
-    if (!profile) {
-      return c.json({ error: 'Profile not found' }, 404);
+    try {
+      const view = await usecase.execute(userId);
+      return c.json(view);
+    } catch (e) {
+      if (e instanceof UserProfileNotFoundError) {
+        return c.json({ error: 'Profile not found' }, 404);
+      }
+      throw e;
     }
-
-    const props = profile.toProps();
-    return c.json({
-      id: props.id,
-      nickname: props.nickname,
-      avatarUrl: props.avatarUrl,
-      onboardingCompleted: props.onboardingCompleted,
-    });
   })
   .patch('/onboarding', async (c) => {
     completeOnboardingSchema.parse(await c.req.json());

--- a/apps/server/test/contexts/user/application/usecases/get-user-me.usecase.test.ts
+++ b/apps/server/test/contexts/user/application/usecases/get-user-me.usecase.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserProfileNotFoundError } from '@/contexts/user/application/errors/user.errors';
+import { GetUserMeUsecase } from '@/contexts/user/application/usecases/get-user-me.usecase';
+import type { UserActivityStatsRepositoryGateway } from '@/contexts/user/domain/gateways/user-activity-stats-repository.gateway';
+import type { UserProfileRepositoryGateway } from '@/contexts/user/domain/gateways/user-profile-repository.gateway';
+import { UserProfile } from '@/contexts/user/domain/models/user-profile';
+
+describe('GetUserMeUsecase', () => {
+  let profileRepo: UserProfileRepositoryGateway;
+  let statsRepo: UserActivityStatsRepositoryGateway;
+  let usecase: GetUserMeUsecase;
+
+  const baseProfile = UserProfile.fromProps({
+    id: 'user-1',
+    nickname: 'taro',
+    avatarUrl: null,
+    onboardingCompleted: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  });
+
+  beforeEach(() => {
+    profileRepo = {
+      findById: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(undefined),
+      count: vi.fn().mockResolvedValue(0),
+    };
+    statsRepo = {
+      hasPickled: vi.fn().mockResolvedValue(false),
+      hasLinkedQuestion: vi.fn().mockResolvedValue(false),
+    };
+    usecase = new GetUserMeUsecase(profileRepo, statsRepo);
+  });
+
+  it('プロフィールと集計フラグ (false/false) を返す', async () => {
+    vi.mocked(profileRepo.findById).mockResolvedValue(baseProfile);
+
+    const view = await usecase.execute('user-1');
+
+    expect(view).toEqual({
+      id: 'user-1',
+      nickname: 'taro',
+      avatarUrl: null,
+      onboardingCompleted: true,
+      hasPickled: false,
+      hasLinkedQuestion: false,
+    });
+    expect(statsRepo.hasPickled).toHaveBeenCalledWith('user-1');
+    expect(statsRepo.hasLinkedQuestion).toHaveBeenCalledWith('user-1');
+  });
+
+  it('一度でも漬け込んでいれば hasPickled=true', async () => {
+    vi.mocked(profileRepo.findById).mockResolvedValue(baseProfile);
+    vi.mocked(statsRepo.hasPickled).mockResolvedValue(true);
+
+    const view = await usecase.execute('user-1');
+
+    expect(view.hasPickled).toBe(true);
+    expect(view.hasLinkedQuestion).toBe(false);
+  });
+
+  it('一度でも問いを紐付けていれば hasLinkedQuestion=true', async () => {
+    vi.mocked(profileRepo.findById).mockResolvedValue(baseProfile);
+    vi.mocked(statsRepo.hasLinkedQuestion).mockResolvedValue(true);
+
+    const view = await usecase.execute('user-1');
+
+    expect(view.hasPickled).toBe(false);
+    expect(view.hasLinkedQuestion).toBe(true);
+  });
+
+  it('プロフィールが無ければ UserProfileNotFoundError を throw する', async () => {
+    await expect(usecase.execute('missing-user')).rejects.toThrow(UserProfileNotFoundError);
+    expect(statsRepo.hasPickled).not.toHaveBeenCalled();
+    expect(statsRepo.hasLinkedQuestion).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Issue #316 の実装。**Issue #314 (PR #315) と並行で比較テスト**するための独立 PR です。

## 仕様の要点

### 1. 「漬け込む」ボタン押下時のモーダル分岐 (4 通り)

| タイトル | 問い | モーダル |
|---|---|---|
| あり | あり | `PickleConfirmModal` (確認のみ、タイトル編集なし) |
| なし | あり | 既存 `SaveTitleModal` (タイトル編集 + pickle) |
| あり | なし | `QuestionSelectModal` (既存問い選択 or 新規入力 → pickle) |
| なし | なし | `QuestionSelectModal` (本文先頭行を title として暗黙採用 → pickle) |

### 2. 保存成功直後のガイドモーダル

オンボーディング完了後 (`onboardingCompleted: true`) かつ 1 セッション 1 回のみ:

- 問い紐付済み + 一度も漬け込み未実行ユーザー → `PickleNudgeModal`「漬け込んでみませんか」
- 問い未紐付で一度も問いを紐付けたことがないユーザー → `LinkQuestionNudgeModal`「問いを紐付けてみませんか」

強制ではなく可能性の提示。`sessionStorage` で同一セッション内の重複表示を抑止。

## #315 との違い

| 観点 | PR #315 (#314) | この PR (#316) |
|---|---|---|
| 保存と漬け込み | 統合 (保存=漬け込み) | 分離 (現行通り) |
| 問い紐付け | 必須 | 任意 (ガイドで誘導) |
| 既存「問い無し」エントリ | 後方互換のため許容 | 引き続き許容 |
| 新規エントリ | 問いを必須で要求 | 任意、ガイドで促す |

## サーバー変更

`GET /api/v1/users/me` レスポンスに 2 フィールド追加:

```json
{
  "id": "...",
  "nickname": "...",
  "avatarUrl": null,
  "onboardingCompleted": true,
  "hasPickled": false,        // 新規 (Issue #316)
  "hasLinkedQuestion": true   // 新規 (Issue #316)
}
```

集計は `user-context-isolation` ルールを保つため、user 側に
`UserActivityStatsRepositoryGateway` を切り、infrastructure 実装が
`entries` / `entry_question_links` テーブルを `limit(1)` で軽量に問い合わせる
(entry / question repository を経由しない)。

## i18n

JSON 4 言語 (ja/en/zh/ko) に追加済み。**SSoT スプレッドシートへの反映が別途必要**:
- 貼付用 TSV: `.tmp/issue-316-i18n-rows.tsv` (gitignore 配下)
- 24 キー × 4 言語 (8 列フォーマット: key, ja, en, zh, ko, file, line, context)
- 反映後 `pnpm --filter @oryzae/client build-i18n` を走らせて整合性確認

## チェック (全て pass)

- ✅ `pnpm typecheck` (server + client + admin)
- ✅ `pnpm test` 585 件 pass (server 341 + client 174 + admin 70)
- ✅ `pnpm dep-cruise` 0 violations
- ✅ `pnpm knip` no dead code
- ✅ `pnpm lint` 既存の 25 warnings のみ (新規エラーなし)

## マニュアル QA 観点 (vercel preview)

- 新規ユーザーで onboarding 後、新規エントリで:
  - 問い未紐付 → 漬け込みボタン → 問い選択モーダル
  - 問い紐付済 + タイトル空 → 漬け込みボタン → タイトル編集モーダル
  - 問い紐付済 + タイトルあり → 漬け込みボタン → 漬け込み確認のみ
- 保存後ガイド:
  - オンボーディング中は出ない
  - 問い紐付け済保存 → 「漬け込んで見て」が 1 セッション 1 回出る
  - 問い無し保存 → 「問い紐付けて見て」が 1 セッション 1 回出る
- 既に漬け込み履歴があるユーザーには pickle nudge は出ない
- 既に問い紐付け履歴があるユーザーには link nudge は出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)