### PR TITLE
feat(admin): ユーザーアカウントと関連データの一括削除機能を追加 (#326)

### DIFF
--- a/apps/admin/src/app/(protected)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(protected)/users/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { DeleteUserPanel } from '@/features/users/components/delete-user-panel';
 import { FireFermentationPanel } from '@/features/users/components/fire-fermentation-panel';
 import { UserEntryList } from '@/features/users/components/user-entry-list';
 import { UserFermentationHistory } from '@/features/users/components/user-fermentation-history';
@@ -88,6 +89,8 @@ export default function UserDetailPage() {
           <UserFermentationHistory fermentations={data.fermentations} />
         </div>
       </div>
+
+      <DeleteUserPanel userId={userId} email={data.profile.email} />
     </div>
   );
 }

--- a/apps/admin/src/features/users/components/delete-user-panel.tsx
+++ b/apps/admin/src/features/users/components/delete-user-panel.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDeleteUser } from '../hooks/use-delete-user';
+
+// Issue #326: テストアカウントとその関連データを一括削除する管理者向け UI。
+// 一覧画面 (/users) ではなくユーザー詳細画面 (/users/[id]) にだけ置く。
+// 一括削除は致命的なヒューマンエラーを生みかねないため、複数選択削除は実装しない。
+
+interface Props {
+  userId: string;
+  email: string;
+}
+
+export function DeleteUserPanel({ userId, email }: Props) {
+  const router = useRouter();
+  const { deleteUser, loading, error, reset } = useDeleteUser();
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) reset();
+  };
+
+  const handleConfirm = async () => {
+    const ok = await deleteUser(userId);
+    if (ok) {
+      setOpen(false);
+      router.push('/users');
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-3">
+      <h4 className="text-xs font-medium uppercase tracking-wider text-destructive">危険な操作</h4>
+      <p className="text-xs text-muted-foreground">
+        このユーザーアカウントと、エントリ・問い・発酵結果・ボード・プロフィール・アバター画像など
+        全ての関連データを完全に削除します。元に戻すことはできません。
+      </p>
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() => handleOpenChange(true)}
+        disabled={loading}
+      >
+        <Trash2 className="mr-1.5 h-3 w-3" />
+        このユーザーアカウントと関連データを一括削除する
+      </Button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>本当に削除しますか？</DialogTitle>
+            <DialogDescription>
+              <span className="font-mono">{email || userId}</span>{' '}
+              のアカウントと、エントリ・問い・発酵結果・ボード・プロフィール・アバター画像など
+              全ての関連データを完全に削除します。この操作は取り消せません。
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleOpenChange(false)}
+              disabled={loading}
+            >
+              キャンセル
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleConfirm} disabled={loading}>
+              <Trash2 className={`mr-1.5 h-3 w-3 ${loading ? 'animate-pulse' : ''}`} />
+              {loading ? '削除中...' : '削除する'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/src/features/users/hooks/use-delete-user.ts
+++ b/apps/admin/src/features/users/hooks/use-delete-user.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { createApiClient } from '@/lib/api';
+import { getAccessToken } from '@/lib/auth';
+
+// Issue #326: 管理画面からテストアカウントを一括削除する。
+// 関連テーブル (entries, questions, fermentation_results, boards, profiles, ...)
+// と storage オブジェクト (avatars/, board-photos/) をまとめて消してから
+// auth.users から削除する。Supabase Dashboard の Auth → Users 削除が
+// "Database error deleting user" で失敗するケースのワークアラウンド。
+
+export function useDeleteUser() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteUser = useCallback(async (userId: string): Promise<boolean> => {
+    const token = getAccessToken();
+    if (!token) return false;
+
+    setLoading(true);
+    setError(null);
+
+    const api = createApiClient(token);
+    const res = await api.fetch(`/api/v1/admin/users/${userId}`, { method: 'DELETE' });
+
+    if (res.ok) {
+      setLoading(false);
+      return true;
+    }
+
+    let message = 'ユーザーの削除に失敗しました';
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (typeof body.error === 'string' && body.error.length > 0) message = body.error;
+    } catch {
+      // body が JSON でない場合はデフォルト文言のまま
+    }
+    setError(message);
+    setLoading(false);
+    return false;
+  }, []);
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { deleteUser, loading, error, reset };
+}

