### PR TITLE
fix(client): PostHog を reverse proxy 経由に切り替え広告ブロッカー遮断を回避 (#225)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@ AI_GATEWAY_API_KEY=your-ai-gateway-api-key
 
 # ── PostHog ──
 # Project API Key (phc_...) — クライアント側イベント送信用
+# クライアントは `/ingest/*` reverse proxy 経由で PostHog に送信するため
+# (apps/client/next.config.ts、#225 参照)、ホスト URL を env で指定する必要はない。
 NEXT_PUBLIC_POSTHOG_KEY=your-posthog-project-api-key
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # Personal API Key (phx_...) — サーバー側 API クエリ用
 # https://us.posthog.com/settings/user-api-keys
 POSTHOG_PERSONAL_API_KEY=

--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -15,6 +15,28 @@ const nextConfig: NextConfig = {
     '/privacy': ['./src/content/legal/**/*.md'],
     '/support': ['./src/content/support/**/*.md'],
   },
+  // PostHog reverse proxy: 広告ブロッカーが posthog.com 系ドメインを既定で遮断する
+  // ため (#225)、自ドメインの `/ingest/*` 経由でリクエストを中継する。
+  // 公式ガイド: https://posthog.com/docs/advanced/proxy/nextjs
+  async rewrites() {
+    return [
+      {
+        source: '/ingest/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/ingest/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+      {
+        source: '/ingest/decide',
+        destination: 'https://us.i.posthog.com/decide',
+      },
+    ];
+  },
+  // PostHog の rewrite 先 (`/ingest/...`) で末尾スラッシュリダイレクトが起きると
+  // CORS/プリフライトが壊れるため無効化する。
+  skipTrailingSlashRedirect: true,
 };
 
 export default withSentryConfig(withNextIntl(nextConfig), {

--- a/apps/client/src/lib/posthog.ts
+++ b/apps/client/src/lib/posthog.ts
@@ -3,7 +3,12 @@ import posthog from 'posthog-js';
 export function initPostHog() {
   if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      // 自ドメインの `/ingest/*` rewrite 経由で送信し、広告ブロッカーによる
+      // posthog.com への直接遮断 (#225) を回避する。rewrite は
+      // `apps/client/next.config.ts` で定義。
+      api_host: '/ingest',
+      // Toolbar から "View in PostHog" 等で遷移するときの UI URL。
+      ui_host: 'https://us.posthog.com',
       person_profiles: 'identified_only',
       capture_pageview: false,
       capture_pageleave: true,


### PR DESCRIPTION
Closes #225

## 背景

検証ツール（ブラウザ DevTools）のコンソールで PostHog 関連リクエストが軒並み `net::ERR_BLOCKED_BY_CLIENT` で失敗していた。Chrome の `ERR_BLOCKED_BY_CLIENT` は **ブラウザ拡張（広告ブロッカー）がリクエストを遮断したとき** に出るエラーで、PostHog のドメイン (`posthog.com` / `us.i.posthog.com` / `us-assets.i.posthog.com`) は uBlock Origin / AdBlock / Brave Shields 等の既定ブロックリストに含まれているため、それらを入れているユーザーでは PostHog がまったく機能しなくなる。

具体的にブロックされていたもの:
- `us-assets.i.posthog.com/static/posthog-recorder.js` (セッション録画)
- `us-assets.i.posthog.com/static/dead-clicks-autocapture.js`
- `us.i.posthog.com/e/?ip=0&...` (イベント送信)
- `us.i.posthog.com/i/v0/e/?ip=0&...` (イベント送信 v2)

## 対応

PostHog 公式が推奨する **Next.js reverse proxy パターン** を採用 ([docs](https://posthog.com/docs/advanced/proxy/nextjs))。自ドメインの `/ingest/*` を rewrite 先とすることで、ブラウザからは PostHog ドメインへのリクエストには見えず広告ブロッカーをすり抜ける。

### 変更点

| ファイル | 変更 |
|---|---|
| \`apps/client/next.config.ts\` | \`/ingest/static/*\`, \`/ingest/*\`, \`/ingest/decide\` の 3 つの rewrite を追加。\`skipTrailingSlashRedirect: true\` を有効化（proxy 先での 308 ループ回避） |
| \`apps/client/src/lib/posthog.ts\` | \`api_host: '/ingest'\` に固定。\`ui_host: 'https://us.posthog.com'\` を追加（Toolbar の "View in PostHog" 用） |
| \`.env.example\` | \`NEXT_PUBLIC_POSTHOG_HOST\` を削除（reverse proxy 経由なので env での切り替え不要） |

## 検証

dev server で \`/entries/new\` を開いて Chrome DevTools MCP で確認:

✅ 全 PostHog リクエストが \`localhost:3000/ingest/*\` 経由で **200 OK**
- \`/ingest/static/posthog-recorder.js\` (元 \`ERR_BLOCKED_BY_CLIENT\`)
- \`/ingest/static/dead-clicks-autocapture.js\` (元 \`ERR_BLOCKED_BY_CLIENT\`)
- \`/ingest/static/web-vitals.js\`, \`/ingest/static/surveys.js\`
- \`/ingest/array/phc_.../config.js\`
- \`POST /ingest/flags/?v=2&ip=0&...\`

✅ \`posthog.com\` / \`us.i.posthog.com\` への直接リクエストはゼロ
✅ PostHog 由来のコンソールエラーはゼロ

\`pnpm typecheck && pnpm test && pnpm lint && pnpm dep-cruise\` 全て通過。

スクリーンショット: \`.tmp/screenshots/issue-225-posthog-proxy-entries-new.png\`

## 注意（オリザエ無関係）

issue #225 のログに混じっていた以下はオリザエではなくユーザー側のブラウザ拡張のノイズ:
- \`lockdown-install.js: SES Removing unpermitted intrinsics\` → MetaMask (LavaMoat)
- \`chrome-extension://mppblpedoemekekejafmcopafmkagkic/...\` → Bitwarden

これらは本 PR では対応しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)