### PR TITLE
feat(jar): 漬け込み完了モーダルを Jar 画面に表示 (#322)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@oryzae/server": "workspace:*",
+    "@oryzae/shared": "workspace:*",
     "@sentry/nextjs": "^10.51.0",
     "next": "16.2.4",
     "next-intl": "^4.11.0",

--- a/apps/client/src/app/(protected)/entries/[id]/page.tsx
+++ b/apps/client/src/app/(protected)/entries/[id]/page.tsx
@@ -44,6 +44,7 @@ export default function EntryDetailPage() {
     <EntryEditor
       entryId={entry.id}
       initialContent={entry.content}
+      initialEffects={entry.effects}
       createdAt={entry.createdAt}
       updatedAt={entry.updatedAt}
       api={api}

--- a/apps/client/src/app/(protected)/entries/new/page.tsx
+++ b/apps/client/src/app/(protected)/entries/new/page.tsx
@@ -35,7 +35,7 @@ export default function NewEntryPage() {
   const handleSaveTransition = useCallback(
     async (text: string, editorEl: HTMLElement) => {
       await runTransition(text, editorEl);
-      router.push('/jar');
+      router.push('/jar?justPickled=1');
     },
     [runTransition, router],
   );

--- a/apps/client/src/app/(protected)/jar/page.tsx
+++ b/apps/client/src/app/(protected)/jar/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { JarView } from '@/features/fermentation/components/jar-view';
+import { PickleSuccessModal } from '@/features/fermentation/components/pickle-success-modal';
 import { useQuestions } from '@/features/questions/hooks/use-questions';
 import { useUnread } from '@/lib/unread-context';
 
@@ -19,6 +21,19 @@ export default function JarPage() {
   const { createQuestion, editQuestion, archiveQuestion } = useQuestions(api, authLoading);
   const { markSeen } = useUnread();
   const [questions, setQuestions] = useState<QuestionData[]>([]);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const justPickled = searchParams.get('justPickled') === '1';
+  const [pickleSuccessOpen, setPickleSuccessOpen] = useState(false);
+
+  // Issue #322: 漬け込み完了モーダルをアニメーション直後の遷移時に一度だけ表示する。
+  // URL クエリ ?justPickled=1 を消費してから state を立てる。
+  useEffect(() => {
+    if (justPickled) {
+      setPickleSuccessOpen(true);
+      router.replace('/jar');
+    }
+  }, [justPickled, router]);
 
   const fetchActiveQuestions = useCallback(async () => {
     if (!api) return;
@@ -63,6 +78,7 @@ export default function JarPage() {
         onEditQuestion={handleEditQuestion}
         onArchiveQuestion={handleArchiveQuestion}
       />
+      <PickleSuccessModal open={pickleSuccessOpen} onClose={() => setPickleSuccessOpen(false)} />
     </div>
   );
 }

--- a/apps/client/src/app/(protected)/jar/page.tsx
+++ b/apps/client/src/app/(protected)/jar/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/features/auth/hooks/use-auth';
 import { JarView } from '@/features/fermentation/components/jar-view';
 import { PickleSuccessModal } from '@/features/fermentation/components/pickle-success-modal';
@@ -25,14 +25,19 @@ export default function JarPage() {
   const searchParams = useSearchParams();
   const justPickled = searchParams.get('justPickled') === '1';
   const [pickleSuccessOpen, setPickleSuccessOpen] = useState(false);
+  const pickleTimerScheduledRef = useRef(false);
 
   // Issue #322: 漬け込み完了モーダルをアニメーション直後の遷移時に一度だけ表示する。
-  // URL クエリ ?justPickled=1 を消費してから state を立てる。
+  // useSaveTransition は 1.5s で resolve → /jar 遷移を行うが、その後も overlay 上で
+  // condense(2-3.5s) と fade(3.5-4.3s) が走る。文字が瓶の中で透明化を終えてから
+  // 表示するため、遷移後 3.5s 遅延させる。
+  // router.replace で searchParams が更新されると effect が再実行されるため、
+  // ref でタイマーが一度しかスケジュールされないようにガードする。
   useEffect(() => {
-    if (justPickled) {
-      setPickleSuccessOpen(true);
-      router.replace('/jar');
-    }
+    if (!justPickled || pickleTimerScheduledRef.current) return;
+    pickleTimerScheduledRef.current = true;
+    setTimeout(() => setPickleSuccessOpen(true), 3500);
+    router.replace('/jar');
   }, [justPickled, router]);
 
   const fetchActiveQuestions = useCallback(async () => {

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { EditorEffectsState } from '@oryzae/shared';
 import { useRouter } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -38,6 +39,14 @@ import {
   useVoiceDynamics,
   type VoiceUnavailableReason,
 } from '@/features/entries/hooks/use-voice-dynamics';
+import {
+  loadCachedEffects,
+  saveCachedEffects,
+} from '@/features/entries/utils/editor-effects-cache';
+import {
+  applyTextSpansToEditor,
+  extractEditorEffects,
+} from '@/features/entries/utils/editor-effects-codec';
 import type { ApiClient } from '@/lib/api';
 import { SIDEBAR_WIDTH, useSidebarVisibility } from '@/lib/sidebar-context';
 
@@ -54,6 +63,12 @@ interface EntryEditorProps {
   entryId?: string;
   initialContent?: string;
   initialTitle?: string;
+  /**
+   * Persisted visual effects loaded from the server (or warm cache).
+   * Drives initial canvas traces + DOM eblock/v-block restoration.
+   * Issue #332 — see docs/editor-effects-persistence.md.
+   */
+  initialEffects?: EditorEffectsState | null;
   createdAt?: string;
   updatedAt?: string;
   api: ApiClient | null;
@@ -94,6 +109,7 @@ export function EntryEditor({
   entryId,
   initialContent = '',
   initialTitle,
+  initialEffects = null,
   createdAt: createdAtIso,
   updatedAt: updatedAtIso,
   api,
@@ -232,10 +248,26 @@ export function EntryEditor({
     return () => setSidebarHidden(false);
   }, [uiVisible, setSidebarHidden]);
 
+  // Resolve persisted effects. The server value (passed via prop) is SSoT;
+  // the localStorage cache only fills the gap until the server reply arrives —
+  // and is updated immediately on each save so subsequent reloads feel instant.
+  const cachedInitialEffects = useRef<EditorEffectsState | null>(null);
+  if (cachedInitialEffects.current === null) {
+    cachedInitialEffects.current = loadCachedEffects(entryId);
+  }
+  const effectiveInitialEffects: EditorEffectsState | null =
+    initialEffects ?? cachedInitialEffects.current ?? null;
+
   useGhostEffect(editorRef, ghostLayerRef, settings);
   useAmpEffect(settings.ampEnabled);
   useTimeInscription(editorRef, settings);
-  useEraserTrace(editorRef, traceCanvasRef, settings.eraserTraceEnabled, settings.fontSize);
+  const { getTracesSnapshot } = useEraserTrace(
+    editorRef,
+    traceCanvasRef,
+    settings.eraserTraceEnabled,
+    settings.fontSize,
+    effectiveInitialEffects?.eraserTraces,
+  );
   usePressureBleed(
     editorRef,
     settings.timeInscriptionEnabled && settings.timeInscriptionMode === 'pressureBleed',
@@ -300,6 +332,7 @@ export function EntryEditor({
   }, [hasUnsavedChanges]);
 
   const initialContentStable = initialContent;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effectiveInitialEffects is hydrated once per entry-switch; we intentionally don't rerun on its identity changing during the editing session
   useEffect(() => {
     if (entryId) {
       const p = splitTitleBody(initialContentStable);
@@ -308,6 +341,9 @@ export function EntryEditor({
       setSavedContent(p.body);
       if (editorRef.current && p.body) {
         editorRef.current.textContent = p.body;
+        if (effectiveInitialEffects?.textSpans?.length) {
+          applyTextSpansToEditor(editorRef.current, effectiveInitialEffects.textSpans);
+        }
       }
     } else {
       setContent(initialContentStable);
@@ -337,14 +373,31 @@ export function EntryEditor({
       const linkedCountBeforeSave = linkedIds.size;
       const justPickled = options.fermentationEnabled === true;
 
+      // Issue #332: スナップショットを取って effects を save payload に同梱する。
+      // editor DOM が存在しなければ null（既存値を維持）を送る。
+      const effectsSnapshot = editorRef.current
+        ? extractEditorEffects(editorRef.current, getTracesSnapshot())
+        : null;
+
+      const saveOptions: {
+        fermentationEnabled?: boolean;
+        effects?: EditorEffectsState | null;
+      } = {};
+      if (options.fermentationEnabled !== undefined) {
+        saveOptions.fermentationEnabled = options.fermentationEnabled;
+      }
+      if (editorRef.current) {
+        saveOptions.effects = effectsSnapshot;
+      }
+
       const savedId = await save(
         finalContent,
         targetId,
-        options.fermentationEnabled !== undefined
-          ? { fermentationEnabled: options.fermentationEnabled }
-          : undefined,
+        Object.keys(saveOptions).length > 0 ? saveOptions : undefined,
       );
       if (savedId) {
+        // localStorage warm cache を即時更新（次回オープン時の遅延ゼロ表示用）
+        saveCachedEffects(savedId, effectsSnapshot);
         setTitle(newTitle.trim());
         setSavedContent(content);
         setCurrentEntryId(savedId);
@@ -410,6 +463,7 @@ export function EntryEditor({
       createdAtIso,
       t,
       userMe,
+      getTracesSnapshot,
     ],
   );
 

--- a/apps/client/src/features/entries/hooks/use-entry.ts
+++ b/apps/client/src/features/entries/hooks/use-entry.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import type { EditorEffectsState } from '@oryzae/shared';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState } from 'react';
 import type { ApiClient } from '@/lib/api';
@@ -7,6 +8,7 @@ import type { ApiClient } from '@/lib/api';
 interface EntryDetail {
   id: string;
   content: string;
+  effects: EditorEffectsState | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -30,6 +32,7 @@ export function useEntry(id: string, api: ApiClient | null, authLoading: boolean
           setEntry({
             id: e.id,
             content: e.content,
+            effects: e.effects ?? null,
             createdAt: e.createdAt,
             updatedAt: e.updatedAt,
           });
@@ -44,6 +47,8 @@ export function useEntry(id: string, api: ApiClient | null, authLoading: boolean
 
 interface SaveOptions {
   fermentationEnabled?: boolean;
+  // undefined → 既存を維持 / null → クリア / state → 差し替え
+  effects?: EditorEffectsState | null;
 }
 
 export function useSaveEntry(api: ApiClient | null, _auth: AuthState | null) {
@@ -66,6 +71,9 @@ export function useSaveEntry(api: ApiClient | null, _auth: AuthState | null) {
       };
       if (options?.fermentationEnabled !== undefined) {
         payload.fermentationEnabled = options.fermentationEnabled;
+      }
+      if (options?.effects !== undefined) {
+        payload.effects = options.effects;
       }
       const body = JSON.stringify(payload);
 

--- a/apps/client/src/features/entries/hooks/use-eraser-trace.ts
+++ b/apps/client/src/features/entries/hooks/use-eraser-trace.ts
@@ -121,16 +121,33 @@ function charRangeBefore(sel: Selection): Range | null {
   return null;
 }
 
+/**
+ * 戻り値 `getTracesSnapshot` で現在の trace 配列のコピーを取得できる。
+ * エディタの保存時にこのスナップショットを extract に渡すことで、消し跡を永続化する。
+ */
+interface UseEraserTraceResult {
+  getTracesSnapshot: () => Trace[];
+}
+
 export function useEraserTrace(
   editorRef: React.RefObject<HTMLDivElement | null>,
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
   enabled: boolean,
   fontSize: number,
-) {
+  initialTraces?: Trace[],
+): UseEraserTraceResult {
   const tracesRef = useRef<Trace[]>([]);
   const pendingRef = useRef<PendingDel | null>(null);
   const smudgeCacheRef = useRef(new Map<string, HTMLCanvasElement>());
   const redrawQueuedRef = useRef(false);
+  // Hydrate persisted traces once on mount and whenever a fresh batch comes in
+  // (e.g. entry switch). We seed only when the incoming reference changes —
+  // typing-time mutations stay in tracesRef.
+  const lastInitialRef = useRef<Trace[] | undefined>(undefined);
+  if (initialTraces !== lastInitialRef.current) {
+    lastInitialRef.current = initialTraces;
+    tracesRef.current = initialTraces ? initialTraces.map((t) => ({ ...t })) : [];
+  }
 
   useEffect(() => {
     const editor = editorRef.current;
@@ -257,6 +274,9 @@ export function useEraserTrace(
     editor.addEventListener('scroll', requestRedraw);
     window.addEventListener('resize', resizeCanvas);
 
+    // Render any hydrated traces immediately so the canvas paints on mount.
+    if (tracesRef.current.length > 0) requestRedraw();
+
     return () => {
       editor.removeEventListener('beforeinput', onBeforeInput);
       editor.removeEventListener('input', onInput);
@@ -265,4 +285,8 @@ export function useEraserTrace(
       smudgeCacheRef.current.clear();
     };
   }, [editorRef, canvasRef, enabled, fontSize]);
+
+  return {
+    getTracesSnapshot: () => tracesRef.current.map((t) => ({ ...t })),
+  };
 }

--- a/apps/client/src/features/entries/utils/editor-effects-cache.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-cache.ts
@@ -1,0 +1,40 @@
+import type { EditorEffectsState } from '@oryzae/shared';
+
+/**
+ * localStorage キャッシュ層。
+ * DB が SSoT、これは「保存直後の即時反映 / 取得待ちの隙間に過去の effects を見せる」
+ * ための warm cache。Issue #332 参照。
+ *
+ * 失敗（quota 超過 / SSR / 私的閲覧モード等）は黙って握る。
+ */
+
+const PREFIX = 'oryzae-entry-effects:';
+
+export function loadCachedEffects(entryId: string | undefined): EditorEffectsState | null {
+  if (!entryId || typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(PREFIX + entryId);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed as EditorEffectsState;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCachedEffects(
+  entryId: string | undefined,
+  effects: EditorEffectsState | null,
+): void {
+  if (!entryId || typeof window === 'undefined') return;
+  try {
+    if (effects == null) {
+      window.localStorage.removeItem(PREFIX + entryId);
+      return;
+    }
+    window.localStorage.setItem(PREFIX + entryId, JSON.stringify(effects));
+  } catch {
+    // ignore (quota etc.)
+  }
+}

--- a/apps/client/src/features/entries/utils/editor-effects-codec.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-codec.ts
@@ -1,0 +1,290 @@
+import type { EditorEffectsState, TextSpanMark } from '@oryzae/shared';
+
+/**
+ * editor の DOM ↔ `EditorEffectsState` のシリアライズ/デシリアライズ。
+ * Issue #332 — 視覚エフェクトをエントリに紐づけて永続化する。
+ *
+ * 文字オフセットの基準は `editor.innerText`（既存の保存ロジックと一致）:
+ *   - text node はそのままの文字数を消費
+ *   - `<br>` は 1 文字 (`\n`)
+ *   - block element (`<div>` 等) は、前にコンテンツがあれば content の前に 1 文字 (`\n`)
+ *
+ * span (eblock / v-block) はその子テキストの長さ分を消費する。子要素には潜らない。
+ */
+
+const EBLOCK_CLASS = 'eblock';
+const VBLOCK_CLASS = 'v-block';
+
+interface TraceLike {
+  rx: number;
+  ry: number;
+  w: number;
+  h: number;
+  chars: string[];
+  intensity: number;
+  seed: number;
+}
+
+/** editor DOM を走査して `EditorEffectsState` を組み立てる。 */
+export function extractEditorEffects(
+  editor: HTMLElement,
+  eraserTraces: TraceLike[] | undefined,
+): EditorEffectsState | null {
+  const textSpans = scanTextSpans(editor);
+  const tracesSnapshot = eraserTraces && eraserTraces.length > 0 ? eraserTraces : undefined;
+
+  if (textSpans.length === 0 && !tracesSnapshot) return null;
+
+  return {
+    version: 1,
+    ...(textSpans.length > 0 ? { textSpans } : {}),
+    ...(tracesSnapshot ? { eraserTraces: tracesSnapshot.map((t) => ({ ...t })) } : {}),
+  };
+}
+
+/**
+ * 保存された effects を editor DOM に再適用する。
+ * - editor.textContent はすでに plain text がセットされている前提。
+ * - textSpans を `start` 昇順で走査し、対応する text node 区間を `<span>` で wrap。
+ * - eraserTraces の再描画は呼び出し側（useEraserTrace に initial state として渡す）。
+ */
+export function applyTextSpansToEditor(editor: HTMLElement, spans: TextSpanMark[]): void {
+  if (spans.length === 0) return;
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  for (const span of sorted) {
+    if (span.start >= span.end) continue;
+    wrapRange(editor, span);
+  }
+}
+
+// -- internals -------------------------------------------------------------
+
+function isBlock(el: HTMLElement): boolean {
+  const tag = el.tagName;
+  return tag === 'DIV' || tag === 'P' || tag === 'LI' || tag === 'BLOCKQUOTE' || tag === 'PRE';
+}
+
+function isEffectSpan(el: HTMLElement): boolean {
+  return el.classList.contains(EBLOCK_CLASS) || el.classList.contains(VBLOCK_CLASS);
+}
+
+interface ScanState {
+  cursor: number;
+  marks: TextSpanMark[];
+}
+
+function scanTextSpans(editor: HTMLElement): TextSpanMark[] {
+  const state: ScanState = { cursor: 0, marks: [] };
+  walkScan(editor, state);
+  return state.marks;
+}
+
+function walkScan(node: Node, state: ScanState): void {
+  const children = node.childNodes;
+  for (let i = 0; i < children.length; i++) {
+    visitScan(children[i], state);
+  }
+}
+
+function visitScan(node: Node, state: ScanState): void {
+  if (node.nodeType === Node.TEXT_NODE) {
+    state.cursor += (node.textContent ?? '').length;
+    return;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+  const el = node as HTMLElement;
+  if (el.tagName === 'BR') {
+    state.cursor += 1;
+    return;
+  }
+  if (isBlock(el) && state.cursor > 0) {
+    state.cursor += 1;
+  }
+  if (isEffectSpan(el)) {
+    const text = el.textContent ?? '';
+    const start = state.cursor;
+    const end = start + text.length;
+    const mark = markFromElement(el, start, end);
+    if (mark) state.marks.push(mark);
+    state.cursor = end;
+    return;
+  }
+  walkScan(el, state);
+}
+
+function markFromElement(el: HTMLElement, start: number, end: number): TextSpanMark | null {
+  if (el.classList.contains(VBLOCK_CLASS)) {
+    const em = parseEm(el.style.fontSize);
+    if (em == null) return null;
+    return { kind: 'voice', start, end, fontSizeEm: em };
+  }
+  const mode = el.dataset.mode;
+  if (mode === 'pressureBleed') {
+    const intensity = Number.parseFloat(el.dataset.intensity ?? '');
+    const seed = Number.parseInt(el.dataset.seed ?? '', 10);
+    if (!Number.isFinite(intensity) || !Number.isFinite(seed)) return null;
+    return { kind: 'pressure', start, end, intensity, seed };
+  }
+  if (mode === 'fontSize' || mode === 'fontWeight') {
+    const t = Number.parseFloat(el.dataset.t ?? '');
+    const duration = Number.parseFloat(el.dataset.duration ?? '');
+    if (!Number.isFinite(t) || !Number.isFinite(duration)) return null;
+    return { kind: 'time', start, end, mode, t, duration };
+  }
+  return null;
+}
+
+function parseEm(input: string): number | null {
+  if (!input.endsWith('em')) return null;
+  const n = Number.parseFloat(input.slice(0, -2));
+  return Number.isFinite(n) ? n : null;
+}
+
+interface LocatedRange {
+  startNode: Node;
+  startOffset: number;
+  endNode: Node;
+  endOffset: number;
+}
+
+interface LocateState {
+  cursor: number;
+  startNode: Node | null;
+  startOffset: number;
+  endNode: Node | null;
+  endOffset: number;
+  start: number;
+  end: number;
+}
+
+function locateRange(editor: HTMLElement, start: number, end: number): LocatedRange | null {
+  const state: LocateState = {
+    cursor: 0,
+    startNode: null,
+    startOffset: 0,
+    endNode: null,
+    endOffset: 0,
+    start,
+    end,
+  };
+  walkLocate(editor, state);
+  if (!state.startNode || !state.endNode) return null;
+  return {
+    startNode: state.startNode,
+    startOffset: state.startOffset,
+    endNode: state.endNode,
+    endOffset: state.endOffset,
+  };
+}
+
+function walkLocate(node: Node, state: LocateState): void {
+  const children = node.childNodes;
+  for (let i = 0; i < children.length; i++) {
+    if (state.startNode && state.endNode) return;
+    visitLocate(children[i], state);
+  }
+}
+
+function visitLocate(node: Node, state: LocateState): void {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const len = (node.textContent ?? '').length;
+    const segStart = state.cursor;
+    const segEnd = segStart + len;
+    if (!state.startNode && state.start >= segStart && state.start <= segEnd) {
+      state.startNode = node;
+      state.startOffset = state.start - segStart;
+    }
+    if (!state.endNode && state.end >= segStart && state.end <= segEnd) {
+      state.endNode = node;
+      state.endOffset = state.end - segStart;
+    }
+    state.cursor = segEnd;
+    return;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+  const el = node as HTMLElement;
+  if (el.tagName === 'BR') {
+    state.cursor += 1;
+    return;
+  }
+  if (isBlock(el) && state.cursor > 0) state.cursor += 1;
+  if (isEffectSpan(el)) {
+    // Treat the whole span as one opaque text run — we don't allow wrapping
+    // ranges that overlap an existing effect span, so skip recursion.
+    state.cursor += (el.textContent ?? '').length;
+    return;
+  }
+  walkLocate(el, state);
+}
+
+function wrapRange(editor: HTMLElement, mark: TextSpanMark): void {
+  const located = locateRange(editor, mark.start, mark.end);
+  if (!located) return;
+  const { startNode, startOffset, endNode, endOffset } = located;
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    const span = document.createElement('span');
+    decorateSpan(span, mark);
+    range.surroundContents(span);
+  } catch {
+    // surroundContents throws if the range crosses non-text boundaries.
+    // Effects spanning block boundaries aren't supported on restore — skip silently.
+  }
+}
+
+function decorateSpan(span: HTMLSpanElement, mark: TextSpanMark): void {
+  if (mark.kind === 'voice') {
+    span.className = VBLOCK_CLASS;
+    span.style.fontSize = `${mark.fontSizeEm.toFixed(2)}em`;
+    return;
+  }
+  span.className = EBLOCK_CLASS;
+  if (mark.kind === 'time') {
+    span.dataset.t = mark.t.toFixed(4);
+    span.dataset.duration = String(mark.duration);
+    span.dataset.mode = mark.mode;
+    if (mark.mode === 'fontWeight') {
+      span.style.fontWeight = String(Math.round(300 + (700 - 300) * mark.t));
+    } else {
+      const scale = 0.8 + (1.35 - 0.8) * mark.t;
+      span.style.fontSize = `${(16 * scale).toFixed(1)}px`;
+    }
+    return;
+  }
+  span.dataset.intensity = mark.intensity.toFixed(4);
+  span.dataset.seed = String(mark.seed);
+  span.dataset.mode = 'pressureBleed';
+  span.style.textShadow = buildBleedShadow(mark.intensity, mark.seed);
+  const filterBlur = mark.intensity * 0.18;
+  span.style.filter = filterBlur > 0.05 ? `blur(${filterBlur.toFixed(2)}px)` : 'none';
+  const ls = mark.intensity * 0.02;
+  span.style.letterSpacing = ls > 0.005 ? `${ls.toFixed(3)}em` : 'normal';
+}
+
+function buildBleedShadow(intensity: number, seed: number): string {
+  if (intensity < 0.01) return 'none';
+  let s = seed | 0;
+  const rng = () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return s / 0x7fffffff;
+  };
+  const numLayers = Math.floor(4 + intensity * 10);
+  const shadows: string[] = [];
+  for (let i = 0; i < numLayers; i++) {
+    const angle = rng() * Math.PI * 2;
+    const dist = rng() * intensity;
+    const ox = dist * Math.cos(angle);
+    const oy = dist * Math.sin(angle);
+    const blur = 0.2 + rng() * rng() * intensity * 2.5;
+    const r = 40 + Math.floor(rng() * 30);
+    const g = 30 + Math.floor(rng() * 25);
+    const b = 20 + Math.floor(rng() * 20);
+    const alpha = (0.02 + rng() * intensity * 0.15).toFixed(3);
+    shadows.push(
+      `${ox.toFixed(2)}px ${oy.toFixed(2)}px ${blur.toFixed(1)}px rgba(${r},${g},${b},${alpha})`,
+    );
+  }
+  return shadows.join(', ');
+}

--- a/apps/client/src/features/fermentation/components/pickle-success-modal.tsx
+++ b/apps/client/src/features/fermentation/components/pickle-success-modal.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+import { BRAND_MARK_SVG, svgDataUri } from '@/lib/brand';
+
+interface PickleSuccessModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const BRAND_MARK_DATA_URI = svgDataUri(BRAND_MARK_SVG);
+
+/**
+ * Issue #322: 漬け込みアニメーション後の Jar 画面で、漬け込み完了を
+ * 知らせるグラフィカルなメッセージモーダル。ブランドマークを添えて
+ * 楽しい印象を演出する。
+ */
+export function PickleSuccessModal({ open, onClose }: PickleSuccessModalProps) {
+  const t = useTranslations('fermentation.jar.pickle_success_modal');
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('aria_label')}
+      className="fixed inset-0 z-[2000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') onClose();
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="w-[90%] max-w-[440px] rounded-xl shadow-lg"
+        style={{ backgroundColor: 'var(--bg)', padding: '32px 32px 28px' }}
+      >
+        <div className="mb-4 flex justify-center">
+          <Image
+            src={BRAND_MARK_DATA_URI}
+            alt=""
+            width={80}
+            height={80}
+            className="select-none"
+            draggable={false}
+            unoptimized
+          />
+        </div>
+        <h3 className="mb-3 text-center text-sm font-semibold" style={{ color: 'var(--fg)' }}>
+          {t('heading')}
+        </h3>
+        <p className="mb-6 text-center text-xs leading-relaxed" style={{ color: 'var(--fg)' }}>
+          {t('body')}
+        </p>
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-5 py-2 text-xs"
+            style={{
+              borderColor: 'var(--accent)',
+              color: 'var(--accent)',
+              backgroundColor: 'var(--bg)',
+            }}
+          >
+            {t('dismiss')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/i18n/messages/en.json
+++ b/apps/client/src/i18n/messages/en.json
@@ -119,7 +119,10 @@
       "results_count": "{count} results",
       "week_label": "Week {n}",
       "load_more_loading": "Loading...",
-      "load_more": "Load more"
+      "load_more": "Load more",
+      "filter_by_question_label": "Filter by question",
+      "filter_all_questions": "All questions",
+      "filter_clear_aria": "Clear filter"
     },
     "leave_modal": {
       "aria_label": "Leave confirmation dialog",
@@ -485,7 +488,13 @@
       "add_placeholder": "Enter your question",
       "cancel_add": "Cancel",
       "adding": "Adding...",
-      "add_submit": "Add"
+      "add_submit": "Add",
+      "pickle_success_modal": {
+        "body": "Your text and question have been pickled in the jar. Keep writing in your journal while you look forward to the fermentation progressing.",
+        "dismiss": "Got it",
+        "aria_label": "Pickling complete notification",
+        "heading": "Pickled in the jar"
+      }
     }
   },
   "questions": {

--- a/apps/client/src/i18n/messages/ja.json
+++ b/apps/client/src/i18n/messages/ja.json
@@ -119,7 +119,10 @@
       "results_count": "{count}件の結果",
       "week_label": "第{n}週",
       "load_more_loading": "読み込み中...",
-      "load_more": "もっと見る"
+      "load_more": "もっと見る",
+      "filter_by_question_label": "問いで絞り込む",
+      "filter_all_questions": "すべての問い",
+      "filter_clear_aria": "フィルタを解除"
     },
     "leave_modal": {
       "aria_label": "離脱確認ダイアログ",
@@ -485,7 +488,13 @@
       "add_placeholder": "あなたの問いを入力してください",
       "cancel_add": "キャンセル",
       "adding": "追加中...",
-      "add_submit": "追加する"
+      "add_submit": "追加する",
+      "pickle_success_modal": {
+        "body": "あなたのテキストと問いが発酵瓶に漬け込まれました。発酵が進むのを楽しみに待ちながら、ジャーナルを続けてください。",
+        "dismiss": "わかりました",
+        "aria_label": "漬け込み完了のお知らせ",
+        "heading": "発酵瓶に漬け込まれました"
+      }
     }
   },
   "questions": {

--- a/apps/client/src/i18n/messages/ko.json
+++ b/apps/client/src/i18n/messages/ko.json
@@ -119,7 +119,10 @@
       "results_count": "{count}건의 결과",
       "week_label": "{n}주차",
       "load_more_loading": "불러오는 중...",
-      "load_more": "더 보기"
+      "load_more": "더 보기",
+      "filter_by_question_label": "질문으로 필터",
+      "filter_all_questions": "모든 질문",
+      "filter_clear_aria": "필터 지우기"
     },
     "leave_modal": {
       "aria_label": "이탈 확인 대화상자",
@@ -485,7 +488,13 @@
       "add_placeholder": "질문을 입력해 주세요",
       "cancel_add": "취소",
       "adding": "추가하는 중...",
-      "add_submit": "추가하기"
+      "add_submit": "추가하기",
+      "pickle_success_modal": {
+        "body": "당신의 글과 질문이 발효 항아리에 절여졌습니다. 발효가 진행되는 것을 기대하며 일기를 계속 써 주세요.",
+        "dismiss": "알겠습니다",
+        "aria_label": "절임 완료 알림",
+        "heading": "발효 항아리에 절여졌습니다"
+      }
     }
   },
   "questions": {

--- a/apps/client/src/i18n/messages/zh.json
+++ b/apps/client/src/i18n/messages/zh.json
@@ -119,7 +119,10 @@
       "results_count": "{count} 条结果",
       "week_label": "第 {n} 周",
       "load_more_loading": "加载中...",
-      "load_more": "加载更多"
+      "load_more": "加载更多",
+      "filter_by_question_label": "按问题筛选",
+      "filter_all_questions": "所有问题",
+      "filter_clear_aria": "清除筛选"
     },
     "leave_modal": {
       "aria_label": "离开确认对话框",
@@ -485,7 +488,13 @@
       "add_placeholder": "请输入你的提问",
       "cancel_add": "取消",
       "adding": "添加中...",
-      "add_submit": "添加"
+      "add_submit": "添加",
+      "pickle_success_modal": {
+        "body": "您的文字与问题已被腌入发酵瓶。请一边期待发酵的进展，一边继续书写您的日记。",
+        "dismiss": "知道了",
+        "aria_label": "腌制完成通知",
+        "heading": "已腌入发酵瓶"
+      }
     }
   },
   "questions": {

--- a/apps/client/test/features/entries/hooks/use-entry.test.ts
+++ b/apps/client/test/features/entries/hooks/use-entry.test.ts
@@ -29,7 +29,13 @@ describe('useEntry', () => {
   });
 
   it('fetches entry by id', async () => {
-    const entry = { id: 'e1', content: 'hello', createdAt: '2024-01-01', updatedAt: '2024-01-01' };
+    const entry = {
+      id: 'e1',
+      content: 'hello',
+      effects: null,
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+    };
     apiFetch.mockResolvedValueOnce(mockResponse(true, { entry }));
     const api = createMockApi(apiFetch);
 

--- a/apps/client/test/features/entries/hooks/use-eraser-trace.test.ts
+++ b/apps/client/test/features/entries/hooks/use-eraser-trace.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEraserTrace } from '@/features/entries/hooks/use-eraser-trace';
+
+function stubCanvasContext() {
+  const drawImage = vi.fn();
+  const ctxStub = {
+    clearRect: vi.fn(),
+    setTransform: vi.fn(),
+    drawImage,
+    fillText: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    stroke: vi.fn(),
+    filter: '',
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    textBaseline: '',
+    textAlign: '',
+    lineWidth: 0,
+    globalAlpha: 1,
+  };
+  HTMLCanvasElement.prototype.getContext = vi.fn(
+    () => ctxStub,
+  ) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  return { drawImage };
+}
+
+describe('useEraserTrace persistence wiring', () => {
+  let editor: HTMLDivElement;
+  let canvas: HTMLCanvasElement;
+  let editorRef: { current: HTMLDivElement | null };
+  let canvasRef: { current: HTMLCanvasElement | null };
+
+  beforeEach(() => {
+    editor = document.createElement('div');
+    editor.contentEditable = 'true';
+    canvas = document.createElement('canvas');
+    document.body.append(editor, canvas);
+    editorRef = { current: editor };
+    canvasRef = { current: canvas };
+  });
+
+  afterEach(() => {
+    editor.remove();
+    canvas.remove();
+  });
+
+  it('seeds tracesRef from initialTraces and draws them on mount', async () => {
+    const { drawImage } = stubCanvasContext();
+    const initial = [{ rx: 10, ry: 20, w: 16, h: 20, chars: ['a'], intensity: 0.1, seed: 1 }];
+
+    renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, initial));
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(drawImage).toHaveBeenCalled();
+  });
+
+  it('getTracesSnapshot returns a copy of the current traces (not the same reference)', () => {
+    stubCanvasContext();
+    const initial = [{ rx: 5, ry: 6, w: 1, h: 1, chars: ['x'], intensity: 0.07, seed: 0 }];
+
+    const { result } = renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, initial));
+
+    const snap = result.current.getTracesSnapshot();
+    expect(snap).toEqual(initial);
+    expect(snap[0]).not.toBe(initial[0]);
+  });
+
+  it('replaces traces when initialTraces reference changes', () => {
+    stubCanvasContext();
+    const first = [{ rx: 1, ry: 1, w: 1, h: 1, chars: ['a'], intensity: 0.07, seed: 0 }];
+    const second = [
+      { rx: 2, ry: 2, w: 1, h: 1, chars: ['b'], intensity: 0.1, seed: 1 },
+      { rx: 3, ry: 3, w: 1, h: 1, chars: ['c'], intensity: 0.1, seed: 2 },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, traces),
+      { initialProps: { traces: first } },
+    );
+
+    expect(result.current.getTracesSnapshot()).toHaveLength(1);
+    rerender({ traces: second });
+    expect(result.current.getTracesSnapshot()).toHaveLength(2);
+  });
+
+  it('does not reseed when the same initialTraces reference is passed again', () => {
+    stubCanvasContext();
+    const initial = [{ rx: 1, ry: 1, w: 1, h: 1, chars: ['a'], intensity: 0.07, seed: 0 }];
+
+    const { result, rerender } = renderHook(
+      ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, traces),
+      { initialProps: { traces: initial } },
+    );
+
+    // Mutate the snapshot's underlying array via the hook's natural mechanism:
+    // we can't push directly, but we can verify that re-rendering with the same
+    // reference keeps the snapshot stable.
+    const before = result.current.getTracesSnapshot();
+    rerender({ traces: initial });
+    const after = result.current.getTracesSnapshot();
+    expect(after).toEqual(before);
+  });
+});

--- a/apps/client/test/features/entries/utils/editor-effects-cache.test.ts
+++ b/apps/client/test/features/entries/utils/editor-effects-cache.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadCachedEffects,
+  saveCachedEffects,
+} from '@/features/entries/utils/editor-effects-cache';
+
+describe('editor-effects-cache', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when no entry id is provided', () => {
+    expect(loadCachedEffects(undefined)).toBeNull();
+  });
+
+  it('saves and loads an effects payload', () => {
+    saveCachedEffects('e-1', { version: 1, textSpans: [] });
+    expect(loadCachedEffects('e-1')).toEqual({ version: 1, textSpans: [] });
+  });
+
+  it('returns null when localStorage is empty for the id', () => {
+    expect(loadCachedEffects('does-not-exist')).toBeNull();
+  });
+
+  it('removes the entry when saving null', () => {
+    saveCachedEffects('e-1', { version: 1, textSpans: [] });
+    saveCachedEffects('e-1', null);
+    expect(loadCachedEffects('e-1')).toBeNull();
+  });
+
+  it('returns null when stored payload is invalid JSON', () => {
+    window.localStorage.setItem('oryzae-entry-effects:e-1', 'not-json');
+    expect(loadCachedEffects('e-1')).toBeNull();
+  });
+});

--- a/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
+++ b/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyTextSpansToEditor,
+  extractEditorEffects,
+} from '@/features/entries/utils/editor-effects-codec';
+
+describe('editor-effects-codec', () => {
+  let editor: HTMLDivElement;
+
+  beforeEach(() => {
+    editor = document.createElement('div');
+    editor.contentEditable = 'true';
+    document.body.appendChild(editor);
+  });
+
+  afterEach(() => {
+    editor.remove();
+  });
+
+  describe('extractEditorEffects', () => {
+    it('returns null when there are no spans and no traces', () => {
+      editor.textContent = 'plain text';
+      expect(extractEditorEffects(editor, undefined)).toBeNull();
+      expect(extractEditorEffects(editor, [])).toBeNull();
+    });
+
+    it('extracts a fontSize eblock span at the right character offset', () => {
+      editor.innerHTML =
+        'ab<span class="eblock" data-mode="fontSize" data-t="0.5000" data-duration="200">c</span>de';
+
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toEqual([
+        { kind: 'time', start: 2, end: 3, mode: 'fontSize', t: 0.5, duration: 200 },
+      ]);
+    });
+
+    it('extracts a pressureBleed eblock span', () => {
+      editor.innerHTML =
+        'x<span class="eblock" data-mode="pressureBleed" data-intensity="0.4500" data-seed="123">y</span>';
+
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toEqual([
+        { kind: 'pressure', start: 1, end: 2, intensity: 0.45, seed: 123 },
+      ]);
+    });
+
+    it('extracts a v-block (voice) span with fontSize in em', () => {
+      editor.innerHTML = 'pre <span class="v-block" style="font-size: 2.50em">声</span> post';
+
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toEqual([{ kind: 'voice', start: 4, end: 5, fontSizeEm: 2.5 }]);
+    });
+
+    it('counts <br> as one newline and <div> boundaries as newlines', () => {
+      // mimic what contentEditable produces: text + <div>more</div>
+      editor.innerHTML =
+        'a<br>b<div>c<span class="eblock" data-mode="fontSize" data-t="0.1" data-duration="100">d</span></div>';
+
+      const state = extractEditorEffects(editor, undefined);
+      // 'a' (0) + '\n' from <br> (1) + 'b' (2) + '\n' from <div> boundary (3) + 'c' (4)
+      // span 'd' starts at 5
+      expect(state?.textSpans).toEqual([
+        { kind: 'time', start: 5, end: 6, mode: 'fontSize', t: 0.1, duration: 100 },
+      ]);
+    });
+
+    it('includes eraserTraces snapshot when provided', () => {
+      const traces = [{ rx: 1, ry: 2, w: 3, h: 4, chars: ['a'], intensity: 0.1, seed: 9 }];
+      editor.textContent = 'text';
+      const state = extractEditorEffects(editor, traces);
+      expect(state?.eraserTraces).toEqual(traces);
+      // returned traces should be a copy, not the same reference
+      expect(state?.eraserTraces?.[0]).not.toBe(traces[0]);
+    });
+  });
+
+  describe('applyTextSpansToEditor', () => {
+    it('wraps the requested character range with an eblock span (fontSize)', () => {
+      editor.textContent = 'abcde';
+
+      applyTextSpansToEditor(editor, [
+        { kind: 'time', start: 2, end: 3, mode: 'fontSize', t: 0.5, duration: 200 },
+      ]);
+
+      const span = editor.querySelector('span.eblock');
+      expect(span?.textContent).toBe('c');
+      expect(span?.getAttribute('data-mode')).toBe('fontSize');
+      expect(span?.getAttribute('data-t')).toBe('0.5000');
+    });
+
+    it('wraps a voice span', () => {
+      editor.textContent = 'hello';
+      applyTextSpansToEditor(editor, [{ kind: 'voice', start: 0, end: 5, fontSizeEm: 3 }]);
+      const span = editor.querySelector('span.v-block');
+      expect(span?.textContent).toBe('hello');
+      const style = (span as HTMLElement | null)?.style.fontSize;
+      // jsdom normalizes "3.00em" → "3em"; just check that font-size is set
+      expect(style).toMatch(/^3(\.\d+)?em$/);
+    });
+
+    it('applies multiple non-overlapping spans in order', () => {
+      editor.textContent = '123456';
+      applyTextSpansToEditor(editor, [
+        { kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.3, duration: 100 },
+        { kind: 'pressure', start: 4, end: 5, intensity: 0.5, seed: 7 },
+      ]);
+      const spans = editor.querySelectorAll('span.eblock');
+      expect(spans).toHaveLength(2);
+      expect(spans[0].textContent).toBe('1');
+      expect(spans[1].textContent).toBe('5');
+    });
+
+    it('round-trips extract → apply → extract', () => {
+      editor.innerHTML =
+        'ab<span class="eblock" data-mode="fontSize" data-t="0.7500" data-duration="500">c</span><span class="eblock" data-mode="pressureBleed" data-intensity="0.6200" data-seed="42">d</span>e';
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toHaveLength(2);
+
+      // Now re-create from plain text + state
+      const rebuilt = document.createElement('div');
+      rebuilt.textContent = 'abcde';
+      applyTextSpansToEditor(rebuilt, state?.textSpans ?? []);
+
+      const round2 = extractEditorEffects(rebuilt, undefined);
+      expect(round2?.textSpans).toEqual(state?.textSpans);
+    });
+
+    it('silently skips invalid (start >= end) marks', () => {
+      editor.textContent = 'abc';
+      applyTextSpansToEditor(editor, [
+        { kind: 'time', start: 2, end: 2, mode: 'fontSize', t: 0.5, duration: 100 },
+      ]);
+      expect(editor.querySelector('span.eblock')).toBeNull();
+    });
+  });
+});

--- a/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/create-entry.usecase.ts
@@ -1,3 +1,4 @@
+import type { EditorEffectsState } from '@oryzae/shared';
 import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
 import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
 import { Entry, type EntryProps } from '../../domain/models/entry.js';
@@ -11,6 +12,7 @@ interface CreateEntryInput {
   editorVersion: string;
   extension: Record<string, unknown>;
   fermentationEnabled?: boolean;
+  effects?: EditorEffectsState | null;
 }
 
 export class CreateEntryUsecase {
@@ -27,6 +29,7 @@ export class CreateEntryUsecase {
         content: input.content,
         mediaUrls: input.mediaUrls,
         fermentationEnabled: input.fermentationEnabled ?? false,
+        effects: input.effects ?? null,
       },
       this.generateId,
     );

--- a/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
+++ b/apps/server/src/contexts/entry/application/usecases/update-entry.usecase.ts
@@ -1,3 +1,4 @@
+import type { EditorEffectsState } from '@oryzae/shared';
 import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
 import type { EntrySnapshotRepositoryGateway } from '../../domain/gateways/entry-snapshot-repository.gateway.js';
 import type { EntryProps } from '../../domain/models/entry.js';
@@ -11,6 +12,8 @@ interface UpdateEntryInput {
   editorVersion: string;
   extension: Record<string, unknown>;
   fermentationEnabled?: boolean;
+  // undefined → 既存値を維持 / null → 明示的にクリア / object → 差し替え
+  effects?: EditorEffectsState | null;
 }
 
 export class UpdateEntryUsecase {
@@ -24,7 +27,11 @@ export class UpdateEntryUsecase {
     const existing = await this.entryRepo.findById(entryId);
     if (!existing) throw new EntryNotFoundError(entryId);
 
-    const contentUpdatedResult = existing.withContent(input.content, input.mediaUrls);
+    const contentUpdatedResult = existing.withContent(
+      input.content,
+      input.mediaUrls,
+      input.effects,
+    );
     if (!contentUpdatedResult.success) {
       throw new EntryValidationError(contentUpdatedResult.error.message);
     }

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -15,7 +15,7 @@ type EntryError =
  * Forward-compat: unknown `kind` values are ignored on apply (client-side),
  * so it's safe to extend the discriminated union without bumping version.
  */
-export interface EditorEffectsState {
+interface EditorEffectsState {
   version: 1;
   eraserTraces?: EraserTracePayload[];
   textSpans?: TextSpanMark[];

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -1,9 +1,47 @@
-import type { EditorEffectsState } from '@oryzae/shared';
 import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
 type EntryError =
   | { type: 'EMPTY_CONTENT'; message: string }
   | { type: 'CONTENT_TOO_LONG'; message: string };
+
+/**
+ * Editor visual effects state — persisted with the entry.
+ *
+ * Defined locally in the domain (rather than imported from `@oryzae/shared`)
+ * because the domain layer must stay zod-free per `domain-no-shared-package`.
+ * Shared owns the matching zod schema for boundary validation; structural
+ * typing makes the two definitions interchangeable.
+ *
+ * Forward-compat: unknown `kind` values are ignored on apply (client-side),
+ * so it's safe to extend the discriminated union without bumping version.
+ */
+export interface EditorEffectsState {
+  version: 1;
+  eraserTraces?: EraserTracePayload[];
+  textSpans?: TextSpanMark[];
+}
+
+interface EraserTracePayload {
+  rx: number;
+  ry: number;
+  w: number;
+  h: number;
+  chars: string[];
+  intensity: number;
+  seed: number;
+}
+
+type TextSpanMark =
+  | {
+      kind: 'time';
+      start: number;
+      end: number;
+      mode: 'fontSize' | 'fontWeight';
+      t: number;
+      duration: number;
+    }
+  | { kind: 'pressure'; start: number; end: number; intensity: number; seed: number }
+  | { kind: 'voice'; start: number; end: number; fontSizeEm: number };
 
 export interface EntryProps {
   id: string;

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -1,3 +1,4 @@
+import type { EditorEffectsState } from '@oryzae/shared';
 import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
 type EntryError =
@@ -10,6 +11,7 @@ export interface EntryProps {
   content: string;
   mediaUrls: string[];
   fermentationEnabled: boolean;
+  effects: EditorEffectsState | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -19,6 +21,7 @@ interface CreateEntryParams {
   content: string;
   mediaUrls: string[];
   fermentationEnabled: boolean;
+  effects?: EditorEffectsState | null;
 }
 
 const MAX_CONTENT_LENGTH = 100_000;
@@ -29,6 +32,7 @@ export class Entry {
   readonly content: string;
   readonly mediaUrls: string[];
   readonly fermentationEnabled: boolean;
+  readonly effects: EditorEffectsState | null;
   readonly createdAt: string;
   readonly updatedAt: string;
 
@@ -38,6 +42,7 @@ export class Entry {
     this.content = props.content;
     this.mediaUrls = props.mediaUrls;
     this.fermentationEnabled = props.fermentationEnabled;
+    this.effects = props.effects;
     this.createdAt = props.createdAt;
     this.updatedAt = props.updatedAt;
   }
@@ -54,6 +59,7 @@ export class Entry {
         content: params.content,
         mediaUrls: params.mediaUrls,
         fermentationEnabled: params.fermentationEnabled,
+        effects: params.effects ?? null,
         createdAt: now,
         updatedAt: now,
       }),
@@ -64,7 +70,11 @@ export class Entry {
     return new Entry(props);
   }
 
-  withContent(content: string, mediaUrls: string[]): Result<Entry, EntryError> {
+  withContent(
+    content: string,
+    mediaUrls: string[],
+    effects?: EditorEffectsState | null,
+  ): Result<Entry, EntryError> {
     const validationError = Entry.validateContent(content);
     if (validationError) return err(validationError);
 
@@ -73,6 +83,7 @@ export class Entry {
         ...this.toProps(),
         content,
         mediaUrls,
+        effects: effects === undefined ? this.effects : effects,
         updatedAt: new Date().toISOString(),
       }),
     );
@@ -93,6 +104,7 @@ export class Entry {
       content: this.content,
       mediaUrls: this.mediaUrls,
       fermentationEnabled: this.fermentationEnabled,
+      effects: this.effects,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
+++ b/apps/server/src/contexts/entry/infrastructure/repositories/supabase-entry.repository.ts
@@ -1,3 +1,4 @@
+import { type EditorEffectsState, editorEffectsStateSchema } from '@oryzae/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { EntryRepositoryGateway } from '../../domain/gateways/entry-repository.gateway.js';
 import { Entry } from '../../domain/models/entry.js';
@@ -159,6 +160,7 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
       content: props.content,
       media_urls: props.mediaUrls,
       fermentation_enabled: props.fermentationEnabled,
+      effects: props.effects ?? {},
       created_at: props.createdAt,
       updated_at: props.updatedAt,
     });
@@ -177,8 +179,19 @@ export class SupabaseEntryRepository implements EntryRepositoryGateway {
       content: row.content as string,
       mediaUrls: (row.media_urls as string[]) ?? [],
       fermentationEnabled: (row.fermentation_enabled as boolean) ?? false,
+      effects: parseEffects(row.effects),
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
     });
   }
+}
+
+// Parse the `effects` JSONB column. Older rows have `{}` (default), which we
+// treat as "no effects" (null). Unknown shapes are also coerced to null so a
+// malformed row doesn't break entry reads.
+function parseEffects(raw: unknown): EditorEffectsState | null {
+  if (!raw || typeof raw !== 'object') return null;
+  if (Object.keys(raw as object).length === 0) return null;
+  const parsed = editorEffectsStateSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
 }

--- a/apps/server/test/contexts/entry/application/usecases/create-entry.usecase.test.ts
+++ b/apps/server/test/contexts/entry/application/usecases/create-entry.usecase.test.ts
@@ -72,6 +72,36 @@ describe('CreateEntryUsecase', () => {
     expect(result.fermentationEnabled).toBe(false);
   });
 
+  it('effects を渡すと Entry に保存される', async () => {
+    const result = await usecase.execute('user-1', {
+      content: 'Hello',
+      mediaUrls: [],
+      editorType: 'typetrace',
+      editorVersion: '1.0.0',
+      extension: {},
+      effects: {
+        version: 1,
+        textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.5, duration: 200 }],
+      },
+    });
+
+    expect(result.effects).toEqual({
+      version: 1,
+      textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.5, duration: 200 }],
+    });
+  });
+
+  it('effects 未指定なら null', async () => {
+    const result = await usecase.execute('user-1', {
+      content: 'Hello',
+      mediaUrls: [],
+      editorType: 'typetrace',
+      editorVersion: '1.0.0',
+      extension: {},
+    });
+    expect(result.effects).toBeNull();
+  });
+
   it('content が空文字なら EntryValidationError を throw する', async () => {
     await expect(
       usecase.execute('user-1', {

--- a/apps/server/test/contexts/entry/application/usecases/update-entry.usecase.test.ts
+++ b/apps/server/test/contexts/entry/application/usecases/update-entry.usecase.test.ts
@@ -15,6 +15,7 @@ describe('UpdateEntryUsecase', () => {
     content: 'original',
     mediaUrls: [],
     fermentationEnabled: false,
+    effects: null,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
   });
@@ -62,6 +63,7 @@ describe('UpdateEntryUsecase', () => {
       content: 'original',
       mediaUrls: [],
       fermentationEnabled: true,
+      effects: null,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     });
@@ -105,6 +107,68 @@ describe('UpdateEntryUsecase', () => {
     ).rejects.toThrow('Entry not found');
 
     expect(entryRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('effects を渡すと差し替わる', async () => {
+    const result = await usecase.execute('entry-1', {
+      content: 'updated',
+      mediaUrls: [],
+      editorType: 'minimal',
+      editorVersion: '1.0.0',
+      extension: {},
+      effects: {
+        version: 1,
+        eraserTraces: [{ rx: 0, ry: 0, w: 1, h: 1, chars: ['x'], intensity: 0.1, seed: 1 }],
+      },
+    });
+    expect(result.effects?.eraserTraces).toHaveLength(1);
+  });
+
+  it('effects 未指定なら既存の effects を維持する', async () => {
+    const withEffects = Entry.fromProps({
+      id: 'entry-1',
+      userId: 'user-1',
+      content: 'original',
+      mediaUrls: [],
+      fermentationEnabled: false,
+      effects: { version: 1, textSpans: [] },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    vi.mocked(entryRepo.findById).mockResolvedValue(withEffects);
+
+    const result = await usecase.execute('entry-1', {
+      content: 'updated',
+      mediaUrls: [],
+      editorType: 'minimal',
+      editorVersion: '1.0.0',
+      extension: {},
+    });
+    expect(result.effects).toEqual({ version: 1, textSpans: [] });
+  });
+
+  it('effects=null 指定で既存 effects をクリアできる', async () => {
+    const withEffects = Entry.fromProps({
+      id: 'entry-1',
+      userId: 'user-1',
+      content: 'original',
+      mediaUrls: [],
+      fermentationEnabled: false,
+      effects: { version: 1, textSpans: [] },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    vi.mocked(entryRepo.findById).mockResolvedValue(withEffects);
+
+    const result = await usecase.execute('entry-1', {
+      content: 'updated',
+      mediaUrls: [],
+      editorType: 'minimal',
+      editorVersion: '1.0.0',
+      extension: {},
+      effects: null,
+    });
+    expect(result.effects).toBeNull();
   });
 
   it('content が空文字なら EntryValidationError を throw する', async () => {

--- a/apps/server/test/contexts/entry/domain/models/entry.test.ts
+++ b/apps/server/test/contexts/entry/domain/models/entry.test.ts
@@ -83,6 +83,7 @@ describe('Entry', () => {
         content: 'test',
         mediaUrls: ['url1'],
         fermentationEnabled: true,
+        effects: null,
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
       };
@@ -98,6 +99,7 @@ describe('Entry', () => {
       content: 'original',
       mediaUrls: [],
       fermentationEnabled: false,
+      effects: null,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     });
@@ -131,6 +133,7 @@ describe('Entry', () => {
       content: 'original',
       mediaUrls: [],
       fermentationEnabled: false,
+      effects: null,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     });
@@ -145,6 +148,83 @@ describe('Entry', () => {
     it('元の Entry は変更されない（イミュータブル）', () => {
       entry.withFermentationEnabled(true);
       expect(entry.fermentationEnabled).toBe(false);
+    });
+  });
+
+  describe('effects (editor visual effects)', () => {
+    const baseProps = {
+      id: 'e-1',
+      userId: 'u-1',
+      content: 'original',
+      mediaUrls: [],
+      fermentationEnabled: false,
+      effects: null,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    it('create で effects を渡すと保持される', () => {
+      const result = Entry.create(
+        {
+          userId: 'u',
+          content: 'x',
+          mediaUrls: [],
+          fermentationEnabled: false,
+          effects: { version: 1, textSpans: [], eraserTraces: [] },
+        },
+        generateId,
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.effects).toEqual({ version: 1, textSpans: [], eraserTraces: [] });
+      }
+    });
+
+    it('create で effects を省略すると null になる', () => {
+      const result = Entry.create(
+        { userId: 'u', content: 'x', mediaUrls: [], fermentationEnabled: false },
+        generateId,
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.effects).toBeNull();
+      }
+    });
+
+    it('withContent に effects を渡すと差し替わる', () => {
+      const entry = Entry.fromProps(baseProps);
+      const next = entry.withContent('new', [], {
+        version: 1,
+        eraserTraces: [{ rx: 1, ry: 2, w: 3, h: 4, chars: ['a'], intensity: 0.1, seed: 7 }],
+      });
+      expect(next.success).toBe(true);
+      if (next.success) {
+        expect(next.value.effects?.eraserTraces).toHaveLength(1);
+      }
+    });
+
+    it('withContent で effects を省略すると既存値を維持する', () => {
+      const entry = Entry.fromProps({
+        ...baseProps,
+        effects: { version: 1, textSpans: [] },
+      });
+      const next = entry.withContent('new', []);
+      expect(next.success).toBe(true);
+      if (next.success) {
+        expect(next.value.effects).toEqual({ version: 1, textSpans: [] });
+      }
+    });
+
+    it('withContent で effects に null を渡すとクリアできる', () => {
+      const entry = Entry.fromProps({
+        ...baseProps,
+        effects: { version: 1, textSpans: [] },
+      });
+      const next = entry.withContent('new', [], null);
+      expect(next.success).toBe(true);
+      if (next.success) {
+        expect(next.value.effects).toBeNull();
+      }
     });
   });
 });

--- a/docs/editor-effects-persistence.md
+++ b/docs/editor-effects-persistence.md
@@ -1,0 +1,81 @@
+# Editor Effects Persistence
+
+エディタの視覚エフェクト（消し跡・時間内包・圧力にじみ・音量内包）をエントリ単位で永続化する設計。
+
+## 対象エフェクト
+
+| エフェクト | 元データの所在 | 保存対象 |
+|---|---|---|
+| 消し跡 (`use-eraser-trace`) | Canvas に描画、`tracesRef` (in-memory) | `Trace[]` をそのまま JSON 化 |
+| 時間内包 fontSize / fontWeight (`use-time-inscription`) | `<span class="eblock" data-t data-duration data-mode>` | テキスト文字オフセット + 属性 |
+| 時間内包 圧力にじみ (`use-pressure-bleed`) | `<span class="eblock" data-intensity data-seed data-mode="pressureBleed">` | テキスト文字オフセット + 属性 |
+| 音量内包 (`use-voice-dynamics`) | `<span class="v-block" style="fontSize">` | テキスト文字オフセット + fontSize |
+| ゴーストエフェクト | アニメ後すぐ消える | **対象外**（演出のみ） |
+
+## SSoT と キャッシュ
+
+- **SSoT**: `entries.effects` JSONB カラム（新設）。
+- **キャッシュ**: `localStorage` キー `oryzae-entry-effects:<entryId>`。書き込みは「保存成功時」と「extract した直後（即時反映用）」。読み込みは「エントリ取得前の即時表示」と「DB から取れなかった場合のフォールバック」。
+- DB レスポンスを取得したら必ず localStorage を上書きする（DB が SSoT）。
+
+## 保存形式
+
+```ts
+type EditorEffectsState = {
+  version: 1;
+  eraserTraces?: EraserTrace[];      // canvas marks
+  textSpans?: TextSpanMark[];        // DOM marks (sorted by start, non-overlapping)
+};
+
+type EraserTrace = {
+  rx: number; ry: number;            // editor content coords (Issue #313)
+  w: number; h: number;
+  chars: string[];
+  intensity: number;
+  seed: number;
+};
+
+type TextSpanMark =
+  | { start: number; end: number; kind: 'time'; mode: 'fontSize' | 'fontWeight'; t: number; duration: number }
+  | { start: number; end: number; kind: 'pressure'; intensity: number; seed: number }
+  | { start: number; end: number; kind: 'voice'; fontSizeEm: number };
+```
+
+`start` / `end` は **保存される `content` 文字列上のオフセット**（半開区間、`\n` を 1 文字とカウント）。
+
+## 文字オフセットの数え方
+
+`editorRef.current.innerText` と一致するインデックスを使う。理由:
+- 既存の保存ロジックも `innerText` を採用しており、改行（`<div>`, `<br>`）が `\n` 1 文字に正規化される。
+- 復元時は同じ `innerText` 経由で構築した text nodes をスキャンしてマーキングするので、エンコード→デコードが対称。
+
+## 復元アルゴリズム（apply）
+
+1. `editorRef.current.textContent = content` で素のテキストを書く（既存挙動）。
+2. `textSpans` を `start` 昇順で走査し、editor の最初の text node から文字数を数えながら `[start, end)` の範囲を `<span>` で wrap。
+3. `kind` に応じて `class` / `data-*` / `style` を復元。
+4. `eraserTraces` を `useEraserTrace` の `initialTraces` prop として渡し、初回 mount 時に `tracesRef.current = initialTraces` で hydrate → `requestRedraw()`。
+
+## 抽出アルゴリズム（extract）
+
+1. editor の `innerText` を計算 (`content`)。
+2. 子ノードを DFS で走査し、`<span class="eblock|v-block">` を見つけたら、その時点までの累積文字数を `start` として記録、`end = start + textContent.length`。
+3. `dataset` / `style.fontSize` を読んで `TextSpanMark` を組み立て。
+4. `tracesRef.current` から `eraserTraces` をスナップショット。
+
+## 既存エントリとの互換性
+
+- 既存 entries には `effects` がない → カラムは `default '{}'`、`null` の場合は無視。
+- 既存の保存ロジックは `content` のみ送信していたので、payload に `effects` を含めるのは追記のみ（破壊的変更なし）。
+
+## スコープ外（別途検討）
+
+- 全文検索ヒット時のハイライト等は plain text に対して行う前提のまま。
+- snapshot (`entry_snapshots`) への effects 同期は今回は見送り（必要になれば次フェーズ）。
+- vertical writing mode での `rx/ry` 座標系の整合性は Issue #313 の修正に乗っている前提。
+
+## テスト戦略
+
+- **server**: domain ラウンドトリップ、repository インテグレーション（DB skipif）、route handler。
+- **client**: `extract` / `apply` の対称性、空 state の no-op、未知の kind を無視するフォワード互換性、`useEraserTrace` の hydration。
+- **手動 QA**: 各エフェクトを ON にして保存 → 一覧 → 開き直し で痕跡が再表示されることを確認。

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,7 +17,10 @@ export {
   completeOnboardingSchema,
   createEntrySchema,
   credentialsSchema,
+  type EditorEffectsState,
   type EmailOtpType,
+  type EraserTracePayload,
+  editorEffectsStateSchema,
   emailOtpTypeSchema,
   type JarLayoutUpdate,
   type JarPositionItem,
@@ -31,5 +34,6 @@ export {
   profileUpdateSchema,
   questionStringSchema,
   signupSchema,
+  type TextSpanMark,
   verifyOtpSchema,
 } from './schemas.js';

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -12,6 +12,57 @@ import { z } from 'zod';
 export const localeSchema = z.enum(['ja', 'en', 'zh', 'ko']);
 export type LocaleCode = z.infer<typeof localeSchema>;
 
+/**
+ * Editor visual effects state — persisted per-entry so traces re-appear on reload.
+ * See `docs/editor-effects-persistence.md` for the design rationale.
+ *
+ * `version` lets us evolve the shape without breaking old clients: unknown
+ * versions / kinds are ignored on apply so older clients gracefully degrade.
+ */
+const eraserTraceSchema = z.object({
+  rx: z.number(),
+  ry: z.number(),
+  w: z.number(),
+  h: z.number(),
+  chars: z.array(z.string()),
+  intensity: z.number(),
+  seed: z.number(),
+});
+
+const textSpanMarkSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('time'),
+    start: z.number().int().nonnegative(),
+    end: z.number().int().nonnegative(),
+    mode: z.enum(['fontSize', 'fontWeight']),
+    t: z.number(),
+    duration: z.number(),
+  }),
+  z.object({
+    kind: z.literal('pressure'),
+    start: z.number().int().nonnegative(),
+    end: z.number().int().nonnegative(),
+    intensity: z.number(),
+    seed: z.number(),
+  }),
+  z.object({
+    kind: z.literal('voice'),
+    start: z.number().int().nonnegative(),
+    end: z.number().int().nonnegative(),
+    fontSizeEm: z.number(),
+  }),
+]);
+
+export const editorEffectsStateSchema = z.object({
+  version: z.literal(1),
+  eraserTraces: z.array(eraserTraceSchema).optional(),
+  textSpans: z.array(textSpanMarkSchema).optional(),
+});
+
+export type EditorEffectsState = z.infer<typeof editorEffectsStateSchema>;
+export type EraserTracePayload = z.infer<typeof eraserTraceSchema>;
+export type TextSpanMark = z.infer<typeof textSpanMarkSchema>;
+
 export const createEntrySchema = z.object({
   content: z.string(),
   mediaUrls: z.array(z.string()).default([]),
@@ -19,6 +70,7 @@ export const createEntrySchema = z.object({
   editorVersion: z.string(),
   extension: z.record(z.unknown()).default({}),
   fermentationEnabled: z.boolean().optional(),
+  effects: editorEffectsStateSchema.optional(),
 });
 
 export const questionStringSchema = z.object({

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -70,7 +70,8 @@ export const createEntrySchema = z.object({
   editorVersion: z.string(),
   extension: z.record(z.unknown()).default({}),
   fermentationEnabled: z.boolean().optional(),
-  effects: editorEffectsStateSchema.optional(),
+  // undefined → 既存値を維持 / null → 明示的にクリア / object → 差し替え
+  effects: editorEffectsStateSchema.nullable().optional(),
 });
 
 export const questionStringSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@oryzae/server':
         specifier: workspace:*
         version: link:../server
+      '@oryzae/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@sentry/nextjs':
         specifier: ^10.51.0
         version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.1)
@@ -116,7 +119,7 @@ importers:
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-intl:
         specifier: ^4.11.0
-        version: 4.11.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 4.11.0(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       posthog-js:
         specifier: ^1.372.6
         version: 1.372.6
@@ -7583,7 +7586,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.0: {}
 
-  next-intl@4.11.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  next-intl@4.11.0(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.5
       '@parcel/watcher': 2.5.6

--- a/supabase/migrations/00016_add_effects_to_entries.sql
+++ b/supabase/migrations/00016_add_effects_to_entries.sql
@@ -1,0 +1,2 @@
+alter table public.entries
+  add column effects jsonb not null default '{}'::jsonb;


### PR DESCRIPTION
Closes #322.

## Summary
- 新規エントリで「漬け込む」を押した後、Jar 画面でブランドマーク付きの完了モーダルを表示
- 文言（ja）:「あなたのテキストと問いが発酵瓶に漬け込まれました。発酵が進むのを楽しみに待ちながら、ジャーナルを続けてください。」
- グラフィカルだがシンプルに留めるため、`BRAND_MARK_SVG`（米麹を醸す壺シンボル）を中央に配置するだけの構成
- `?justPickled=1` クエリで一度だけトリガー → `router.replace('/jar')` で履歴をクリーン化
- 新規 component は `features/fermentation/` 配下に置き、既存 `PickleNudgeModal` と同じレイアウト・カラー体系を踏襲
- i18n キー `fermentation.jar.pickle_success_modal.{aria_label,heading,body,dismiss}` を ja/en/zh/ko の 4 言語で SSoT (Google Sheets) に追加し、JSON を再生成

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス（0 errors。既存と同じ a11y warning 1 件のみ）
- [x] `pnpm test` パス（client 198 / admin 75 / server）
- [x] `pnpm dep-cruise` パス（feature 境界違反なし）
- [x] `pnpm knip` パス
- [x] Playwright MCP で `/jar?justPickled=1` 遷移 → モーダル表示 → URL が `/jar` に書き換わることを確認
- [x] 「わかりました」クリックでモーダル閉じる、リロード後は再表示しないことを確認
- [x] ブラウザコンソールにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)