--- a/apps/admin/test/features/users/hooks/use-delete-user.test.ts
+++ b/apps/admin/test/features/users/hooks/use-delete-user.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeleteUser } from '@/features/users/hooks/use-delete-user';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+interface MockResponseInit {
+  ok: boolean;
+  status?: number;
+  body?: unknown;
+}
+
+function mockResponse({ ok, status, body }: MockResponseInit): Response {
+  return {
+    ok,
+    status: status ?? (ok ? 200 : 400),
+    json: () => Promise.resolve(body ?? {}),
+    // @type-assertion-allowed: テスト用の最小限 Response スタブ
+  } as Response;
+}
+
+describe('useDeleteUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('oryzae_admin_access_token', 'test-token');
+  });
+
+  it('DELETE /api/v1/admin/users/:id を叩いて成功時は true を返す', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        ok: true,
+        body: { deleted: { userId: 'u1', email: 'a@b.com' } },
+      }),
+    );
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteUser('u1');
+    });
+
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/admin/users/u1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('サーバーのエラーメッセージを拾って表示する', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 400,
+        body: { error: 'Admin cannot delete their own account' },
+      }),
+    );
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteUser('u1');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toBe('Admin cannot delete their own account');
+  });
+
+  it('レスポンスが JSON でないときはデフォルト文言にフォールバックする', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json')),
+      // @type-assertion-allowed: テスト用の最小限 Response スタブ
+    } as Response);
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    await act(async () => {
+      await result.current.deleteUser('u1');
+    });
+
+    expect(result.current.error).toBe('ユーザーの削除に失敗しました');
+  });
+
+  it('アクセストークンが無いときは fetch を呼ばずに false を返す', async () => {
+    localStorage.removeItem('oryzae_admin_access_token');
+    const { result } = renderHook(() => useDeleteUser());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteUser('u1');
+    });
+
+    expect(ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('reset() でエラーをクリアする', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 500, body: { error: 'boom' } }),
+    );
+
+    const { result } = renderHook(() => useDeleteUser());
+
+    await act(async () => {
+      await result.current.deleteUser('u1');
+    });
+    expect(result.current.error).toBe('boom');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/server/src/contexts/user/application/errors/user.errors.ts
+++ b/apps/server/src/contexts/user/application/errors/user.errors.ts
@@ -1,7 +1,22 @@
-import { NotFoundError } from '../../../shared/application/errors/application.errors.js';
+import {
+  NotFoundError,
+  ValidationError,
+} from '../../../shared/application/errors/application.errors.js';
 
 export class UserProfileNotFoundError extends NotFoundError {
   constructor(userId: string) {
     super(`User profile not found: ${userId}`);
+  }
+}
+
+export class AuthUserNotFoundError extends NotFoundError {
+  constructor(userId: string) {
+    super(`Auth user not found: ${userId}`);
+  }
+}
+
+export class CannotDeleteSelfError extends ValidationError {
+  constructor() {
+    super('Admin cannot delete their own account');
   }
 }

--- a/apps/server/src/contexts/user/application/usecases/delete-user-admin.usecase.ts
+++ b/apps/server/src/contexts/user/application/usecases/delete-user-admin.usecase.ts
@@ -1,0 +1,44 @@
+import type {
+  DeleteUserDataRepositoryGateway,
+  DeleteUserDataResult,
+} from '../../domain/gateways/delete-user-data-repository.gateway.js';
+import { AuthUserNotFoundError, CannotDeleteSelfError } from '../errors/user.errors.js';
+
+interface DeleteUserAdminInput {
+  /** 削除対象のユーザー ID */
+  targetUserId: string;
+  /** 操作を実行している管理者の ID */
+  requesterUserId: string;
+}
+
+/**
+ * Issue #326: 管理画面からテストアカウントとその関連データを一括削除する。
+ *
+ * 削除順:
+ *   1. public.* の関連行 (entries, questions, fermentation_results, boards, profiles, ...)
+ *   2. storage の関連オブジェクト (avatars/, board-photos/)
+ *   3. auth.users 本体
+ *
+ * Supabase Dashboard の Auth → Users 削除は "Database error deleting user" で
+ * 失敗するケースがあるため、CASCADE に頼らず明示的に消してから auth を消す。
+ */
+export class DeleteUserAdminUsecase {
+  constructor(private repo: DeleteUserDataRepositoryGateway) {}
+
+  async execute(input: DeleteUserAdminInput): Promise<DeleteUserDataResult> {
+    if (input.targetUserId === input.requesterUserId) {
+      throw new CannotDeleteSelfError();
+    }
+
+    const email = await this.repo.findAuthUserEmail(input.targetUserId);
+    if (email === null) {
+      throw new AuthUserNotFoundError(input.targetUserId);
+    }
+
+    await this.repo.deletePublicData(input.targetUserId);
+    await this.repo.deleteStorageObjects(input.targetUserId);
+    await this.repo.deleteAuthUser(input.targetUserId);
+
+    return { userId: input.targetUserId, email };
+  }
+}

