### PR TITLE
chore(i18n): regenerate JSON from SSoT after #316 i18n keys added

### DIFF
--- a/apps/client/src/i18n/messages/en.json
+++ b/apps/client/src/i18n/messages/en.json
@@ -329,38 +329,6 @@
       "cancel": "Cancel",
       "saving": "Saving..."
     },
-    "pickle_confirm_modal": {
-      "aria_label": "Pickle confirmation dialog",
-      "heading": "Pickle this entry into the Jar",
-      "body": "Send \"{title}\" to the fermentation process. You can still edit the content and links afterwards.",
-      "cancel": "Cancel",
-      "confirm": "Pickle",
-      "saving": "Pickling..."
-    },
-    "question_select_modal": {
-      "aria_label": "Question selection dialog",
-      "heading": "Link a question to this entry",
-      "body": "To pickle and ferment, an entry must be linked to one question. Pick an existing question or write a new one here.",
-      "mode_pick": "Pick existing",
-      "mode_create": "Write new",
-      "pick_placeholder": "Choose a question...",
-      "create_placeholder": "Write a question (e.g. What did I notice today?)",
-      "cancel": "Cancel",
-      "confirm": "Link and pickle",
-      "saving": "Pickling..."
-    },
-    "pickle_nudge_modal": {
-      "aria_label": "Pickling guidance",
-      "heading": "Try pickling this entry",
-      "body": "Entries linked to a question can move into the fermentation process when you pickle them. Press the pickle button (jar icon) anytime to try.",
-      "dismiss": "Got it"
-    },
-    "link_question_nudge_modal": {
-      "aria_label": "Question linking guidance",
-      "heading": "Try linking a question",
-      "body": "Linking a question to an entry lets you pickle it and start the fermentation process. Pick an existing question from the linker above or create a new one.",
-      "dismiss": "Got it"
-    },
     "settings": {
       "close_aria": "Close settings",
       "section_basic": "Basics",
@@ -408,6 +376,38 @@
       "day_thu": "Thursday",
       "day_fri": "Friday",
       "day_sat": "Saturday"
+    },
+    "pickle_confirm_modal": {
+      "aria_label": "Pickle confirmation dialog",
+      "heading": "Pickle this entry into the Jar",
+      "body": "Send \"{title}\" to the fermentation process. You can still edit the content and links afterwards.",
+      "cancel": "Cancel",
+      "confirm": "Pickle",
+      "saving": "Pickling..."
+    },
+    "question_select_modal": {
+      "aria_label": "Question selection dialog",
+      "heading": "Link a question to this entry",
+      "body": "To pickle and ferment, an entry must be linked to one question. Pick an existing question or write a new one here.",
+      "mode_pick": "Pick existing",
+      "mode_create": "Write new",
+      "pick_placeholder": "Choose a question...",
+      "create_placeholder": "Write a question (e.g. What did I notice today?)",
+      "cancel": "Cancel",
+      "confirm": "Link and pickle",
+      "saving": "Pickling..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "Pickling guidance",
+      "heading": "Try pickling this entry",
+      "body": "Entries linked to a question can move into the fermentation process when you pickle them. Press the pickle button (jar icon) anytime to try.",
+      "dismiss": "Got it"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "Question linking guidance",
+      "heading": "Try linking a question",
+      "body": "Linking a question to an entry lets you pickle it and start the fermentation process. Pick an existing question from the linker above or create a new one.",
+      "dismiss": "Got it"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/ja.json
+++ b/apps/client/src/i18n/messages/ja.json
@@ -329,38 +329,6 @@
       "cancel": "キャンセル",
       "saving": "保存中..."
     },
