### PR TITLE
feat(entries): 新規エントリで紐付けた問いの発酵結果をフローティング表示 (#329)

### DIFF
--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -7,6 +7,8 @@ import {
   type EditorStatus,
   EditorStatusBar,
 } from '@/features/entries/components/editor-status-bar';
+import { FermentationDisplayPromptModal } from '@/features/entries/components/fermentation-display-prompt-modal';
+import { FermentationOverlay } from '@/features/entries/components/fermentation-overlay';
 import { formatEntryDate } from '@/features/entries/components/format-entry-date';
 import { LeaveConfirmModal } from '@/features/entries/components/leave-confirm-modal';
 import { LinkQuestionNudgeModal } from '@/features/entries/components/link-question-nudge-modal';
@@ -24,6 +26,7 @@ import { useAutosaveEntry } from '@/features/entries/hooks/use-autosave-entry';
 import { useBrowserNavGuard } from '@/features/entries/hooks/use-browser-nav-guard';
 import { useEditorSettings } from '@/features/entries/hooks/use-editor-settings';
 import { useSaveEntry } from '@/features/entries/hooks/use-entry';
+import { useEntryFermentationDetail } from '@/features/entries/hooks/use-entry-fermentation-detail';
 import { useEraserTrace } from '@/features/entries/hooks/use-eraser-trace';
 import { useFocusMode } from '@/features/entries/hooks/use-focus-mode';
 import { useGhostEffect } from '@/features/entries/hooks/use-ghost-effect';
@@ -135,6 +138,50 @@ export function EntryEditor({
     linkedIds,
     link: onLinkQuestion,
   });
+
+  // Issue #329: 新規エントリで紐付けた問いに発酵結果がある場合のオーバーレイ表示制御。
+  // 既存エントリでは表示しない (執筆中の判断材料として使うため新規限定)。
+  const isNewEntry = !entryId;
+  const firstLinkedQuestionId = isNewEntry ? Array.from(linkedIds)[0] : undefined;
+  const { detail: fermentationOverlayDetail } = useEntryFermentationDetail(
+    api,
+    firstLinkedQuestionId,
+  );
+  const [overlayVisible, setOverlayVisible] = useState(false);
+  const [overlayPromptOpen, setOverlayPromptOpen] = useState(false);
+  const promptedForQuestionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!fermentationOverlayDetail) {
+      setOverlayVisible(false);
+      setOverlayPromptOpen(false);
+      promptedForQuestionRef.current = null;
+      return;
+    }
+    if (promptedForQuestionRef.current === fermentationOverlayDetail.questionId) return;
+    promptedForQuestionRef.current = fermentationOverlayDetail.questionId;
+    if (settings.fermentationOverlayPreference === 'always') {
+      setOverlayVisible(true);
+      setOverlayPromptOpen(false);
+    } else if (settings.fermentationOverlayPreference === 'never') {
+      setOverlayVisible(false);
+      setOverlayPromptOpen(false);
+    } else {
+      setOverlayPromptOpen(true);
+    }
+  }, [fermentationOverlayDetail, settings.fermentationOverlayPreference]);
+  const handleOverlayPromptChoose = useCallback(
+    (display: boolean, remember: boolean) => {
+      setOverlayVisible(display);
+      setOverlayPromptOpen(false);
+      if (remember) {
+        updateSettings({ fermentationOverlayPreference: display ? 'always' : 'never' });
+      }
+    },
+    [updateSettings],
+  );
+  const toggleOverlay = useCallback(() => {
+    setOverlayVisible((v) => !v);
+  }, []);
   const [dateStr, setDateStr] = useState(() => {
     const now = new Date();
     const created = createdAtIso ? new Date(createdAtIso) : now;
@@ -168,7 +215,8 @@ export function EntryEditor({
     isEditingTitle ||
     statsOpen ||
     pendingNavPath !== null ||
-    leaveConfirmOpen;
+    leaveConfirmOpen ||
+    overlayPromptOpen;
   const uiVisible = useFocusMode({
     enabled: settings.focusModeEnabled,
     forceVisible: anyOverlayOpen,
@@ -775,6 +823,40 @@ export function EntryEditor({
               <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3zM19 10v2a7 7 0 0 1-14 0v-2M12 19v4M8 23h8" />
             </svg>
           </button>
+          {/* Issue #329: Fermentation overlay toggle — visible when a completed result exists */}
+          {fermentationOverlayDetail && (
+            <button
+              type="button"
+              onClick={toggleOverlay}
+              aria-pressed={overlayVisible}
+              className={`rounded-md p-1.5 transition-all hover:bg-[var(--toolbar-hover)] ${
+                overlayVisible
+                  ? 'text-emerald-600'
+                  : 'text-[var(--date-color)] hover:text-[var(--fg)]'
+              }`}
+              data-tooltip={
+                overlayVisible
+                  ? t('toolbar.fermentation_overlay_hide')
+                  : t('toolbar.fermentation_overlay_show')
+              }
+              data-testid="fermentation-overlay-toggle"
+            >
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 3.75v3.75M15 3.75v3.75M7.5 7.5h9a1.5 1.5 0 0 1 1.5 1.5v9a3 3 0 0 1-3 3h-6a3 3 0 0 1-3-3V9a1.5 1.5 0 0 1 1.5-1.5Zm1.5 5.25h6m-6 3h4.5"
+                />
+              </svg>
+            </button>
+          )}
           {/* Settings */}
           <button
             type="button"
@@ -921,6 +1003,11 @@ export function EntryEditor({
 
       {/* Editor area — outer wrapper (no overflow) holds fade overlay; inner div scrolls */}
       <div className="relative flex-1">
+        {/* Issue #329: 発酵オーバーレイ。エディタ領域に重ねて表示。pointer-events は子要素のみで
+            受け取るため、執筆エリアの入力を妨げない。 */}
+        {overlayVisible && fermentationOverlayDetail && (
+          <FermentationOverlay detail={fermentationOverlayDetail} />
+        )}
         {/* End-side fade for vertical mode — appears only when content is clipped at the end */}
         {settings.writingMode === 'vertical' && fadeLeft && (
           <div
@@ -1073,6 +1160,13 @@ export function EntryEditor({
       <LinkQuestionNudgeModal
         open={linkQuestionNudgeOpen}
         onClose={() => setLinkQuestionNudgeOpen(false)}
+      />
+
+      {/* Issue #329: 発酵結果フローティング表示の確認モーダル */}
+      <FermentationDisplayPromptModal
+        open={overlayPromptOpen}
+        onChoose={handleOverlayPromptChoose}
+        onClose={() => setOverlayPromptOpen(false)}
       />
     </div>
   );

--- a/apps/client/src/features/entries/components/fermentation-display-prompt-modal.tsx
+++ b/apps/client/src/features/entries/components/fermentation-display-prompt-modal.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+interface FermentationDisplayPromptModalProps {
+  open: boolean;
+  /** Called when the user picks display/hide. `remember` tells the caller to persist the choice. */
+  onChoose: (display: boolean, remember: boolean) => void;
+  onClose: () => void;
+}
+
+/**
+ * Issue #329: 新規エントリで問いを紐付けたとき、その問いの発酵結果をエディタ上に
+ * フローティング表示するかを確認するモーダル。「次回からは確認しない」を ON にすると
+ * 選んだ挙動が設定に保存され、以降はモーダルなしで自動適用される。
+ */
+export function FermentationDisplayPromptModal({
+  open,
+  onChoose,
+  onClose,
+}: FermentationDisplayPromptModalProps) {
+  const t = useTranslations('editor.fermentation_overlay.prompt');
+  const [remember, setRemember] = useState(false);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed inset-0 z-[70] bg-black/30"
+        onClick={onClose}
+        aria-label={t('close_aria')}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('aria_label')}
+        className="-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-[71] w-[min(440px,92vw)] rounded-xl border border-[var(--border-subtle)] bg-[var(--bg)] p-6 shadow-2xl"
+      >
+        <h2 className="mb-2 text-lg font-bold text-[var(--fg)]">{t('heading')}</h2>
+        <p className="mb-4 text-sm text-zinc-600 dark:text-zinc-300">{t('body')}</p>
+
+        <label className="mb-5 flex cursor-pointer items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+            className="h-3.5 w-3.5 cursor-pointer accent-emerald-600"
+          />
+          {t('remember_label')}
+        </label>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => onChoose(false, remember)}
+            className="rounded-md border border-[var(--border-subtle)] px-4 py-2 text-sm text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            {t('hide')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onChoose(true, remember)}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm text-white transition-colors hover:bg-emerald-700"
+          >
+            {t('show')}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/client/src/features/entries/components/fermentation-overlay-detail-pane.tsx
+++ b/apps/client/src/features/entries/components/fermentation-overlay-detail-pane.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export type FermentationOverlayDetailType = 'keyword' | 'snippet' | 'letter';
+
+export interface FermentationOverlayDetailData {
+  keyword?: string;
+  description?: string;
+  originalText?: string;
+  sourceDate?: string;
+  selectionReason?: string;
+  bodyText?: string;
+}
+
+interface FermentationOverlayDetailPaneProps {
+  open: boolean;
+  onClose: () => void;
+  type: FermentationOverlayDetailType | null;
+  data: FermentationOverlayDetailData | null;
+}
+
+/**
+ * Issue #329: 発酵オーバーレイ上のキーワード／スニペット／レターをクリックしたときに右側に
+ * スライドインする詳細ペイン。Jar 画面の DetailPane と挙動を揃えるが、エントリ編集中の
+ * オーバーレイから開かれるため "エントリを書く" ボタンは不要。
+ */
+export function FermentationOverlayDetailPane({
+  open,
+  onClose,
+  type,
+  data,
+}: FermentationOverlayDetailPaneProps) {
+  const t = useTranslations('editor.fermentation_overlay.detail');
+
+  const headers: Record<FermentationOverlayDetailType, string> = {
+    keyword: t('header_keyword'),
+    snippet: t('header_snippet'),
+    letter: t('header_letter'),
+  };
+
+  return (
+    <div
+      className="fixed top-0 z-[65] flex h-full w-[400px] flex-col border-l border-[rgba(139,115,85,0.2)] bg-[#faf8f5] transition-[right] duration-500"
+      style={{
+        right: open ? 0 : -400,
+        backdropFilter: 'blur(12px)',
+        fontFamily: "'Noto Serif JP', serif",
+      }}
+      aria-hidden={!open}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-4 right-4 flex h-8 w-8 items-center justify-center rounded-full text-lg text-[#6b5c4a] hover:bg-[rgba(139,115,85,0.1)]"
+        aria-label={t('close_aria')}
+      >
+        ×
+      </button>
+
+      <div className="shrink-0 border-b border-[rgba(139,115,85,0.1)] px-8 pt-12 pb-5 text-[22px] font-medium text-[#4a3f35]">
+        {type ? headers[type] : ''}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6 text-sm leading-[2.0] text-[#4a3f35]">
+        {type === 'keyword' && data && (
+          <>
+            <h3 className="mb-3 text-lg font-medium text-[var(--accent)]">{data.keyword}</h3>
+            <p>{data.description}</p>
+          </>
+        )}
+        {type === 'snippet' && data && (
+          <>
+            <blockquote className="mb-4 text-base font-medium leading-relaxed">
+              「{data.originalText}」
+            </blockquote>
+            {data.sourceDate && (
+              <p className="mb-4 text-xs text-[var(--date-color)]">
+                <span>{t('snippet_source_prefix')}</span> {data.sourceDate}
+              </p>
+            )}
+            <p>{data.selectionReason}</p>
+          </>
+        )}
+        {type === 'letter' && data && <div className="whitespace-pre-wrap">{data.bodyText}</div>}
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/entries/components/fermentation-overlay.tsx
+++ b/apps/client/src/features/entries/components/fermentation-overlay.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { type CSSProperties, type ReactNode, useCallback, useRef, useState } from 'react';
+import {
+  type FermentationOverlayDetailData,
+  FermentationOverlayDetailPane,
+  type FermentationOverlayDetailType,
+} from '@/features/entries/components/fermentation-overlay-detail-pane';
+import type { EntryFermentationDetail } from '@/features/entries/hooks/use-entry-fermentation-detail';
+import { useOverlayDrag } from '@/features/entries/hooks/use-overlay-drag';
+
+interface FermentationOverlayProps {
+  detail: EntryFermentationDetail;
+}
+
+interface Pos {
+  x: number;
+  y: number;
+}
+
+/* Fallback positions when the user hasn't dragged yet. Spread across the editor viewport so
+ * elements don't pile onto each other. */
+const KEYWORD_FALLBACK_POSITIONS: Pos[] = [
+  { x: 12, y: 18 },
+  { x: 72, y: 22 },
+  { x: 16, y: 68 },
+  { x: 76, y: 64 },
+  { x: 44, y: 12 },
+];
+const SNIPPET_FALLBACK_POSITIONS: Pos[] = [
+  { x: 22, y: 42 },
+  { x: 64, y: 46 },
+  { x: 40, y: 78 },
+];
+const LETTER_FALLBACK_POSITION: Pos = { x: 50, y: 32 };
+
+const FLOAT_CLASSES = ['oz-overlay-float-1', 'oz-overlay-float-2', 'oz-overlay-float-3'];
+const MICROBE_TYPES: Array<'koji' | 'yeast' | 'lab'> = ['koji', 'yeast', 'lab'];
+const MICROBE_SVGS: Record<'koji' | 'yeast' | 'lab', string> = {
+  koji: '<svg viewBox="0 0 28 28"><g fill="none"><path d="M14,24 C10,20 8,14 12,8 C14,6 16,6 18,8 C22,12 22,18 18,22" stroke="#A3B8A8" stroke-width="2" stroke-linecap="round" opacity="0.65"/><ellipse cx="14" cy="6" rx="3.5" ry="5" fill="#A3B8A8" opacity="0.35"/><ellipse cx="9" cy="10" rx="2" ry="3" fill="#8EA89C" opacity="0.45"/><ellipse cx="19" cy="14" rx="1.5" ry="2.5" fill="#8EA89C" opacity="0.3"/></g></svg>',
+  yeast:
+    '<svg viewBox="0 0 24 36"><g fill="#D9B48F" opacity="0.55"><rect x="8" y="4" width="8" height="20" rx="4" fill="#D9B48F" opacity="0.6"/><rect x="6" y="2" width="5" height="14" rx="2.5" fill="#E2C28E" opacity="0.7"/><rect x="14" y="8" width="4" height="12" rx="2" fill="#D9B48F" opacity="0.45"/><rect x="10" y="20" width="4" height="10" rx="2" fill="#E2C28E" opacity="0.5"/></g></svg>',
+  lab: '<svg viewBox="0 0 32 20"><g fill="none"><path d="M6,14 Q12,6 18,12 Q26,18 30,10" stroke="#A3B8A8" stroke-width="2.5" stroke-linecap="round" opacity="0.6"/><circle cx="6" cy="14" r="3" fill="#A3B8A8" opacity="0.4"/><circle cx="18" cy="12" r="2.5" fill="#8EA89C" opacity="0.35"/><circle cx="30" cy="10" r="2" fill="#A3B8A8" opacity="0.3"/></g></svg>',
+};
+
+interface FloatingElementProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  pos: Pos;
+  onMove: (x: number, y: number) => void;
+  onEnd: (x: number, y: number) => void;
+  onClick: () => void;
+  floatClass: string;
+  children: ReactNode;
+  style?: CSSProperties;
+  ariaLabel: string;
+}
+
+function FloatingElement({
+  containerRef,
+  pos,
+  onMove,
+  onEnd,
+  onClick,
+  floatClass,
+  children,
+  style,
+  ariaLabel,
+}: FloatingElementProps) {
+  const { isDragging, pointerHandlers } = useOverlayDrag({
+    containerRef,
+    enabled: true,
+    x: pos.x,
+    y: pos.y,
+    onClickWithoutDrag: onClick,
+    onDragMove: onMove,
+    onDragEnd: onEnd,
+  });
+  return (
+    <button
+      type="button"
+      {...pointerHandlers}
+      aria-label={ariaLabel}
+      className={`pointer-events-auto border-none bg-transparent p-0 text-left ${floatClass}`}
+      style={{
+        position: 'absolute',
+        top: `${pos.y}%`,
+        left: `${pos.x}%`,
+        transform: 'translate(-50%, -50%)',
+        cursor: isDragging ? 'grabbing' : 'grab',
+        touchAction: 'none',
+        userSelect: 'none',
+        zIndex: 20,
+        ...style,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Issue #329: 新規エントリ編集中、紐付けた問いに完了済み発酵結果がある場合に表示する
+ * フローティング・オーバーレイ。oryzae のスニペット、yeast のキーワード、L.A.B. の手紙を
+ * エディタ上をふわふわ漂わせる。各要素はドラッグで自由に動かせ、クリックすると右側に
+ * 詳細ペインが開く。書き込みを妨げないようコンテナ自体は `pointer-events: none` で、
+ * 子要素のみが `pointer-events: auto` で操作を受け取る。
+ */
+export function FermentationOverlay({ detail }: FermentationOverlayProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const t = useTranslations('editor.fermentation_overlay');
+  const [positions, setPositions] = useState<{
+    keywords: Record<string, Pos>;
+    snippets: Record<string, Pos>;
+    letter: Pos | null;
+  }>(() => ({ keywords: {}, snippets: {}, letter: null }));
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailType, setDetailType] = useState<FermentationOverlayDetailType | null>(null);
+  const [detailData, setDetailData] = useState<FermentationOverlayDetailData | null>(null);
+
+  const openDetail = useCallback(
+    (type: FermentationOverlayDetailType, data: FermentationOverlayDetailData) => {
+      setDetailType(type);
+      setDetailData(data);
+      setDetailOpen(true);
+    },
+    [],
+  );
+
+  const updateKeyword = useCallback((id: string, x: number, y: number) => {
+    setPositions((prev) => ({ ...prev, keywords: { ...prev.keywords, [id]: { x, y } } }));
+  }, []);
+  const updateSnippet = useCallback((id: string, x: number, y: number) => {
+    setPositions((prev) => ({ ...prev, snippets: { ...prev.snippets, [id]: { x, y } } }));
+  }, []);
+  const updateLetter = useCallback((x: number, y: number) => {
+    setPositions((prev) => ({ ...prev, letter: { x, y } }));
+  }, []);
+
+  return (
+    <>
+      <style>{`
+        @keyframes oz-overlay-float-1 {
+          0%, 100% { transform: translate(-50%, -50%) translateY(0) translateX(0); }
+          33% { transform: translate(-50%, -50%) translateY(-10px) translateX(5px); }
+          66% { transform: translate(-50%, -50%) translateY(5px) translateX(-5px); }
+        }
+        @keyframes oz-overlay-float-2 {
+          0%, 100% { transform: translate(-50%, -50%) translateY(0) translateX(0); }
+          33% { transform: translate(-50%, -50%) translateY(5px) translateX(-8px); }
+          66% { transform: translate(-50%, -50%) translateY(-8px) translateX(3px); }
+        }
+        @keyframes oz-overlay-float-3 {
+          0%, 100% { transform: translate(-50%, -50%) translateY(0) translateX(0); }
+          33% { transform: translate(-50%, -50%) translateY(-6px) translateX(-4px); }
+          66% { transform: translate(-50%, -50%) translateY(8px) translateX(6px); }
+        }
+        .oz-overlay-float-1 { animation: oz-overlay-float-1 8s ease-in-out infinite; }
+        .oz-overlay-float-2 { animation: oz-overlay-float-2 12s ease-in-out infinite; }
+        .oz-overlay-float-3 { animation: oz-overlay-float-3 10s ease-in-out infinite 2s; }
+      `}</style>
+
+      <div
+        ref={containerRef}
+        aria-hidden="false"
+        className="pointer-events-none absolute inset-0 z-[5] overflow-visible"
+        data-testid="fermentation-overlay"
+      >
+        {detail.keywords.slice(0, 5).map((kw, i) => {
+          const pos =
+            positions.keywords[kw.id] ??
+            KEYWORD_FALLBACK_POSITIONS[i] ??
+            KEYWORD_FALLBACK_POSITIONS[0];
+          const microbe = MICROBE_TYPES[i % MICROBE_TYPES.length];
+          return (
+            <FloatingElement
+              key={kw.id}
+              containerRef={containerRef}
+              pos={pos}
+              floatClass={FLOAT_CLASSES[i % FLOAT_CLASSES.length]}
+              ariaLabel={t('aria_keyword', { keyword: kw.keyword })}
+              onMove={(x, y) => updateKeyword(kw.id, x, y)}
+              onEnd={(x, y) => updateKeyword(kw.id, x, y)}
+              onClick={() =>
+                openDetail('keyword', { keyword: kw.keyword, description: kw.description })
+              }
+            >
+              <div
+                style={{
+                  position: 'relative',
+                  background: 'linear-gradient(135deg, #E8D1B5, #D9B48F)',
+                  color: 'var(--fg)',
+                  fontFamily: "'Noto Serif JP', serif",
+                  fontSize: '13px',
+                  letterSpacing: '0.15em',
+                  padding: '6px 16px',
+                  borderRadius: '999px',
+                  boxShadow: '0 4px 12px rgba(217,180,143,0.3)',
+                  border: '1px solid rgba(255,255,255,0.5)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {kw.keyword}
+                <span
+                  className="pointer-events-none absolute -top-2.5 -right-3 block h-[18px] w-[18px] opacity-60"
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: static constant SVG, no user input
+                  dangerouslySetInnerHTML={{ __html: MICROBE_SVGS[microbe] }}
+                />
+              </div>
+            </FloatingElement>
+          );
+        })}
+
+        {detail.snippets.slice(0, 3).map((s, i) => {
+          const pos =
+            positions.snippets[s.id] ??
+            SNIPPET_FALLBACK_POSITIONS[i] ??
+            SNIPPET_FALLBACK_POSITIONS[0];
+          const displayText =
+            s.originalText.length > 60 ? `${s.originalText.substring(0, 60)}…` : s.originalText;
+          return (
+            <FloatingElement
+              key={s.id}
+              containerRef={containerRef}
+              pos={pos}
+              floatClass={FLOAT_CLASSES[(i + 1) % FLOAT_CLASSES.length]}
+              ariaLabel={t('aria_snippet')}
+              onMove={(x, y) => updateSnippet(s.id, x, y)}
+              onEnd={(x, y) => updateSnippet(s.id, x, y)}
+              onClick={() =>
+                openDetail('snippet', {
+                  originalText: s.originalText,
+                  sourceDate: s.sourceDate,
+                  selectionReason: s.selectionReason,
+                })
+              }
+            >
+              <div
+                style={{
+                  background: 'rgba(253,251,247,0.6)',
+                  backdropFilter: 'blur(12px)',
+                  WebkitBackdropFilter: 'blur(12px)',
+                  border: '1px solid rgba(255,255,255,0.6)',
+                  padding: '10px 12px',
+                  borderRadius: '12px',
+                  maxWidth: '200px',
+                  boxShadow: '0 4px 16px rgba(140,133,126,0.12)',
+                  color: 'var(--fg)',
+                  fontFamily: "'Noto Sans JP', sans-serif",
+                  fontWeight: 500,
+                  fontSize: '11px',
+                  lineHeight: 1.6,
+                }}
+              >
+                {displayText}
+              </div>
+            </FloatingElement>
+          );
+        })}
+
+        {detail.letter && (
+          <FloatingElement
+            containerRef={containerRef}
+            pos={positions.letter ?? LETTER_FALLBACK_POSITION}
+            floatClass={FLOAT_CLASSES[2]}
+            ariaLabel={t('aria_letter')}
+            onMove={(x, y) => updateLetter(x, y)}
+            onEnd={(x, y) => updateLetter(x, y)}
+            onClick={() =>
+              openDetail('letter', { bodyText: detail.letter ? detail.letter.bodyText : '' })
+            }
+          >
+            <div
+              style={{
+                background: 'rgba(247, 240, 230, 0.8)',
+                border: '1px solid rgba(217, 180, 143, 0.5)',
+                padding: '8px 14px',
+                borderRadius: '4px',
+                boxShadow: '0 4px 12px rgba(140, 133, 126, 0.12)',
+                color: 'var(--fg)',
+                fontFamily: "'Noto Serif JP', serif",
+                fontSize: '12px',
+                letterSpacing: '0.05em',
+              }}
+            >
+              {t('letter_badge')}
+            </div>
+          </FloatingElement>
+        )}
+      </div>
+
+      <FermentationOverlayDetailPane
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        type={detailType}
+        data={detailData}
+      />
+    </>
+  );
+}

--- a/apps/client/src/features/entries/components/settings-drawer.tsx
+++ b/apps/client/src/features/entries/components/settings-drawer.tsx
@@ -7,6 +7,13 @@ type FontFamily = 'serif' | 'sans';
 export type TimeInscriptionMode = 'fontSize' | 'fontWeight' | 'pressureBleed';
 type GhostMode = 'block' | 'dust';
 
+/**
+ * Issue #329: 新規エントリで問いを紐付けたとき、その問いの発酵結果をエディタ上に
+ * フローティング表示するかどうかの既定挙動。'ask' は毎回モーダルで確認、
+ * 'always' は自動表示、'never' は表示しない。
+ */
+export type FermentationOverlayPreference = 'ask' | 'always' | 'never';
+
 export interface EditorSettings {
   writingMode: WritingMode;
   fontFamily: FontFamily;
@@ -25,6 +32,7 @@ export interface EditorSettings {
   ghostBlurStart: number;
   ghostBlurEnd: number;
   ghostDuration: number;
+  fermentationOverlayPreference: FermentationOverlayPreference;
 }
 
 export const DEFAULT_SETTINGS: EditorSettings = {
@@ -45,6 +53,7 @@ export const DEFAULT_SETTINGS: EditorSettings = {
   ghostBlurStart: 4,
   ghostBlurEnd: 14,
   ghostDuration: 100,
+  fermentationOverlayPreference: 'ask',
 };
 
 interface SettingsDrawerProps {
@@ -322,6 +331,30 @@ export function SettingsDrawer({ open, settings, onChange, onClose }: SettingsDr
                 </div>
               </div>
             )}
+          </div>
+
+          {/* 発酵オーバーレイ (Issue #329) */}
+          <div className="mt-5">
+            <div className="mb-2 text-xs font-semibold tracking-wider text-zinc-400">
+              {t('section_fermentation_overlay')}
+            </div>
+            <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+              {t('fermentation_overlay_description')}
+            </p>
+            <RadioGroup
+              name="fermentation-overlay-preference"
+              options={[
+                { value: 'ask', label: t('fermentation_overlay_ask') },
+                { value: 'always', label: t('fermentation_overlay_always') },
+                { value: 'never', label: t('fermentation_overlay_never') },
+              ]}
+              value={settings.fermentationOverlayPreference}
+              onChange={(v) => {
+                if (v === 'ask' || v === 'always' || v === 'never') {
+                  onChange({ fermentationOverlayPreference: v });
+                }
+              }}
+            />
           </div>
         </div>
       </div>

--- a/apps/client/src/features/entries/hooks/use-editor-settings.ts
+++ b/apps/client/src/features/entries/hooks/use-editor-settings.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import {
   DEFAULT_SETTINGS,
   type EditorSettings,
+  type FermentationOverlayPreference,
 } from '@/features/entries/components/settings-drawer';
 
 const FONT_SIZE_STORAGE_KEY = 'oryzae-editor-font-size';
@@ -15,6 +16,8 @@ const LINE_HEIGHT_MIN = 1.0;
 const LINE_HEIGHT_MAX = 2.5;
 
 const FOCUS_MODE_STORAGE_KEY = 'oryzae-editor-focus-mode';
+
+const FERMENTATION_OVERLAY_PREFERENCE_KEY = 'oryzae-editor-fermentation-overlay-preference';
 
 function readStoredFontSize(): number | null {
   if (typeof window === 'undefined') return null;
@@ -83,6 +86,26 @@ function writeStoredFocusMode(value: boolean): void {
   }
 }
 
+function readStoredFermentationOverlayPreference(): FermentationOverlayPreference | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(FERMENTATION_OVERLAY_PREFERENCE_KEY);
+    if (raw === 'ask' || raw === 'always' || raw === 'never') return raw;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredFermentationOverlayPreference(value: FermentationOverlayPreference): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(FERMENTATION_OVERLAY_PREFERENCE_KEY, value);
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
 function getInitialSettings(locale: string | undefined): EditorSettings {
   const next: EditorSettings = { ...DEFAULT_SETTINGS };
   // 英語ロケールでサインアップ／利用しているユーザーは横書きをデフォルトにする (issue #269)
@@ -95,6 +118,8 @@ function getInitialSettings(locale: string | undefined): EditorSettings {
   if (lineHeight !== null) next.lineHeight = lineHeight;
   const focusMode = readStoredFocusMode();
   if (focusMode !== null) next.focusModeEnabled = focusMode;
+  const overlayPref = readStoredFermentationOverlayPreference();
+  if (overlayPref !== null) next.fermentationOverlayPreference = overlayPref;
   return next;
 }
 
@@ -112,6 +137,13 @@ export function useEditorSettings(
     }
     if (typeof patch.focusModeEnabled === 'boolean') {
       writeStoredFocusMode(patch.focusModeEnabled);
+    }
+    if (
+      patch.fermentationOverlayPreference === 'ask' ||
+      patch.fermentationOverlayPreference === 'always' ||
+      patch.fermentationOverlayPreference === 'never'
+    ) {
+      writeStoredFermentationOverlayPreference(patch.fermentationOverlayPreference);
     }
     setSettings((prev) => ({ ...prev, ...patch }));
   }, []);

--- a/apps/client/src/features/entries/hooks/use-entry-fermentation-detail.ts
+++ b/apps/client/src/features/entries/hooks/use-entry-fermentation-detail.ts
@@ -1,0 +1,217 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { ApiClient } from '@/lib/api';
+
+/**
+ * Issue #329: 新規エントリで紐付けた問いに対応する最新の "completed" 発酵プロセス結果を
+ * フェッチするフック。Jar 画面と同じ API を叩くが、features 境界を守るため
+ * features/entries 内で独立に保持する (dep-cruiser のフィーチャ分離ルール準拠)。
+ */
+
+interface FermentationSnippet {
+  id: string;
+  snippetType: 'new_perspective' | 'deepen' | 'core';
+  originalText: string;
+  sourceDate: string;
+  selectionReason: string;
+}
+
+interface FermentationKeyword {
+  id: string;
+  keyword: string;
+  description: string;
+}
+
+interface FermentationLetter {
+  id: string;
+  bodyText: string;
+}
+
+export interface EntryFermentationDetail {
+  id: string;
+  questionId: string;
+  snippets: FermentationSnippet[];
+  keywords: FermentationKeyword[];
+  letter: FermentationLetter | null;
+}
+
+interface FermentationSummary {
+  id: string;
+  questionId: string;
+  status: string;
+  createdAt: string;
+}
+
+interface ApiSnippet {
+  id?: unknown;
+  snippetType?: unknown;
+  originalText?: unknown;
+  sourceDate?: unknown;
+  selectionReason?: unknown;
+}
+
+interface ApiKeyword {
+  id?: unknown;
+  keyword?: unknown;
+  description?: unknown;
+}
+
+interface ApiLetter {
+  id?: unknown;
+  bodyText?: unknown;
+}
+
+interface ApiDetail {
+  id?: unknown;
+  questionId?: unknown;
+  status?: unknown;
+  snippets?: unknown;
+  keywords?: unknown;
+  letter?: unknown;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeSnippets(input: unknown): FermentationSnippet[] {
+  if (!Array.isArray(input)) return [];
+  const out: FermentationSnippet[] = [];
+  for (const raw of input) {
+    if (!isObject(raw)) continue;
+    const s = raw as ApiSnippet;
+    if (typeof s.id !== 'string') continue;
+    const snippetType =
+      s.snippetType === 'new_perspective' || s.snippetType === 'deepen' || s.snippetType === 'core'
+        ? s.snippetType
+        : 'core';
+    out.push({
+      id: s.id,
+      snippetType,
+      originalText: typeof s.originalText === 'string' ? s.originalText : '',
+      sourceDate: typeof s.sourceDate === 'string' ? s.sourceDate : '',
+      selectionReason: typeof s.selectionReason === 'string' ? s.selectionReason : '',
+    });
+  }
+  return out;
+}
+
+function normalizeKeywords(input: unknown): FermentationKeyword[] {
+  if (!Array.isArray(input)) return [];
+  const out: FermentationKeyword[] = [];
+  for (const raw of input) {
+    if (!isObject(raw)) continue;
+    const k = raw as ApiKeyword;
+    if (typeof k.id !== 'string') continue;
+    out.push({
+      id: k.id,
+      keyword: typeof k.keyword === 'string' ? k.keyword : '',
+      description: typeof k.description === 'string' ? k.description : '',
+    });
+  }
+  return out;
+}
+
+function normalizeLetter(input: unknown): FermentationLetter | null {
+  if (!isObject(input)) return null;
+  const l = input as ApiLetter;
+  if (typeof l.id !== 'string') return null;
+  return {
+    id: l.id,
+    bodyText: typeof l.bodyText === 'string' ? l.bodyText : '',
+  };
+}
+
+function normalizeDetail(input: unknown): EntryFermentationDetail | null {
+  if (!isObject(input)) return null;
+  const d = input as ApiDetail;
+  if (typeof d.id !== 'string' || typeof d.questionId !== 'string') return null;
+  if (d.status !== 'completed') return null;
+  return {
+    id: d.id,
+    questionId: d.questionId,
+    snippets: normalizeSnippets(d.snippets),
+    keywords: normalizeKeywords(d.keywords),
+    letter: normalizeLetter(d.letter),
+  };
+}
+
+function normalizeSummaries(input: unknown): FermentationSummary[] {
+  if (!Array.isArray(input)) return [];
+  const out: FermentationSummary[] = [];
+  for (const raw of input) {
+    if (!isObject(raw)) continue;
+    const id = raw.id;
+    const questionId = raw.questionId;
+    const status = raw.status;
+    const createdAt = raw.createdAt;
+    if (
+      typeof id !== 'string' ||
+      typeof questionId !== 'string' ||
+      typeof status !== 'string' ||
+      typeof createdAt !== 'string'
+    ) {
+      continue;
+    }
+    out.push({ id, questionId, status, createdAt });
+  }
+  return out;
+}
+
+interface UseEntryFermentationDetailResult {
+  detail: EntryFermentationDetail | null;
+  loading: boolean;
+}
+
+/**
+ * Returns the latest completed fermentation detail for `questionId`, or null if none exists.
+ * Returns null while `questionId` is undefined.
+ */
+export function useEntryFermentationDetail(
+  api: ApiClient | null,
+  questionId: string | undefined,
+): UseEntryFermentationDetailResult {
+  const [detail, setDetail] = useState<EntryFermentationDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchDetail = useCallback(async () => {
+    if (!api || !questionId) {
+      setDetail(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setDetail(null);
+    try {
+      const res = await api.fetch(`/api/v1/fermentations?questionId=${questionId}`);
+      if (!res.ok) {
+        setLoading(false);
+        return;
+      }
+      const summaries = normalizeSummaries(await res.json());
+      const completed = summaries
+        .filter((s) => s.status === 'completed')
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+      if (!completed) {
+        setLoading(false);
+        return;
+      }
+      const detailRes = await api.fetch(`/api/v1/fermentations/${completed.id}`);
+      if (!detailRes.ok) {
+        setLoading(false);
+        return;
+      }
+      const normalized = normalizeDetail(await detailRes.json());
+      setDetail(normalized);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, questionId]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  return { detail, loading };
+}

--- a/apps/client/src/features/entries/hooks/use-overlay-drag.ts
+++ b/apps/client/src/features/entries/hooks/use-overlay-drag.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import {
+  type MouseEvent,
+  type PointerEvent,
+  type RefObject,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+const DRAG_THRESHOLD_PX = 5;
+
+interface UseOverlayDragOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  x: number;
+  y: number;
+  onClickWithoutDrag: () => void;
+  onDragMove: (x: number, y: number) => void;
+  onDragEnd: (x: number, y: number) => void;
+}
+
+interface DragSession {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+  containerWidth: number;
+  containerHeight: number;
+  lastX: number;
+  lastY: number;
+}
+
+function clampPct(v: number): number {
+  if (v < 0) return 0;
+  if (v > 100) return 100;
+  return v;
+}
+
+interface UseOverlayDragResult {
+  isDragging: boolean;
+  pointerHandlers: {
+    onPointerDown: (e: PointerEvent<HTMLElement>) => void;
+    onPointerMove: (e: PointerEvent<HTMLElement>) => void;
+    onPointerUp: (e: PointerEvent<HTMLElement>) => void;
+    onPointerCancel: (e: PointerEvent<HTMLElement>) => void;
+    onClick: (e: MouseEvent<HTMLElement>) => void;
+  };
+}
+
+/**
+ * Issue #329: 発酵オーバーレイ用のドラッグ&クリックハンドラ。座標はコンテナの 0-100% で
+ * 正規化し、ビューポートサイズが変わっても位置が壊れないようにする。クリックは
+ * `DRAG_THRESHOLD_PX` 未満の動きで確定する。
+ */
+export function useOverlayDrag(options: UseOverlayDragOptions): UseOverlayDragResult {
+  const { containerRef, enabled, x, y, onClickWithoutDrag, onDragMove, onDragEnd } = options;
+  const sessionRef = useRef<DragSession | null>(null);
+  const didDragRef = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const onPointerDown = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      if (!enabled) return;
+      if (e.button !== undefined && e.button !== 0) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect || rect.width === 0 || rect.height === 0) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      didDragRef.current = false;
+      sessionRef.current = {
+        pointerId: e.pointerId,
+        startClientX: e.clientX,
+        startClientY: e.clientY,
+        startX: x,
+        startY: y,
+        containerWidth: rect.width,
+        containerHeight: rect.height,
+        lastX: x,
+        lastY: y,
+      };
+    },
+    [enabled, x, y, containerRef],
+  );
+
+  const onPointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      const s = sessionRef.current;
+      if (!s || s.pointerId !== e.pointerId) return;
+      const dx = e.clientX - s.startClientX;
+      const dy = e.clientY - s.startClientY;
+      if (!didDragRef.current && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+      if (!didDragRef.current) {
+        didDragRef.current = true;
+        setIsDragging(true);
+      }
+      const newX = clampPct(s.startX + (dx / s.containerWidth) * 100);
+      const newY = clampPct(s.startY + (dy / s.containerHeight) * 100);
+      s.lastX = newX;
+      s.lastY = newY;
+      onDragMove(newX, newY);
+    },
+    [onDragMove],
+  );
+
+  const onPointerUp = useCallback(
+    (e: PointerEvent<HTMLElement>) => {
+      const s = sessionRef.current;
+      if (!s || s.pointerId !== e.pointerId) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // Safari/Edge may throw if capture already lost
+      }
+      sessionRef.current = null;
+      setIsDragging(false);
+      if (didDragRef.current) {
+        onDragEnd(s.lastX, s.lastY);
+      }
+    },
+    [onDragEnd],
+  );
+
+  const onPointerCancel = useCallback((e: PointerEvent<HTMLElement>) => {
+    const s = sessionRef.current;
+    if (!s || s.pointerId !== e.pointerId) return;
+    sessionRef.current = null;
+    setIsDragging(false);
+    didDragRef.current = false;
+  }, []);
+
+  const onClick = useCallback(
+    (e: MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      if (didDragRef.current) {
+        didDragRef.current = false;
+        return;
+      }
+      onClickWithoutDrag();
+    },
+    [onClickWithoutDrag],
+  );
+
+  return {
+    isDragging,
+    pointerHandlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick },
+  };
+}

--- a/apps/client/src/i18n/messages/en.json
+++ b/apps/client/src/i18n/messages/en.json
@@ -310,7 +310,9 @@
       "writing_vertical": "Switch to vertical",
       "font_sans": "Switch to gothic (sans)",
       "font_serif": "Switch to mincho (serif)",
-      "fullscreen": "Fullscreen"
+      "fullscreen": "Fullscreen",
+      "fermentation_overlay_show": "Show fermentation result",
+      "fermentation_overlay_hide": "Hide fermentation result"
     },
     "title": {
       "placeholder": "Enter a title...",
@@ -351,7 +353,12 @@
       "ghost_scatter": "Scatter",
       "ghost_blur_start": "Initial blur",
       "ghost_blur_end": "Final blur",
-      "ghost_duration": "Duration"
+      "ghost_duration": "Duration",
+      "section_fermentation_overlay": "Fermentation overlay",
+      "fermentation_overlay_description": "When you link a question to a new entry, the latest fermentation result for that question can float over the editor. Choose how this should behave.",
+      "fermentation_overlay_ask": "Ask before showing",
+      "fermentation_overlay_always": "Always show fermentation result on entry screen",
+      "fermentation_overlay_never": "Never show fermentation result on entry screen"
     },
     "snippet_toolbar": {
       "saving": "Saving…",
@@ -409,6 +416,28 @@
       "heading": "Try linking a question",
       "body": "Linking a question to an entry lets you pickle it and start the fermentation process. Pick an existing question from the linker above or create a new one.",
       "dismiss": "Got it"
+    },
+    "fermentation_overlay": {
+      "prompt": {
+        "aria_label": "Fermentation result display confirmation",
+        "close_aria": "Close modal",
+        "heading": "Show this question's fermentation result?",
+        "body": "The question you linked has a past fermentation result. We can float its snippets, keywords, and letter over the editor as reference while you write.",
+        "remember_label": "Remember this choice; don't ask next time (changeable in settings)",
+        "show": "Show",
+        "hide": "Don't show"
+      },
+      "detail": {
+        "header_keyword": "Keyword",
+        "header_snippet": "Snippet",
+        "header_letter": "Letter",
+        "close_aria": "Close details",
+        "snippet_source_prefix": "From:"
+      },
+      "aria_keyword": "Open fermentation keyword \"{keyword}\"",
+      "aria_snippet": "Open fermentation snippet",
+      "aria_letter": "Open letter from the fermentation process",
+      "letter_badge": "Letter from the fermentation process"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/ja.json
+++ b/apps/client/src/i18n/messages/ja.json
@@ -310,7 +310,9 @@
       "writing_vertical": "縦書きに切替",
       "font_sans": "ゴシックに切替",
       "font_serif": "明朝に切替",
-      "fullscreen": "フルスクリーン"
+      "fullscreen": "フルスクリーン",
+      "fermentation_overlay_show": "発酵結果を表示する",
+      "fermentation_overlay_hide": "発酵結果を非表示にする"
     },
     "title": {
       "placeholder": "タイトルを入力...",
@@ -351,7 +353,12 @@
       "ghost_scatter": "散乱",
       "ghost_blur_start": "初期ブラー",
       "ghost_blur_end": "最終ブラー",
-      "ghost_duration": "持続時間"
+      "ghost_duration": "持続時間",
+      "section_fermentation_overlay": "発酵オーバーレイ",
+      "fermentation_overlay_description": "新規エントリで問いを紐付けたとき、その問いの最新の発酵結果をエディタ上に重ねて表示できます。表示／非表示の挙動を選んでください。",
+      "fermentation_overlay_ask": "表示前に毎回確認する",
+      "fermentation_overlay_always": "エントリ画面で発酵プロセスを常に表示する",
+      "fermentation_overlay_never": "エントリ画面で発酵プロセスを常に表示しない"
     },
     "snippet_toolbar": {
       "saving": "保存中…",
@@ -409,6 +416,28 @@
       "heading": "問いを紐付けてみませんか",
       "body": "エントリに問いを紐付けると、漬け込んで発酵プロセスに進められるようになります。エディタ上部の問いリンカーから既存の問いを選ぶか、新しく作れます。",
       "dismiss": "わかりました"
+    },
+    "fermentation_overlay": {
+      "prompt": {
+        "aria_label": "発酵結果の表示確認",
+        "close_aria": "モーダルを閉じる",
+        "heading": "この問いの発酵結果を表示しますか？",
+        "body": "紐付けた問いには、過去に行われた発酵プロセスの結果があります。執筆の参考になるよう、エディタ上にスニペット・キーワード・手紙を重ねて表示できます。",
+        "remember_label": "この選択を保存し、次回からは確認しない（設定画面で変更可能）",
+        "show": "表示する",
+        "hide": "表示しない"
+      },
+      "detail": {
+        "header_keyword": "キーワード",
+        "header_snippet": "スニペット",
+        "header_letter": "手紙",
+        "close_aria": "詳細を閉じる",
+        "snippet_source_prefix": "出典:"
+      },
+      "aria_keyword": "発酵キーワード「{keyword}」を開く",
+      "aria_snippet": "発酵スニペットを開く",
+      "aria_letter": "発酵プロセスからの手紙を開く",
+      "letter_badge": "発酵プロセスからの手紙"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/ko.json
+++ b/apps/client/src/i18n/messages/ko.json
@@ -310,7 +310,9 @@
       "writing_vertical": "세로쓰기로 전환",
       "font_sans": "고딕체로 전환",
       "font_serif": "명조체로 전환",
-      "fullscreen": "전체 화면"
+      "fullscreen": "전체 화면",
+      "fermentation_overlay_show": "발효 결과 표시",
+      "fermentation_overlay_hide": "발효 결과 숨기기"
     },
     "title": {
       "placeholder": "제목을 입력하세요...",
@@ -351,7 +353,12 @@
       "ghost_scatter": "흩어짐",
       "ghost_blur_start": "초기 블러",
       "ghost_blur_end": "최종 블러",
-      "ghost_duration": "지속 시간"
+      "ghost_duration": "지속 시간",
+      "section_fermentation_overlay": "발효 오버레이",
+      "fermentation_overlay_description": "새 항목에 질문을 연결하면 해당 질문의 최신 발효 결과를 에디터 위에 띄울 수 있습니다. 기본 동작을 선택하세요.",
+      "fermentation_overlay_ask": "표시 전 매번 확인",
+      "fermentation_overlay_always": "항목 화면에서 항상 발효 결과 표시",
+      "fermentation_overlay_never": "항목 화면에서 항상 발효 결과 숨기기"
     },
     "snippet_toolbar": {
       "saving": "저장 중…",
@@ -409,6 +416,28 @@
       "heading": "질문을 연결해 보시겠어요?",
       "body": "항목에 질문을 연결하면 담가서 발효 과정으로 보낼 수 있습니다. 에디터 상단 질문 링커에서 기존 질문을 선택하거나 새로 만드세요.",
       "dismiss": "알겠습니다"
+    },
+    "fermentation_overlay": {
+      "prompt": {
+        "aria_label": "발효 결과 표시 확인",
+        "close_aria": "모달 닫기",
+        "heading": "이 질문의 발효 결과를 표시하시겠습니까?",
+        "body": "연결한 질문에는 과거 발효 결과가 있습니다. 글을 쓰는 동안 참고할 수 있도록 발췌・키워드・편지를 에디터 위에 띄워 보여드릴 수 있습니다.",
+        "remember_label": "이 선택을 저장하고 다음부터 묻지 않기 (설정에서 변경 가능)",
+        "show": "표시",
+        "hide": "표시 안 함"
+      },
+      "detail": {
+        "header_keyword": "키워드",
+        "header_snippet": "발췌",
+        "header_letter": "편지",
+        "close_aria": "상세 닫기",
+        "snippet_source_prefix": "출처:"
+      },
+      "aria_keyword": "발효 키워드 \"{keyword}\" 열기",
+      "aria_snippet": "발효 발췌 열기",
+      "aria_letter": "발효 과정의 편지 열기",
+      "letter_badge": "발효 과정의 편지"
     }
   },
   "fermentation": {

--- a/apps/client/src/i18n/messages/zh.json
+++ b/apps/client/src/i18n/messages/zh.json
@@ -310,7 +310,9 @@
       "writing_vertical": "切换为竖排",
       "font_sans": "切换为黑体",
       "font_serif": "切换为宋体",
-      "fullscreen": "全屏"
+      "fullscreen": "全屏",
+      "fermentation_overlay_show": "显示发酵结果",
+      "fermentation_overlay_hide": "隐藏发酵结果"
     },
     "title": {
       "placeholder": "请输入标题...",
@@ -351,7 +353,12 @@
       "ghost_scatter": "散布",
       "ghost_blur_start": "初始模糊",
       "ghost_blur_end": "最终模糊",
-      "ghost_duration": "持续时间"
+      "ghost_duration": "持续时间",
+      "section_fermentation_overlay": "发酵叠加",
+      "fermentation_overlay_description": "为新条目关联问题时，可以在编辑器上浮动显示该问题的最新发酵结果。请选择默认行为。",
+      "fermentation_overlay_ask": "每次询问后再显示",
+      "fermentation_overlay_always": "在条目编辑界面始终显示发酵结果",
+      "fermentation_overlay_never": "在条目编辑界面始终不显示发酵结果"
     },
     "snippet_toolbar": {
       "saving": "保存中…",
@@ -409,6 +416,28 @@
       "heading": "试试关联一个问题？",
       "body": "将问题关联到条目后，就可以入瓮并进入发酵过程。可在编辑器顶部的问题关联器选择已有问题，或新建一个。",
       "dismiss": "知道了"
+    },
+    "fermentation_overlay": {
+      "prompt": {
+        "aria_label": "发酵结果显示确认",
+        "close_aria": "关闭对话框",
+        "heading": "显示该问题的发酵结果吗？",
+        "body": "你关联的提问已有过往的发酵结果。我们可以将片段、关键词与信件作为参考浮动展示在编辑器上方。",
+        "remember_label": "记住此选择，下次不再询问（可在设置中更改）",
+        "show": "显示",
+        "hide": "不显示"
+      },
+      "detail": {
+        "header_keyword": "关键词",
+        "header_snippet": "片段",
+        "header_letter": "信件",
+        "close_aria": "关闭详情",
+        "snippet_source_prefix": "出处:"
+      },
+      "aria_keyword": "打开发酵关键词\"{keyword}\"",
+      "aria_snippet": "打开发酵片段",
+      "aria_letter": "打开发酵过程的信件",
+      "letter_badge": "来自发酵过程的信件"
     }
   },
   "fermentation": {

--- a/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
+++ b/apps/client/test/features/entries/hooks/use-editor-settings.test.ts
@@ -6,6 +6,7 @@ import { useEditorSettings } from '@/features/entries/hooks/use-editor-settings'
 const FONT_SIZE_KEY = 'oryzae-editor-font-size';
 const LINE_HEIGHT_KEY = 'oryzae-editor-line-height';
 const FOCUS_MODE_KEY = 'oryzae-editor-focus-mode';
+const FERMENTATION_OVERLAY_KEY = 'oryzae-editor-fermentation-overlay-preference';
 
 describe('useEditorSettings', () => {
   beforeEach(() => {
@@ -154,5 +155,50 @@ describe('useEditorSettings', () => {
     expect(result.current[0].writingMode).toBe('horizontal');
     expect(window.localStorage.getItem(FONT_SIZE_KEY)).toBe('24');
     expect(window.localStorage.getItem(LINE_HEIGHT_KEY)).toBe('1.8');
+  });
+
+  // --- Issue #329: fermentationOverlayPreference ---
+
+  it('fermentationOverlayPreference のデフォルトは "ask"', () => {
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].fermentationOverlayPreference).toBe('ask');
+  });
+
+  it('localStorage に保存された "always" を初期化時に読み込む', () => {
+    window.localStorage.setItem(FERMENTATION_OVERLAY_KEY, 'always');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].fermentationOverlayPreference).toBe('always');
+  });
+
+  it('localStorage に保存された "never" を初期化時に読み込む', () => {
+    window.localStorage.setItem(FERMENTATION_OVERLAY_KEY, 'never');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].fermentationOverlayPreference).toBe('never');
+  });
+
+  it('不正な fermentationOverlayPreference は無視されデフォルトに戻る', () => {
+    window.localStorage.setItem(FERMENTATION_OVERLAY_KEY, 'invalid');
+    const { result } = renderHook(() => useEditorSettings());
+    expect(result.current[0].fermentationOverlayPreference).toBe('ask');
+  });
+
+  it('fermentationOverlayPreference を更新すると localStorage に永続化される', () => {
+    const { result } = renderHook(() => useEditorSettings());
+    act(() => {
+      result.current[1]({ fermentationOverlayPreference: 'always' });
+    });
+    expect(result.current[0].fermentationOverlayPreference).toBe('always');
+    expect(window.localStorage.getItem(FERMENTATION_OVERLAY_KEY)).toBe('always');
+  });
+
+  it('fermentationOverlayPreference は再マウント越しに保持される', () => {
+    const first = renderHook(() => useEditorSettings());
+    act(() => {
+      first.result.current[1]({ fermentationOverlayPreference: 'never' });
+    });
+    first.unmount();
+
+    const second = renderHook(() => useEditorSettings());
+    expect(second.result.current[0].fermentationOverlayPreference).toBe('never');
   });
 });

--- a/apps/client/test/features/entries/hooks/use-entry-fermentation-detail.test.ts
+++ b/apps/client/test/features/entries/hooks/use-entry-fermentation-detail.test.ts
@@ -1,0 +1,193 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEntryFermentationDetail } from '@/features/entries/hooks/use-entry-fermentation-detail';
+import type { ApiClient } from '@/lib/api';
+
+function createMockApi(fetchImpl: ReturnType<typeof vi.fn>): ApiClient {
+  return {
+    baseUrl: '',
+    headers: {},
+    fetch: fetchImpl,
+  };
+}
+
+function mockResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+    status: ok ? 200 : 400,
+    // @type-assertion-allowed: テスト用の最小 Response スタブ
+  } as Response;
+}
+
+describe('useEntryFermentationDetail', () => {
+  let apiFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiFetch = vi.fn();
+  });
+
+  it('questionId が undefined のときは fetch せず detail は null', async () => {
+    const api = createMockApi(apiFetch);
+    const { result } = renderHook(() => useEntryFermentationDetail(api, undefined));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('api が null のときは fetch せず detail は null', async () => {
+    const { result } = renderHook(() => useEntryFermentationDetail(null, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toBeNull();
+  });
+
+  it('完了済み発酵がなければ detail は null', async () => {
+    apiFetch.mockResolvedValueOnce(
+      mockResponse(true, [
+        { id: 'f1', questionId: 'q1', status: 'pending', createdAt: '2025-01-01' },
+      ]),
+    );
+    const api = createMockApi(apiFetch);
+    const { result } = renderHook(() => useEntryFermentationDetail(api, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toBeNull();
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('完了済み発酵があれば最新のものを fetch して正規化する', async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        mockResponse(true, [
+          { id: 'f-old', questionId: 'q1', status: 'completed', createdAt: '2025-01-01' },
+          { id: 'f-new', questionId: 'q1', status: 'completed', createdAt: '2025-02-01' },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        mockResponse(true, {
+          id: 'f-new',
+          questionId: 'q1',
+          status: 'completed',
+          keywords: [{ id: 'k1', keyword: 'hello', description: 'desc' }],
+          snippets: [
+            {
+              id: 's1',
+              snippetType: 'core',
+              originalText: 'orig',
+              sourceDate: '2025-01-15',
+              selectionReason: 'because',
+            },
+          ],
+          letter: { id: 'l1', bodyText: 'dear self' },
+        }),
+      );
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useEntryFermentationDetail(api, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.detail).not.toBeNull();
+    });
+
+    const detail = result.current.detail;
+    expect(detail).not.toBeNull();
+    if (!detail) return;
+    expect(detail.id).toBe('f-new');
+    expect(detail.keywords).toHaveLength(1);
+    expect(detail.keywords[0].keyword).toBe('hello');
+    expect(detail.snippets).toHaveLength(1);
+    expect(detail.snippets[0].snippetType).toBe('core');
+    expect(detail.letter?.bodyText).toBe('dear self');
+    // List + detail call
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(apiFetch.mock.calls[1][0]).toBe('/api/v1/fermentations/f-new');
+  });
+
+  it('list が ok=false なら detail は null', async () => {
+    apiFetch.mockResolvedValueOnce(mockResponse(false, null));
+    const api = createMockApi(apiFetch);
+    const { result } = renderHook(() => useEntryFermentationDetail(api, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toBeNull();
+  });
+
+  it('detail レスポンスが completed 以外なら null として扱う', async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        mockResponse(true, [
+          { id: 'f1', questionId: 'q1', status: 'completed', createdAt: '2025-01-01' },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        mockResponse(true, {
+          id: 'f1',
+          questionId: 'q1',
+          status: 'pending',
+          keywords: [],
+          snippets: [],
+          letter: null,
+        }),
+      );
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useEntryFermentationDetail(api, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.detail).toBeNull();
+  });
+
+  it('不正な snippetType は core に正規化される', async () => {
+    apiFetch
+      .mockResolvedValueOnce(
+        mockResponse(true, [
+          { id: 'f1', questionId: 'q1', status: 'completed', createdAt: '2025-01-01' },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        mockResponse(true, {
+          id: 'f1',
+          questionId: 'q1',
+          status: 'completed',
+          keywords: [],
+          snippets: [
+            {
+              id: 's1',
+              snippetType: 'unknown_type',
+              originalText: 't',
+              sourceDate: 'd',
+              selectionReason: 'r',
+            },
+          ],
+          letter: null,
+        }),
+      );
+    const api = createMockApi(apiFetch);
+
+    const { result } = renderHook(() => useEntryFermentationDetail(api, 'q1'));
+
+    await waitFor(() => {
+      expect(result.current.detail).not.toBeNull();
+    });
+
+    expect(result.current.detail?.snippets[0].snippetType).toBe('core');
+  });
+});

--- a/apps/client/test/features/entries/hooks/use-overlay-drag.test.ts
+++ b/apps/client/test/features/entries/hooks/use-overlay-drag.test.ts
@@ -1,0 +1,151 @@
+import { act, renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useOverlayDrag } from '@/features/entries/hooks/use-overlay-drag';
+
+interface PointerArgs {
+  pointerId?: number;
+  clientX?: number;
+  clientY?: number;
+  button?: number;
+}
+
+interface FakePointerTarget {
+  setPointerCapture: ReturnType<typeof vi.fn>;
+  releasePointerCapture: ReturnType<typeof vi.fn>;
+}
+
+function fakeTarget(): FakePointerTarget {
+  return {
+    setPointerCapture: vi.fn(),
+    releasePointerCapture: vi.fn(),
+  };
+}
+
+function pointerEvent(target: FakePointerTarget, args: PointerArgs = {}) {
+  return {
+    pointerId: args.pointerId ?? 1,
+    clientX: args.clientX ?? 0,
+    clientY: args.clientY ?? 0,
+    button: args.button ?? 0,
+    currentTarget: target,
+    // @type-assertion-allowed: テスト用の最小 PointerEvent ダミー
+  } as unknown as React.PointerEvent<HTMLElement>;
+}
+
+function clickEvent() {
+  return {
+    stopPropagation: vi.fn(),
+    // @type-assertion-allowed: テスト用の最小 MouseEvent ダミー
+  } as unknown as React.MouseEvent<HTMLElement>;
+}
+
+interface SetupOpts {
+  enabled?: boolean;
+  startX?: number;
+  startY?: number;
+}
+
+function setupHook(opts: SetupOpts = {}) {
+  const onClickWithoutDrag = vi.fn();
+  const onDragMove = vi.fn();
+  const onDragEnd = vi.fn();
+  const containerWidth = 1000;
+  const containerHeight = 500;
+
+  const { result } = renderHook(() => {
+    const ref = useRef<HTMLElement | null>(null);
+    if (!ref.current) {
+      ref.current = {
+        getBoundingClientRect: () =>
+          ({
+            x: 0,
+            y: 0,
+            top: 0,
+            left: 0,
+            right: containerWidth,
+            bottom: containerHeight,
+            width: containerWidth,
+            height: containerHeight,
+            toJSON: () => ({}),
+          }) as DOMRect,
+        // @type-assertion-allowed: テスト用の最小 HTMLElement スタブ
+      } as unknown as HTMLElement;
+    }
+    return useOverlayDrag({
+      containerRef: ref,
+      enabled: opts.enabled ?? true,
+      x: opts.startX ?? 50,
+      y: opts.startY ?? 50,
+      onClickWithoutDrag,
+      onDragMove,
+      onDragEnd,
+    });
+  });
+
+  return { result, onClickWithoutDrag, onDragMove, onDragEnd };
+}
+
+describe('useOverlayDrag', () => {
+  it('閾値以下の動きはクリック扱いで onClickWithoutDrag を呼び、onDragEnd は呼ばれない', () => {
+    const { result, onClickWithoutDrag, onDragMove, onDragEnd } = setupHook();
+    const target = fakeTarget();
+    act(() => {
+      result.current.pointerHandlers.onPointerDown(pointerEvent(target));
+      result.current.pointerHandlers.onPointerMove(
+        pointerEvent(target, { clientX: 2, clientY: 1 }),
+      );
+      result.current.pointerHandlers.onPointerUp(pointerEvent(target));
+      result.current.pointerHandlers.onClick(clickEvent());
+    });
+    expect(onDragMove).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+    expect(onClickWithoutDrag).toHaveBeenCalledTimes(1);
+  });
+
+  it('閾値超過の動きはドラッグ扱いで onDragMove/onDragEnd を呼び、onClickWithoutDrag は呼ばれない', () => {
+    const { result, onClickWithoutDrag, onDragMove, onDragEnd } = setupHook();
+    const target = fakeTarget();
+    act(() => {
+      result.current.pointerHandlers.onPointerDown(pointerEvent(target));
+      result.current.pointerHandlers.onPointerMove(
+        pointerEvent(target, { clientX: 100, clientY: 50 }),
+      );
+      result.current.pointerHandlers.onPointerUp(pointerEvent(target));
+      result.current.pointerHandlers.onClick(clickEvent());
+    });
+    // 100/1000 = 10% added to startX 50 → 60. 50/500 = 10% added to startY 50 → 60.
+    expect(onDragMove).toHaveBeenCalledWith(60, 60);
+    expect(onDragEnd).toHaveBeenCalledWith(60, 60);
+    expect(onClickWithoutDrag).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false のときは pointerDown を無視し、ドラッグ・クリックともに発火しない', () => {
+    const { result, onClickWithoutDrag, onDragMove, onDragEnd } = setupHook({ enabled: false });
+    const target = fakeTarget();
+    act(() => {
+      result.current.pointerHandlers.onPointerDown(pointerEvent(target));
+      result.current.pointerHandlers.onPointerMove(
+        pointerEvent(target, { clientX: 100, clientY: 100 }),
+      );
+      result.current.pointerHandlers.onPointerUp(pointerEvent(target));
+    });
+    expect(onDragMove).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+    expect(onClickWithoutDrag).not.toHaveBeenCalled();
+    expect(target.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it('クランプ: コンテナ外への動きは 0-100% にクランプされる', () => {
+    const { result, onDragMove } = setupHook({ startX: 50, startY: 50 });
+    const target = fakeTarget();
+    act(() => {
+      result.current.pointerHandlers.onPointerDown(pointerEvent(target));
+      // 1500px drag → 150% raw → clamp to 100
+      result.current.pointerHandlers.onPointerMove(
+        pointerEvent(target, { clientX: 1500, clientY: 1500 }),
+      );
+    });
+    expect(onDragMove).toHaveBeenLastCalledWith(100, 100);
+  });
+});


### PR DESCRIPTION
Closes #329

## Summary
- 新規エントリで問いを紐付けたとき、その問いの最新の完了済み発酵結果をエディタ上にフローティング表示する機能。Jar 画面で見るだけだった発酵結果を、次の執筆につなげる導線にする。
- 「毎回確認 / 常に表示 / 常に非表示」の 3 通りを設定 (localStorage 永続化)。「毎回確認」モードでは表示時にモーダルで尋ね、「次回からは確認しない」チェックで挙動を保存可。
- 表示中はキーワード・スニペット・レターを Jar 画面と同様の `j2-float-*` パターンでふわふわ漂わせ、各要素はドラッグ移動可能・クリックで右側の詳細ペイン表示。

## 実装メモ
- features 分離ルール (dep-cruise) を守るため、`features/entries` 配下に hook/component を全て新設:
  - `hooks/use-entry-fermentation-detail.ts` — `/api/v1/fermentations?questionId=…` → 最新の completed を 1 件取得、レスポンスは型ガードで正規化
  - `hooks/use-overlay-drag.ts` — `useJarDrag` 相当の最小版 (containerRef 基準 0-100% 正規化、5px 閾値でクリック/ドラッグ判定)
  - `components/fermentation-overlay.tsx` — 全体オーバーレイ。`pointer-events: none` で執筆を妨げず、子要素のみ `auto`
  - `components/fermentation-overlay-detail-pane.tsx` — 右側 400px スライドペイン
  - `components/fermentation-display-prompt-modal.tsx` — 表示確認モーダル
- 設定は既存 `EditorSettings` に `fermentationOverlayPreference: 'ask' | 'always' | 'never'` を追加し `oryzae-editor-fermentation-overlay-preference` で永続化。設定ドロワーに新セクション。
- ツールバーに発酵結果トグルボタンを追加 (発酵結果がある場合のみ表示)。`aria-pressed` で状態を表現。
- 新規エントリ (`!entryId`) のときのみ overlay フローを起動。既存エントリは執筆中の判断材料として不要なため対象外。

## i18n
- Google Sheets MCP で 23 キーを `editor.fermentation_overlay.*` / `editor.settings.*` / `editor.toolbar.*` に追加し、`pnpm --filter @oryzae/client run build-i18n --remote` で 4 ロケール (ja/en/zh/ko) を再生成。

## Quality gates
- `pnpm typecheck` ✅ (server + shared + client + admin)
- `pnpm lint` ✅ (新規エラーなし、既存 warnings のみ)
- `pnpm test` ✅ (273 tests / new hook tests: `use-entry-fermentation-detail` 6, `use-overlay-drag` 4, `use-editor-settings` +6)
- `pnpm dep-cruise` ✅
- `pnpm knip` ✅

## Test plan
- [x] 単体テスト追加 (3 ファイル / 16 新規ケース)
- [x] `/entries/new?questionId=<完了済み発酵あり>` でモーダル表示確認
- [x] モーダル「表示する」→ オーバーレイ表示、トグルボタンが `pressed` 状態に
- [x] トグルクリックで非表示↔表示が反転
- [x] 設定ドロワーに「発酵オーバーレイ」セクションと 3 ラジオが出る
- [x] 実機 (Chrome DevTools MCP) でコンソールエラーなしを確認

## Screenshots
| Prompt modal | Overlay displayed | Settings section |
| --- | --- | --- |
| `.tmp/screenshots/329-prompt-modal.png` | `.tmp/screenshots/329-overlay-active.png` | `.tmp/screenshots/329-settings-drawer-with-new-section.png` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)