--- a/apps/server/src/contexts/user/domain/gateways/delete-user-data-repository.gateway.ts
+++ b/apps/server/src/contexts/user/domain/gateways/delete-user-data-repository.gateway.ts
@@ -1,0 +1,34 @@
+/**
+ * Issue #326: 管理画面からテストアカウントを一括削除するためのポート。
+ *
+ * Supabase Dashboard の Auth → Users 削除が "Database error deleting user"
+ * で失敗するケースに対応するため、auth.users を消す前に public.* の関連行と
+ * storage の関連オブジェクトを明示的に削除する。
+ */
+export interface DeleteUserDataResult {
+  /** 削除されたユーザー ID */
+  userId: string;
+  /** 削除されたメールアドレス (ログ用) */
+  email: string | null;
+}
+
+export interface DeleteUserDataRepositoryGateway {
+  /** 指定ユーザーが auth.users に存在するか確認し、email を返す。存在しなければ null */
+  findAuthUserEmail(userId: string): Promise<string | null>;
+
+  /**
+   * public スキーマ配下の user_id を持つテーブル行を全て削除する。
+   * FK は CASCADE 済みなので親テーブルだけ delete すれば良いが、
+   * Dashboard 経由の削除が失敗するケースがあるため明示的に消す。
+   */
+  deletePublicData(userId: string): Promise<void>;
+
+  /**
+   * storage 上の関連オブジェクトを削除する (avatars/, board-photos/)。
+   * storage は auth.users に FK が無く CASCADE しないため明示的に消す。
+   */
+  deleteStorageObjects(userId: string): Promise<void>;
+
+  /** auth.users から行を削除する */
+  deleteAuthUser(userId: string): Promise<void>;
+}

--- a/apps/server/src/contexts/user/infrastructure/repositories/supabase-delete-user-data.repository.ts
+++ b/apps/server/src/contexts/user/infrastructure/repositories/supabase-delete-user-data.repository.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { DeleteUserDataRepositoryGateway } from '../../domain/gateways/delete-user-data-repository.gateway.js';
+
+/**
+ * public.* で user_id を直接持つテーブル。FK は CASCADE 済みなので、
+ * これらを消すと子テーブル (entry_snapshots, entry_question_links,
+ * question_transactions, analysis_worksheets, etc.) も自動削除される。
+ */
+const USER_OWNED_TABLES = [
+  'entries',
+  'questions',
+  'fermentation_results',
+  'board_snippets',
+  'board_cards',
+  'board_photos',
+  'profiles',
+  'user_fermentation_state',
+] as const;
+
+/** auth.users に FK を持たない storage バケット。明示的に削除する */
+const STORAGE_BUCKETS = ['avatars', 'board-photos'] as const;
+
+export class SupabaseDeleteUserDataRepository implements DeleteUserDataRepositoryGateway {
+  constructor(private supabase: SupabaseClient) {}
+
+  async findAuthUserEmail(userId: string): Promise<string | null> {
+    const { data, error } = await this.supabase.auth.admin.getUserById(userId);
+    if (error || !data.user) return null;
+    return data.user.email ?? '';
+  }
+
+  async deletePublicData(userId: string): Promise<void> {
+    for (const table of USER_OWNED_TABLES) {
+      const idColumn = table === 'profiles' ? 'id' : 'user_id';
+      const { error } = await this.supabase.from(table).delete().eq(idColumn, userId);
+      if (error) {
+        throw new Error(`Failed to delete from ${table}: ${error.message}`);
+      }
+    }
+  }
+
+  async deleteStorageObjects(userId: string): Promise<void> {
+    for (const bucket of STORAGE_BUCKETS) {
+      const { data: files, error: listError } = await this.supabase.storage
+        .from(bucket)
+        .list(userId);
+      if (listError) {
+        // バケット自体が無い場合はスキップ。それ以外は致命的
+        if (listError.message.toLowerCase().includes('not found')) continue;
+        throw new Error(`Failed to list ${bucket}/${userId}: ${listError.message}`);
+      }
+      if (!files || files.length === 0) continue;
+
+      const paths = files.map((f) => `${userId}/${f.name}`);
+      const { error: removeError } = await this.supabase.storage.from(bucket).remove(paths);
+      if (removeError) {
+        throw new Error(`Failed to remove ${bucket} objects: ${removeError.message}`);
+      }
+    }
+  }
+
+  async deleteAuthUser(userId: string): Promise<void> {
+    const { error } = await this.supabase.auth.admin.deleteUser(userId);
+    if (error) {
+      throw new Error(`Failed to delete auth user: ${error.message}`);
+    }
+  }
+}