-    "pickle_confirm_modal": {
-      "aria_label": "漬け込み確認ダイアログ",
-      "heading": "このエントリを瓶に漬け込む",
-      "body": "「{title}」を発酵プロセスに送ります。漬け込み後も内容と紐付けは編集できます。",
-      "cancel": "キャンセル",
-      "confirm": "漬け込む",
-      "saving": "漬け込み中..."
-    },
-    "question_select_modal": {
-      "aria_label": "問い選択ダイアログ",
-      "heading": "このエントリに問いを紐付ける",
-      "body": "漬け込んで発酵させるには、エントリに問いを 1 つ紐付ける必要があります。既存の問いを選ぶか、新しい問いをその場で書いてください。",
-      "mode_pick": "既存の問いから選ぶ",
-      "mode_create": "新しく書く",
-      "pick_placeholder": "問いを選択...",
-      "create_placeholder": "問いを書く (例: 今日の小さな発見は？)",
-      "cancel": "キャンセル",
-      "confirm": "紐付けて漬け込む",
-      "saving": "漬け込み中..."
-    },
-    "pickle_nudge_modal": {
-      "aria_label": "漬け込みのご案内",
-      "heading": "漬け込んでみませんか",
-      "body": "問いの紐付いたエントリは、漬け込むことで発酵プロセスに進みます。漬け込みボタン (瓶のアイコン) を押すといつでも試せます。",
-      "dismiss": "わかりました"
-    },
-    "link_question_nudge_modal": {
-      "aria_label": "問い紐付けのご案内",
-      "heading": "問いを紐付けてみませんか",
-      "body": "エントリに問いを紐付けると、漬け込んで発酵プロセスに進められるようになります。エディタ上部の問いリンカーから既存の問いを選ぶか、新しく作れます。",
-      "dismiss": "わかりました"
-    },
     "settings": {
       "close_aria": "設定を閉じる",
       "section_basic": "基本設定",
@@ -408,6 +376,38 @@
       "day_thu": "木曜日",
       "day_fri": "金曜日",
       "day_sat": "土曜日"
+    },
+    "pickle_confirm_modal": {
+      "aria_label": "漬け込み確認ダイアログ",
+      "heading": "このエントリを瓶に漬け込む",
+      "body": "「{title}」を発酵プロセスに送ります。漬け込み後も内容と紐付けは編集できます。",
+      "cancel": "キャンセル",
+      "confirm": "漬け込む",
+      "saving": "漬け込み中..."
+    },
+    "question_select_modal": {
+      "aria_label": "問い選択ダイアログ",
+      "heading": "このエントリに問いを紐付ける",
+      "body": "漬け込んで発酵させるには、エントリに問いを 1 つ紐付ける必要があります。既存の問いを選ぶか、新しい問いをその場で書いてください。",
+      "mode_pick": "既存の問いから選ぶ",
+      "mode_create": "新しく書く",
+      "pick_placeholder": "問いを選択...",
+      "create_placeholder": "問いを書く (例: 今日の小さな発見は？)",
+      "cancel": "キャンセル",
+      "confirm": "紐付けて漬け込む",
+      "saving": "漬け込み中..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "漬け込みのご案内",
+      "heading": "漬け込んでみませんか",
+      "body": "問いの紐付いたエントリは、漬け込むことで発酵プロセスに進みます。漬け込みボタン (瓶のアイコン) を押すといつでも試せます。",
+      "dismiss": "わかりました"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "問い紐付けのご案内",
+      "heading": "問いを紐付けてみませんか",
+      "body": "エントリに問いを紐付けると、漬け込んで発酵プロセスに進められるようになります。エディタ上部の問いリンカーから既存の問いを選ぶか、新しく作れます。",
+      "dismiss": "わかりました"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/ko.json
+++ b/apps/client/src/i18n/messages/ko.json
@@ -329,38 +329,6 @@
       "cancel": "취소",
       "saving": "저장 중..."
     },
