### PR TITLE
fix(entries): autosave 競合で問いの紐づけが DB に永続化されないバグ修正 (#319)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -27,6 +27,7 @@ import { useSaveEntry } from '@/features/entries/hooks/use-entry';
 import { useEraserTrace } from '@/features/entries/hooks/use-eraser-trace';
 import { useFocusMode } from '@/features/entries/hooks/use-focus-mode';
 import { useGhostEffect } from '@/features/entries/hooks/use-ghost-effect';
+import { useLinkQuestionSync } from '@/features/entries/hooks/use-link-question-sync';
 import { usePressureBleed } from '@/features/entries/hooks/use-pressure-bleed';
 import { useTimeInscription } from '@/features/entries/hooks/use-time-inscription';
 import { useUserMe } from '@/features/entries/hooks/use-user-me';
@@ -128,6 +129,12 @@ export function EntryEditor({
   const [status, setStatus] = useState<EditorStatus>('editing');
   const isAutosavingRef = useRef(false);
   const [linkedIds, setLinkedIds] = useState<Set<string>>(new Set(initialLinkedIds));
+  // Issue #319: autosave で初回エントリが作られた際に、ローカルで紐づけ済みの
+  // questionId を DB に永続化する flush ヘルパー。
+  const { flushPending: flushPendingLinks } = useLinkQuestionSync({
+    linkedIds,
+    link: onLinkQuestion,
+  });
   const [dateStr, setDateStr] = useState(() => {
     const now = new Date();
     const created = createdAtIso ? new Date(createdAtIso) : now;
@@ -468,17 +475,25 @@ export function EntryEditor({
   }, [isEditingTitle]);
 
   const handleAutosaved = useCallback(
-    (newId: string, savedBody: string) => {
+    async (newId: string, savedBody: string) => {
       // Track the id locally so subsequent autosaves PUT instead of POST.
       // URL stays the same — the 新規エントリ button and browser refresh
       // continue to behave as if the user is still composing.
-      if (currentEntryId !== newId) setCurrentEntryId(newId);
+      const wasNew = currentEntryId !== newId;
+      if (wasNew) setCurrentEntryId(newId);
       setSavedContent(savedBody);
       setStatus('saved');
       isAutosavingRef.current = false;
       setTimeout(() => setStatus('editing'), 2000);
+
+      // Issue #319: autosave が手動保存より先にエントリを作成すると、
+      // handleSaveWithTitle の `isNew` 分岐がスキップされ question link が
+      // DB に永続化されないバグを修正。サーバー側 link は upsert で冪等。
+      if (wasNew) {
+        await flushPendingLinks(newId);
+      }
     },
-    [currentEntryId],
+    [currentEntryId, flushPendingLinks],
   );
 
   const autoSave = useCallback(
@@ -533,11 +548,14 @@ export function EntryEditor({
   const handleLink = useCallback(
     async (questionId: string) => {
       setLinkedIds((prev) => new Set(prev).add(questionId));
-      if (entryId && onLinkQuestion) {
-        await onLinkQuestion(entryId, questionId);
+      // Issue #319: autosave 後は currentEntryId が確定するので、
+      // それを優先して使う（entryId は props で新規ページでは undefined）。
+      const targetId = currentEntryId ?? entryId;
+      if (targetId && onLinkQuestion) {
+        await onLinkQuestion(targetId, questionId);
       }
     },
-    [entryId, onLinkQuestion],
+    [currentEntryId, entryId, onLinkQuestion],
   );
 
   const handleUnlink = useCallback(
@@ -547,11 +565,13 @@ export function EntryEditor({
         next.delete(questionId);
         return next;
       });
-      if (entryId && onUnlinkQuestion) {
-        await onUnlinkQuestion(entryId, questionId);
+      // Issue #319: handleLink と同じく autosave 後は currentEntryId を優先.
+      const targetId = currentEntryId ?? entryId;
+      if (targetId && onUnlinkQuestion) {
+        await onUnlinkQuestion(targetId, questionId);
       }
     },
-    [entryId, onUnlinkQuestion],
+    [currentEntryId, entryId, onUnlinkQuestion],
   );
 
   function toggleFullscreen() {

--- a/apps/client/src/features/entries/hooks/use-link-question-sync.ts
+++ b/apps/client/src/features/entries/hooks/use-link-question-sync.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+
+interface UseLinkQuestionSyncParams {
+  /** 現在ユーザーが「紐づけ済み」とみなしているローカル state. */
+  linkedIds: ReadonlySet<string>;
+  /** POST /entries/:id/questions/:qId. サーバー側 link は upsert で冪等. */
+  link?: (entryId: string, questionId: string) => Promise<void>;
+}
+
+/**
+ * Issue #319: 新規エントリで autosave が先に走ると、
+ * `handleSaveWithTitle` の `isNew` 分岐が走らず、ローカルで紐づけられた
+ * questionIds が DB に永続化されないバグの修正用ヘルパー。
+ *
+ * `flushPending(entryId)` を呼ぶと、現在の `linkedIds` を全て POST する。
+ * link は ref 経由で参照するため、呼び出し時点で最新の Set が使われる。
+ *
+ * サーバー側の `LinkQuestionToEntryUsecase` は composite PK への upsert を行うため、
+ * 既に紐づいている (entryId, questionId) を再 POST しても安全。
+ */
+export function useLinkQuestionSync({ linkedIds, link }: UseLinkQuestionSyncParams) {
+  const linkedIdsRef = useRef(linkedIds);
+  linkedIdsRef.current = linkedIds;
+
+  const flushPending = useCallback(
+    async (entryId: string) => {
+      if (!link) return;
+      for (const qId of linkedIdsRef.current) {
+        await link(entryId, qId);
+      }
+    },
+    [link],
+  );
+
+  return { flushPending };
+}

--- a/apps/client/test/features/entries/hooks/use-link-question-sync.test.ts
+++ b/apps/client/test/features/entries/hooks/use-link-question-sync.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useLinkQuestionSync } from '@/features/entries/hooks/use-link-question-sync';
+
+describe('useLinkQuestionSync', () => {
+  it('flushPending は現在の linkedIds 全てに対して link を呼ぶ', async () => {
+    const link = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useLinkQuestionSync({
+        linkedIds: new Set(['q1', 'q2']),
+        link,
+      }),
+    );
+
+    await result.current.flushPending('e1');
+
+    expect(link).toHaveBeenCalledTimes(2);
+    expect(link).toHaveBeenCalledWith('e1', 'q1');
+    expect(link).toHaveBeenCalledWith('e1', 'q2');
+  });
+
+  it('link が undefined のときは何もしない (no-op)', async () => {
+    const { result } = renderHook(() =>
+      useLinkQuestionSync({
+        linkedIds: new Set(['q1']),
+      }),
+    );
+
+    await expect(result.current.flushPending('e1')).resolves.toBeUndefined();
+  });
+
+  it('linkedIds が空のときは link を呼ばない', async () => {
+    const link = vi.fn();
+    const { result } = renderHook(() =>
+      useLinkQuestionSync({
+        linkedIds: new Set(),
+        link,
+      }),
+    );
+
+    await result.current.flushPending('e1');
+
+    expect(link).not.toHaveBeenCalled();
+  });
+
+  it('rerender 後の最新 linkedIds が flushPending に反映される (ref パターン)', async () => {
+    const link = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: Set<string> }) => useLinkQuestionSync({ linkedIds: ids, link }),
+      { initialProps: { ids: new Set(['a']) } },
+    );
+
+    rerender({ ids: new Set(['a', 'b', 'c']) });
+
+    await result.current.flushPending('e1');
+
+    expect(link).toHaveBeenCalledTimes(3);
+    expect(link).toHaveBeenCalledWith('e1', 'a');
+    expect(link).toHaveBeenCalledWith('e1', 'b');
+    expect(link).toHaveBeenCalledWith('e1', 'c');
+  });
+
+  it('link が reject したら flushPending も reject する (後続は試さない)', async () => {
+    const link = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() =>
+      useLinkQuestionSync({
+        linkedIds: new Set(['q1', 'q2', 'q3']),
+        link,
+      }),
+    );
+
+    await expect(result.current.flushPending('e1')).rejects.toThrow('boom');
+    // q1 成功 → q2 失敗で停止 → q3 は呼ばれない
+    expect(link).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #319

## 症状
新規エントリで「問い」を紐づけて保存→entries 一覧に戻る→そのエントリを再オープンすると、紐づけが消えている。オンボーディングフロー直後 (`/entries/new?questionId=xxx` から流れたケース) で再現性が高く報告。

## 原因 (autosave-first レース)
1. `/entries/new?questionId=xxx` → `EntryEditor` がローカル `linkedIds` Set にだけ追加 (DB 未反映)
2. ユーザーが本文入力 → 2 秒 debounce 後 `useAutosaveEntry` が `POST /api/v1/entries` で**新規エントリを先に作成**
3. `handleAutosaved` が `setCurrentEntryId(newId)` のみ実行し、**`onLinkQuestion` を呼ばない**
4. ユーザーが「保存」ボタンを押す → `handleSaveWithTitle` で `targetId = currentEntryId` がセット済みなので `isNew = false`
5. `if (isNew && onLinkQuestion)` ガードを通らず、**link POST ループが完全にスキップされる**
6. 一覧へ遷移 → 再オープン → DB に link が無い

サーバー側の data integrity に問題はなく、`updateEntrySchema` も `entry_question_links` には触れない (entry の更新で link が消える経路は存在しない)。純粋にクライアント側のフロー欠落。

## 修正
### 1. `useLinkQuestionSync` フック新設 (`apps/client/src/features/entries/hooks/use-link-question-sync.ts`)
- ローカル `linkedIds` を任意の `entryId` に対して flush する責務を切り出し
- ref パターンで最新 `linkedIds` を参照 → autosave の useEffect churn を回避
- サーバー側 link は `upsert(onConflict: entry_id,question_id)` のため再 POST も冪等

### 2. `EntryEditor` 3 箇所修正
- `handleAutosaved`: `wasNew === true` のとき `flushPendingLinks(newId)` を呼ぶ
- `handleLink`: `entryId` (props) ではなく `currentEntryId ?? entryId` を参照
- `handleUnlink`: 同上 (autosave 後の unlink も DB に届かないバグ併発を解消)

## 残課題 (本 PR 外)
`handleSaveWithTitle` の `isNew` 分岐は `router.push(\`/entries/\${savedId}\`)` のナビゲーションも兼ねている。autosave-first ケースでは URL が `/entries/new` のまま残る。本 Issue の範囲外として別途対応予定。

## テスト
- `useLinkQuestionSync` の単体テスト 5 件 (flush 全件 / link 未指定 no-op / 空 Set / ref パターン / 失敗時 reject)
- 既存テスト 593 件すべて緑

## 品質ゲート
- `pnpm typecheck` ✅
- `pnpm test` ✅ (server 344 + client 179 + admin 70 = 593 passed)
- `pnpm dep-cruise` ✅ 0 violations
- `pnpm lint` ✅ 0 errors (既存 25 warnings は別件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)