--- a/apps/server/src/contexts/user/presentation/routes/admin-users.ts
+++ b/apps/server/src/contexts/user/presentation/routes/admin-users.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { Hono } from 'hono';
+import { DeleteUserAdminUsecase } from '../../application/usecases/delete-user-admin.usecase.js';
+import { SupabaseDeleteUserDataRepository } from '../../infrastructure/repositories/supabase-delete-user-data.repository.js';
 
 type Env = {
   Variables: {
@@ -170,4 +172,18 @@ export const adminUsers = new Hono<Env>()
       ),
       entryDates: Array.from(dateCountMap.entries()).map(([date, count]) => ({ date, count })),
     });
+  })
+  // Issue #326: テストアカウントとその関連データを一括削除する。
+  // Supabase Dashboard の Auth → Users 削除が "Database error deleting user" で
+  // 失敗するケースに対応するため、CASCADE に頼らず public.* と storage を明示的に
+  // 消してから auth.users を消す。
+  .delete('/:id', async (c) => {
+    const supabase = c.get('adminSupabase');
+    const adminUserId = c.get('adminUserId');
+    const targetUserId = c.req.param('id');
+
+    const usecase = new DeleteUserAdminUsecase(new SupabaseDeleteUserDataRepository(supabase));
+    const result = await usecase.execute({ targetUserId, requesterUserId: adminUserId });
+
+    return c.json({ deleted: result });
   });