-    "pickle_confirm_modal": {
-      "aria_label": "담그기 확인 대화상자",
-      "heading": "이 항목을 항아리에 담그기",
-      "body": "「{title}」을(를) 발효 과정으로 보냅니다. 담근 후에도 내용과 연결을 편집할 수 있습니다.",
-      "cancel": "취소",
-      "confirm": "담그기",
-      "saving": "담그는 중..."
-    },
-    "question_select_modal": {
-      "aria_label": "질문 선택 대화상자",
-      "heading": "이 항목에 질문 연결",
-      "body": "담가서 발효시키려면 항목에 질문을 하나 연결해야 합니다. 기존 질문을 고르거나 새로 작성하세요.",
-      "mode_pick": "기존에서 선택",
-      "mode_create": "새로 작성",
-      "pick_placeholder": "질문 선택...",
-      "create_placeholder": "질문을 작성하세요 (예: 오늘 작은 발견은?)",
-      "cancel": "취소",
-      "confirm": "연결 후 담그기",
-      "saving": "담그는 중..."
-    },
-    "pickle_nudge_modal": {
-      "aria_label": "담그기 안내",
-      "heading": "담가 보시겠어요?",
-      "body": "질문이 연결된 항목은 담그면 발효 과정으로 진입합니다. 항아리 아이콘 버튼으로 언제든 시도해 보세요.",
-      "dismiss": "알겠습니다"
-    },
-    "link_question_nudge_modal": {
-      "aria_label": "질문 연결 안내",
-      "heading": "질문을 연결해 보시겠어요?",
-      "body": "항목에 질문을 연결하면 담가서 발효 과정으로 보낼 수 있습니다. 에디터 상단 질문 링커에서 기존 질문을 선택하거나 새로 만드세요.",
-      "dismiss": "알겠습니다"
-    },
     "settings": {
       "close_aria": "설정 닫기",
       "section_basic": "기본 설정",
@@ -408,6 +376,38 @@
       "day_thu": "목요일",
       "day_fri": "금요일",
       "day_sat": "토요일"
+    },
+    "pickle_confirm_modal": {
+      "aria_label": "담그기 확인 대화상자",
+      "heading": "이 항목을 항아리에 담그기",
+      "body": "「{title}」을(를) 발효 과정으로 보냅니다. 담근 후에도 내용과 연결을 편집할 수 있습니다.",
+      "cancel": "취소",
+      "confirm": "담그기",
+      "saving": "담그는 중..."
+    },
+    "question_select_modal": {
+      "aria_label": "질문 선택 대화상자",
+      "heading": "이 항목에 질문 연결",
+      "body": "담가서 발효시키려면 항목에 질문을 하나 연결해야 합니다. 기존 질문을 고르거나 새로 작성하세요.",
+      "mode_pick": "기존에서 선택",
+      "mode_create": "새로 작성",
+      "pick_placeholder": "질문 선택...",
+      "create_placeholder": "질문을 작성하세요 (예: 오늘 작은 발견은?)",
+      "cancel": "취소",
+      "confirm": "연결 후 담그기",
+      "saving": "담그는 중..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "담그기 안내",
+      "heading": "담가 보시겠어요?",
+      "body": "질문이 연결된 항목은 담그면 발효 과정으로 진입합니다. 항아리 아이콘 버튼으로 언제든 시도해 보세요.",
+      "dismiss": "알겠습니다"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "질문 연결 안내",
+      "heading": "질문을 연결해 보시겠어요?",
+      "body": "항목에 질문을 연결하면 담가서 발효 과정으로 보낼 수 있습니다. 에디터 상단 질문 링커에서 기존 질문을 선택하거나 새로 만드세요.",
+      "dismiss": "알겠습니다"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/zh.json
+++ b/apps/client/src/i18n/messages/zh.json
@@ -329,38 +329,6 @@
       "cancel": "取消",
       "saving": "保存中..."
     },
-    "pickle_confirm_modal": {
-      "aria_label": "入瓮确认对话框",
-      "heading": "将此条目放入瓮中",
-      "body": "将「{title}」送入发酵过程。入瓮之后仍可编辑内容与关联。",
-      "cancel": "取消",
-      "confirm": "入瓮",
-      "saving": "入瓮中..."
-    },
-    "question_select_modal": {
-      "aria_label": "问题选择对话框",
-      "heading": "为此条目关联一个问题",
-      "body": "要入瓮并发酵，需要给条目关联一个问题。请从已有问题中选择，或在此输入新问题。",
-      "mode_pick": "选已有",
-      "mode_create": "新建",
-      "pick_placeholder": "请选择问题...",
-      "create_placeholder": "写一个问题（例：今天的小发现是？）",
-      "cancel": "取消",
-      "confirm": "关联并入瓮",
-      "saving": "入瓮中..."
-    },
-    "pickle_nudge_modal": {
-      "aria_label": "入瓮引导",
-      "heading": "试试将其入瓮？",
-      "body": "已关联问题的条目，入瓮后会进入发酵过程。随时按入瓮按钮（瓶子图标）即可尝试。",
-      "dismiss": "知道了"
-    },
-    "link_question_nudge_modal": {
-      "aria_label": "问题关联引导",
-      "heading": "试试关联一个问题？",
-      "body": "将问题关联到条目后，就可以入瓮并进入发酵过程。可在编辑器顶部的问题关联器选择已有问题，或新建一个。",
-      "dismiss": "知道了"
-    },
     "settings": {
       "close_aria": "关闭设置",
       "section_basic": "基本设置",
@@ -408,6 +376,38 @@
       "day_thu": "星期四",
       "day_fri": "星期五",
       "day_sat": "星期六"
+    },
+    "pickle_confirm_modal": {
+      "aria_label": "入瓮确认对话框",
+      "heading": "将此条目放入瓮中",
+      "body": "将「{title}」送入发酵过程。入瓮之后仍可编辑内容与关联。",
+      "cancel": "取消",
+      "confirm": "入瓮",
+      "saving": "入瓮中..."
+    },
+    "question_select_modal": {
+      "aria_label": "问题选择对话框",
+      "heading": "为此条目关联一个问题",
+      "body": "要入瓮并发酵，需要给条目关联一个问题。请从已有问题中选择，或在此输入新问题。",
+      "mode_pick": "选已有",
+      "mode_create": "新建",
+      "pick_placeholder": "请选择问题...",
+      "create_placeholder": "写一个问题（例：今天的小发现是？）",
+      "cancel": "取消",
+      "confirm": "关联并入瓮",
+      "saving": "入瓮中..."
+    },
+    "pickle_nudge_modal": {
+      "aria_label": "入瓮引导",
+      "heading": "试试将其入瓮？",
+      "body": "已关联问题的条目，入瓮后会进入发酵过程。随时按入瓮按钮（瓶子图标）即可尝试。",
+      "dismiss": "知道了"
+    },
+    "link_question_nudge_modal": {
+      "aria_label": "问题关联引导",
+      "heading": "试试关联一个问题？",
+      "body": "将问题关联到条目后，就可以入瓮并进入发酵过程。可在编辑器顶部的问题关联器选择已有问题，或新建一个。",
+      "dismiss": "知道了"
     }
   },
   "fermentation": {


### PR DESCRIPTION
## 概要

PR #318 (Issue #316) で 24 個の i18n キー (新規 pickle / question モーダル用) を `apps/client/src/i18n/messages/{ja,en,zh,ko}.json` に手書きで追加しました。  
そのキーは `editor.save_modal` の直後 (332 行目あたり) に挿入されました。

その後 SSoT スプレッドシートに 24 行を追記し、`node apps/client/scripts/build-i18n.mjs --remote` で JSON を SSoT から再生成したところ、新規キー namespace が **SSoT の行順 (380 行目あたり、editor namespace の末尾)** に移動しました。

## 内容

- 値は **byte 単位で完全一致** (`grep` で全 24 キー確認済)
- **位置だけ** が移動: 手書き挿入位置 → SSoT canonical 順
- 4 言語パリティ維持 (各 475 keys)
- typecheck / 174 client tests pass

## なぜマージするか

リポジトリ JSON と build-i18n 出力の順序が一致していないため、誰かが将来 `build-i18n --remote` を回すと毎回同じ 128/128 行の diff が発生する。**ワンタイム正規化** でドリフトを止めるための chore。

## 動作影響

無し。i18n キーの値は同一なので UI 表示は変わらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)