--- a/apps/server/test/contexts/user/application/usecases/delete-user-admin.usecase.test.ts
+++ b/apps/server/test/contexts/user/application/usecases/delete-user-admin.usecase.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AuthUserNotFoundError,
+  CannotDeleteSelfError,
+} from '@/contexts/user/application/errors/user.errors';
+import { DeleteUserAdminUsecase } from '@/contexts/user/application/usecases/delete-user-admin.usecase';
+import type { DeleteUserDataRepositoryGateway } from '@/contexts/user/domain/gateways/delete-user-data-repository.gateway';
+
+describe('DeleteUserAdminUsecase', () => {
+  let repo: DeleteUserDataRepositoryGateway;
+  let usecase: DeleteUserAdminUsecase;
+
+  beforeEach(() => {
+    repo = {
+      findAuthUserEmail: vi.fn().mockResolvedValue('test@example.com'),
+      deletePublicData: vi.fn().mockResolvedValue(undefined),
+      deleteStorageObjects: vi.fn().mockResolvedValue(undefined),
+      deleteAuthUser: vi.fn().mockResolvedValue(undefined),
+    };
+    usecase = new DeleteUserAdminUsecase(repo);
+  });
+
+  it('public → storage → auth.users の順で削除する', async () => {
+    const calls: string[] = [];
+    vi.mocked(repo.deletePublicData).mockImplementation(async () => {
+      calls.push('public');
+    });
+    vi.mocked(repo.deleteStorageObjects).mockImplementation(async () => {
+      calls.push('storage');
+    });
+    vi.mocked(repo.deleteAuthUser).mockImplementation(async () => {
+      calls.push('auth');
+    });
+
+    const result = await usecase.execute({
+      targetUserId: 'target-1',
+      requesterUserId: 'admin-1',
+    });
+
+    expect(calls).toEqual(['public', 'storage', 'auth']);
+    expect(repo.deletePublicData).toHaveBeenCalledWith('target-1');
+    expect(repo.deleteStorageObjects).toHaveBeenCalledWith('target-1');
+    expect(repo.deleteAuthUser).toHaveBeenCalledWith('target-1');
+    expect(result).toEqual({ userId: 'target-1', email: 'test@example.com' });
+  });
+
+  it('自分自身を削除しようとすると CannotDeleteSelfError を throw する', async () => {
+    await expect(
+      usecase.execute({ targetUserId: 'admin-1', requesterUserId: 'admin-1' }),
+    ).rejects.toThrow(CannotDeleteSelfError);
+
+    expect(repo.findAuthUserEmail).not.toHaveBeenCalled();
+    expect(repo.deletePublicData).not.toHaveBeenCalled();
+    expect(repo.deleteStorageObjects).not.toHaveBeenCalled();
+    expect(repo.deleteAuthUser).not.toHaveBeenCalled();
+  });
+
+  it('auth.users に存在しないユーザーは AuthUserNotFoundError を throw する', async () => {
+    vi.mocked(repo.findAuthUserEmail).mockResolvedValue(null);
+
+    await expect(
+      usecase.execute({ targetUserId: 'missing', requesterUserId: 'admin-1' }),
+    ).rejects.toThrow(AuthUserNotFoundError);
+
+    expect(repo.deletePublicData).not.toHaveBeenCalled();
+    expect(repo.deleteStorageObjects).not.toHaveBeenCalled();
+    expect(repo.deleteAuthUser).not.toHaveBeenCalled();
+  });
+
+  it('email が空文字でも削除を進める (Supabase auth は email 必須でない)', async () => {
+    vi.mocked(repo.findAuthUserEmail).mockResolvedValue('');
+
+    const result = await usecase.execute({
+      targetUserId: 'target-1',
+      requesterUserId: 'admin-1',
+    });
+
+    expect(result).toEqual({ userId: 'target-1', email: '' });
+    expect(repo.deleteAuthUser).toHaveBeenCalledWith('target-1');
+  });
+
+  it('public データ削除中にエラーが出たら storage / auth は呼ばずに throw する', async () => {
+    vi.mocked(repo.deletePublicData).mockRejectedValue(new Error('boom'));
+
+    await expect(
+      usecase.execute({ targetUserId: 'target-1', requesterUserId: 'admin-1' }),
+    ).rejects.toThrow('boom');
+
+    expect(repo.deleteStorageObjects).not.toHaveBeenCalled();
+    expect(repo.deleteAuthUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #326. 管理画面 `/users/[id]` に「このユーザーアカウントと関連データを一括削除する」ボタンと確認モーダルを追加し、テストアカウントを安全に消せるようにした。
- サーバー側は `DELETE /api/v1/admin/users/:id` を追加。`public.*` の関連行 (entries, questions, fermentation_results, board_*, profiles, user_fermentation_state) → storage オブジェクト (avatars/, board-photos/) → auth.users の順で明示的に削除する。FK は CASCADE 済みだが、Supabase Dashboard の `Database error deleting user` 失敗を避けるため CASCADE に頼らない。
- 自分自身を削除しようとすると `400`、対象が存在しない場合は `404` を返す。一覧画面での複数選択削除はヒューマンエラー防止のため実装しない。

## 設計
- `DeleteUserAdminUsecase` (user/application) が orchestration、`DeleteUserDataRepositoryGateway` を port として `SupabaseDeleteUserDataRepository` が public/storage/auth の削除を実装。
- 管理画面側は `useDeleteUser` フックと `DeleteUserPanel` コンポーネント。詳細画面の最下部に「危険な操作」セクションとして配置。

## Test plan
- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅ (新規エラー無し、25 件の事前警告のみ)
- [x] `pnpm test` ✅ — server 349 / client 181 / admin 75 (usecase 5 + hook 5 を追加)
- [x] `pnpm dep-cruise` ✅
- [x] `pnpm knip` ✅
- [ ] ブラウザでの実機確認: Chrome DevTools MCP / Turbopack の組み合わせが応答せず実施できず。テスト環境で `/users/[id]` を開きボタン → 確認モーダル → 削除のフローを手動で確認してください。
- [ ] テスト環境で実際にテストアカウントが削除できることを確認 (acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)