### PR TITLE
feat(editor): エディタ視覚エフェクトをエントリ単位で永続化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # `@oryzae/shared` の `main` は `dist/index.js`。client 側で runtime に
+      # value import (zod schema 等) する場合、build 済みでないと vitest が解決できない。
+      - run: pnpm --filter @oryzae/shared build
       - run: pnpm test
 
   dependency-check:

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -599,11 +599,19 @@ export function EntryEditor({
   );
 
   const autoSave = useCallback(
-    (contentToSave: string, id?: string) => {
+    async (contentToSave: string, id?: string) => {
       isAutosavingRef.current = true;
-      return save(contentToSave, id);
+      // Issue #332: 自動保存でも effects を必ず同梱する。これがないと、ユーザーが
+      // 明示的に保存ボタンを押さずに離脱した場合に消し跡や時間内包の痕跡が
+      // 永続化されない (autosave だけで離脱するユーザのケース)。
+      const effects = editorRef.current
+        ? extractEditorEffects(editorRef.current, getTracesSnapshot())
+        : null;
+      const savedId = await save(contentToSave, id, { effects });
+      if (savedId) saveCachedEffects(savedId, effects);
+      return savedId;
     },
-    [save],
+    [save, getTracesSnapshot],
   );
 
   useAutosaveEntry({

--- a/apps/client/src/features/entries/components/entry-editor.tsx
+++ b/apps/client/src/features/entries/components/entry-editor.tsx
@@ -261,11 +261,17 @@ export function EntryEditor({
   useGhostEffect(editorRef, ghostLayerRef, settings);
   useAmpEffect(settings.ampEnabled);
   useTimeInscription(editorRef, settings);
+  // 消し跡の文字フォントは編集中のフォントと揃える (Issue #332)。
+  // settings.fontFamily は "serif" | "sans" の論理値なので、エディタ本体と同じ
+  // 具体的なフォントスタック文字列に解決して渡す。
+  const eraserFontFamily =
+    settings.fontFamily === 'serif' ? "'Noto Serif JP', serif" : "'Noto Sans JP', sans-serif";
   const { getTracesSnapshot } = useEraserTrace(
     editorRef,
     traceCanvasRef,
     settings.eraserTraceEnabled,
     settings.fontSize,
+    eraserFontFamily,
     effectiveInitialEffects?.eraserTraces,
   );
   usePressureBleed(

--- a/apps/client/src/features/entries/hooks/use-editor-settings.ts
+++ b/apps/client/src/features/entries/hooks/use-editor-settings.ts
@@ -19,6 +19,35 @@ const FOCUS_MODE_STORAGE_KEY = 'oryzae-editor-focus-mode';
 
 const FERMENTATION_OVERLAY_PREFERENCE_KEY = 'oryzae-editor-fermentation-overlay-preference';
 
+/**
+ * 上の 4 つのキー以外の設定（フォント・各種エフェクトのトグルとサブオプション）
+ * は単一の JSON BLOB として保存する。Issue #332 で「一度セットしたエフェクト設定が
+ * エディタを開き直すとリセットされる」という指摘を受けて追加。後方互換のため
+ * 既存 4 キーは温存し、それ以外だけ extras にまとめている。
+ *
+ * 保存形式: `Partial<EditorSettings>`（書き込み時に差分マージ）。
+ * 不明なキー・型不一致は読み込み時に黙ってドロップする。
+ */
+const EXTRAS_STORAGE_KEY = 'oryzae-editor-settings-extras';
+
+const EXTRAS_KEYS = [
+  'fontFamily',
+  'timeInscriptionEnabled',
+  'timeInscriptionMode',
+  'eraserTraceEnabled',
+  'ampEnabled',
+  'voiceEnabled',
+  'ghostEnabled',
+  'ghostMode',
+  'ghostSize',
+  'ghostScatter',
+  'ghostBlurStart',
+  'ghostBlurEnd',
+  'ghostDuration',
+] as const satisfies ReadonlyArray<keyof EditorSettings>;
+type ExtrasKey = (typeof EXTRAS_KEYS)[number];
+type ExtrasPatch = Partial<Pick<EditorSettings, ExtrasKey>>;
+
 function readStoredFontSize(): number | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -106,6 +135,59 @@ function writeStoredFermentationOverlayPreference(value: FermentationOverlayPref
   }
 }
 
+function readStoredExtras(): ExtrasPatch | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(EXTRAS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const out: ExtrasPatch = {};
+    for (const key of EXTRAS_KEYS) {
+      const v = parsed[key];
+      if (key === 'fontFamily') {
+        if (v === 'serif' || v === 'sans') out[key] = v;
+      } else if (key === 'timeInscriptionMode') {
+        if (v === 'fontSize' || v === 'fontWeight' || v === 'pressureBleed') out[key] = v;
+      } else if (key === 'ghostMode') {
+        if (v === 'block' || v === 'dust') out[key] = v;
+      } else if (
+        key === 'timeInscriptionEnabled' ||
+        key === 'eraserTraceEnabled' ||
+        key === 'ampEnabled' ||
+        key === 'voiceEnabled' ||
+        key === 'ghostEnabled'
+      ) {
+        if (typeof v === 'boolean') out[key] = v;
+      } else {
+        // numeric: ghostSize / ghostScatter / ghostBlurStart / ghostBlurEnd / ghostDuration
+        if (typeof v === 'number' && Number.isFinite(v)) out[key] = v;
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function mergeStoredExtras(patch: Partial<EditorSettings>): void {
+  if (typeof window === 'undefined') return;
+  const extras: ExtrasPatch = {};
+  for (const key of EXTRAS_KEYS) {
+    if (key in patch) {
+      // @type-assertion-allowed: Pick<> indexed assignment; runtime type matches by construction
+      (extras as Record<string, unknown>)[key] = patch[key];
+    }
+  }
+  if (Object.keys(extras).length === 0) return;
+  try {
+    const existing = readStoredExtras() ?? {};
+    window.localStorage.setItem(EXTRAS_STORAGE_KEY, JSON.stringify({ ...existing, ...extras }));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
 function getInitialSettings(locale: string | undefined): EditorSettings {
   const next: EditorSettings = { ...DEFAULT_SETTINGS };
   // 英語ロケールでサインアップ／利用しているユーザーは横書きをデフォルトにする (issue #269)
@@ -120,6 +202,8 @@ function getInitialSettings(locale: string | undefined): EditorSettings {
   if (focusMode !== null) next.focusModeEnabled = focusMode;
   const overlayPref = readStoredFermentationOverlayPreference();
   if (overlayPref !== null) next.fermentationOverlayPreference = overlayPref;
+  const extras = readStoredExtras();
+  if (extras) Object.assign(next, extras);
   return next;
 }
 
@@ -145,6 +229,7 @@ export function useEditorSettings(
     ) {
       writeStoredFermentationOverlayPreference(patch.fermentationOverlayPreference);
     }
+    mergeStoredExtras(patch);
     setSettings((prev) => ({ ...prev, ...patch }));
   }, []);
 

--- a/apps/client/src/features/entries/hooks/use-eraser-trace.ts
+++ b/apps/client/src/features/entries/hooks/use-eraser-trace.ts
@@ -45,7 +45,12 @@ function seededRng(seed: number) {
   };
 }
 
-function generateSmudge(char: string, seed: number, fontSize: number): HTMLCanvasElement {
+function generateSmudge(
+  char: string,
+  seed: number,
+  fontSize: number,
+  fontFamily: string,
+): HTMLCanvasElement {
   const pad = 6;
   const sz = Math.ceil(fontSize * 1.4) + pad * 2;
   const c = document.createElement('canvas');
@@ -55,7 +60,7 @@ function generateSmudge(char: string, seed: number, fontSize: number): HTMLCanva
   if (!cx) return c;
 
   cx.filter = 'blur(3px)';
-  cx.font = `${fontSize}px sans-serif`;
+  cx.font = `${fontSize}px ${fontFamily}`;
   cx.fillStyle = 'rgba(140,140,140,1)';
   cx.textBaseline = 'middle';
   cx.textAlign = 'center';
@@ -138,6 +143,7 @@ export function useEraserTrace(
   canvasRef: React.RefObject<HTMLCanvasElement | null>,
   enabled: boolean,
   fontSize: number,
+  fontFamily: string,
   initialTraces?: Trace[],
 ): UseEraserTraceResult {
   const tracesRef = useRef<Trace[]>([]);
@@ -183,10 +189,11 @@ export function useEraserTrace(
     resizeCanvas();
 
     function getSmudge(char: string, seed: number): HTMLCanvasElement {
-      const key = `${char}_${seed}`;
+      // fontFamily is part of the cache key so switching serif↔sans regenerates.
+      const key = `${char}_${seed}_${fontFamily}`;
       const cached = smudgeCacheRef.current.get(key);
       if (cached) return cached;
-      const s = generateSmudge(char, seed, fontSize);
+      const s = generateSmudge(char, seed, fontSize, fontFamily);
       smudgeCacheRef.current.set(key, s);
       return s;
     }
@@ -302,7 +309,7 @@ export function useEraserTrace(
       window.removeEventListener('resize', resizeCanvas);
       smudgeCacheRef.current.clear();
     };
-  }, [editorRef, canvasRef, enabled, fontSize]);
+  }, [editorRef, canvasRef, enabled, fontSize, fontFamily]);
 
   return {
     getTracesSnapshot: () => tracesRef.current.map((t) => ({ ...t })),

--- a/apps/client/src/features/entries/utils/editor-effects-cache.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-cache.ts
@@ -1,4 +1,4 @@
-import type { EditorEffectsState } from '@oryzae/shared';
+import { type EditorEffectsState, editorEffectsStateSchema } from '@oryzae/shared';
 
 /**
  * localStorage キャッシュ層。
@@ -6,6 +6,12 @@ import type { EditorEffectsState } from '@oryzae/shared';
  * ための warm cache。Issue #332 参照。
  *
  * 失敗（quota 超過 / SSR / 私的閲覧モード等）は黙って握る。
+ *
+ * 読み込み時は必ず Zod schema で validate する。理由: 永続化機能の開発過程で
+ * textSpans の time variant の形が `{t, duration}` から `{fontSize}` / `{fontWeight}`
+ * に変わったため、古いキャッシュが残っているとレンダリングが壊れる (`undefinedpx`
+ * になって text が小さくなる等)。schema mismatch なキャッシュは捨てて DB から
+ * fetch し直す。
  */
 
 const PREFIX = 'oryzae-entry-effects:';
@@ -16,8 +22,14 @@ export function loadCachedEffects(entryId: string | undefined): EditorEffectsSta
     const raw = window.localStorage.getItem(PREFIX + entryId);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object') return null;
-    return parsed as EditorEffectsState;
+    const validated = editorEffectsStateSchema.safeParse(parsed);
+    if (!validated.success) {
+      // Outdated / malformed cache — drop it so we don't apply broken styles
+      // (e.g. old `{t, duration}` shape would render `undefinedpx`).
+      window.localStorage.removeItem(PREFIX + entryId);
+      return null;
+    }
+    return validated.data;
   } catch {
     return null;
   }

--- a/apps/client/src/features/entries/utils/editor-effects-codec.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-codec.ts
@@ -255,10 +255,19 @@ function decorateSpan(span: HTMLSpanElement, mark: TextSpanMark): void {
   span.className = EBLOCK_CLASS;
   if (mark.kind === 'time') {
     span.dataset.mode = mark.mode;
+    // Defensive: only write the inline style if the resolved value is a
+    // valid positive number. Prevents `style.fontSize = "undefinedpx"`
+    // (invalid CSS → silently dropped → span inherits parent's font size,
+    // appearing smaller than at composition time) if a malformed mark
+    // somehow slipped past the schema.
     if (mark.mode === 'fontWeight') {
-      span.style.fontWeight = String(mark.fontWeight);
+      if (typeof mark.fontWeight === 'number' && mark.fontWeight > 0) {
+        span.style.fontWeight = String(mark.fontWeight);
+      }
     } else {
-      span.style.fontSize = `${mark.fontSize}px`;
+      if (typeof mark.fontSize === 'number' && mark.fontSize > 0) {
+        span.style.fontSize = `${mark.fontSize}px`;
+      }
     }
     return;
   }

--- a/apps/client/src/features/entries/utils/editor-effects-codec.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-codec.ts
@@ -75,20 +75,35 @@ interface ScanState {
 
 function scanTextSpans(editor: HTMLElement): TextSpanMark[] {
   const state: ScanState = { cursor: 0, marks: [] };
-  walkScan(editor, state);
+  walkScan(editor, null, state);
   return state.marks;
 }
 
-function walkScan(node: Node, state: ScanState): void {
+/**
+ * `ancestor` は「現在の text node に対する effective eblock/v-block 祖先」。
+ * CSS の inline style は最も内側が勝つので、ネストした eblock がある場合は
+ * 一番内側 (最後に walkScan で更新された) の祖先の属性が描画上有効。
+ * use-time-inscription が連続入力時に新しい span をカーソル位置の親 (= 既存の
+ * eblock) の中に挿入してしまい、深い nest が生まれることがある (既存の挙動)
+ * — 永続化側はこの構造をそのままシリアライズする必要がある。
+ */
+function walkScan(node: Node, ancestor: HTMLElement | null, state: ScanState): void {
   const children = node.childNodes;
   for (let i = 0; i < children.length; i++) {
-    visitScan(children[i], state);
+    visitScan(children[i], ancestor, state);
   }
 }
 
-function visitScan(node: Node, state: ScanState): void {
+function visitScan(node: Node, ancestor: HTMLElement | null, state: ScanState): void {
   if (node.nodeType === Node.TEXT_NODE) {
-    state.cursor += (node.textContent ?? '').length;
+    const text = node.textContent ?? '';
+    if (ancestor && text.length > 0) {
+      const start = state.cursor;
+      const end = start + text.length;
+      const mark = markFromElement(ancestor, start, end);
+      if (mark) state.marks.push(mark);
+    }
+    state.cursor += text.length;
     return;
   }
   if (node.nodeType !== Node.ELEMENT_NODE) return;
@@ -101,15 +116,12 @@ function visitScan(node: Node, state: ScanState): void {
     state.cursor += 1;
   }
   if (isEffectSpan(el)) {
-    const text = el.textContent ?? '';
-    const start = state.cursor;
-    const end = start + text.length;
-    const mark = markFromElement(el, start, end);
-    if (mark) state.marks.push(mark);
-    state.cursor = end;
+    // Recurse with `el` as the new effective ancestor — its inline style wins
+    // for any direct text descendants (until a further-nested eblock overrides).
+    walkScan(el, el, state);
     return;
   }
-  walkScan(el, state);
+  walkScan(el, ancestor, state);
 }
 
 function markFromElement(el: HTMLElement, start: number, end: number): TextSpanMark | null {

--- a/apps/client/src/features/entries/utils/editor-effects-codec.ts
+++ b/apps/client/src/features/entries/utils/editor-effects-codec.ts
@@ -125,13 +125,25 @@ function markFromElement(el: HTMLElement, start: number, end: number): TextSpanM
     if (!Number.isFinite(intensity) || !Number.isFinite(seed)) return null;
     return { kind: 'pressure', start, end, intensity, seed };
   }
-  if (mode === 'fontSize' || mode === 'fontWeight') {
-    const t = Number.parseFloat(el.dataset.t ?? '');
-    const duration = Number.parseFloat(el.dataset.duration ?? '');
-    if (!Number.isFinite(t) || !Number.isFinite(duration)) return null;
-    return { kind: 'time', start, end, mode, t, duration };
+  if (mode === 'fontSize') {
+    // Read the *resolved* font size that the time-inscription hook wrote, so
+    // restoration is independent of the editor's current `settings.fontSize`.
+    const fontSize = parsePx(el.style.fontSize);
+    if (fontSize == null) return null;
+    return { kind: 'time', start, end, mode: 'fontSize', fontSize };
+  }
+  if (mode === 'fontWeight') {
+    const fontWeight = Number.parseInt(el.style.fontWeight, 10);
+    if (!Number.isFinite(fontWeight)) return null;
+    return { kind: 'time', start, end, mode: 'fontWeight', fontWeight };
   }
   return null;
+}
+
+function parsePx(input: string): number | null {
+  if (!input.endsWith('px')) return null;
+  const n = Number.parseFloat(input.slice(0, -2));
+  return Number.isFinite(n) && n > 0 ? n : null;
 }
 
 function parseEm(input: string): number | null {
@@ -242,14 +254,11 @@ function decorateSpan(span: HTMLSpanElement, mark: TextSpanMark): void {
   }
   span.className = EBLOCK_CLASS;
   if (mark.kind === 'time') {
-    span.dataset.t = mark.t.toFixed(4);
-    span.dataset.duration = String(mark.duration);
     span.dataset.mode = mark.mode;
     if (mark.mode === 'fontWeight') {
-      span.style.fontWeight = String(Math.round(300 + (700 - 300) * mark.t));
+      span.style.fontWeight = String(mark.fontWeight);
     } else {
-      const scale = 0.8 + (1.35 - 0.8) * mark.t;
-      span.style.fontSize = `${(16 * scale).toFixed(1)}px`;
+      span.style.fontSize = `${mark.fontSize}px`;
     }
     return;
   }

--- a/apps/client/test/features/entries/hooks/use-eraser-trace.test.ts
+++ b/apps/client/test/features/entries/hooks/use-eraser-trace.test.ts
@@ -140,7 +140,7 @@ describe('useEraserTrace', () => {
         scrollTop: 0,
       });
 
-      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16));
+      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif'));
 
       expect(canvas.style.left).toBe('42px');
       expect(canvas.style.top).toBe('16px');
@@ -162,7 +162,7 @@ describe('useEraserTrace', () => {
       });
       stubCharRange(400, 80);
 
-      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16));
+      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif'));
 
       dispatchBackspaceDelete(editor);
       await new Promise((r) => setTimeout(r, 30));
@@ -187,7 +187,7 @@ describe('useEraserTrace', () => {
       });
       stubCharRange(400, 80);
 
-      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16));
+      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif'));
 
       dispatchBackspaceDelete(editor);
       await new Promise((r) => setTimeout(r, 30));
@@ -218,7 +218,9 @@ describe('useEraserTrace', () => {
       const addSpy = vi.spyOn(editor, 'addEventListener');
       const removeSpy = vi.spyOn(editor, 'removeEventListener');
 
-      const { unmount } = renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16));
+      const { unmount } = renderHook(() =>
+        useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif'),
+      );
 
       expect(addSpy.mock.calls.map((c) => c[0])).toContain('scroll');
       unmount();
@@ -239,7 +241,7 @@ describe('useEraserTrace', () => {
       });
       const addSpy = vi.spyOn(editor, 'addEventListener');
 
-      renderHook(() => useEraserTrace(editorRef, canvasRef, false, 16));
+      renderHook(() => useEraserTrace(editorRef, canvasRef, false, 16, 'sans-serif'));
 
       expect(addSpy.mock.calls.map((c) => c[0])).not.toContain('beforeinput');
     });
@@ -260,7 +262,7 @@ describe('useEraserTrace', () => {
       });
       const initial = [{ rx: 10, ry: 20, w: 16, h: 20, chars: ['a'], intensity: 0.1, seed: 1 }];
 
-      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, initial));
+      renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif', initial));
       await new Promise((r) => setTimeout(r, 30));
 
       expect(drawImage).toHaveBeenCalled();
@@ -280,7 +282,9 @@ describe('useEraserTrace', () => {
       });
       const initial = [{ rx: 5, ry: 6, w: 1, h: 1, chars: ['x'], intensity: 0.07, seed: 0 }];
 
-      const { result } = renderHook(() => useEraserTrace(editorRef, canvasRef, true, 16, initial));
+      const { result } = renderHook(() =>
+        useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif', initial),
+      );
 
       const snap = result.current.getTracesSnapshot();
       expect(snap).toEqual(initial);
@@ -306,7 +310,7 @@ describe('useEraserTrace', () => {
       ];
 
       const { result, rerender } = renderHook(
-        ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, traces),
+        ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif', traces),
         { initialProps: { traces: first } },
       );
 
@@ -330,7 +334,7 @@ describe('useEraserTrace', () => {
       const initial = [{ rx: 1, ry: 1, w: 1, h: 1, chars: ['a'], intensity: 0.07, seed: 0 }];
 
       const { result, rerender } = renderHook(
-        ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, traces),
+        ({ traces }) => useEraserTrace(editorRef, canvasRef, true, 16, 'sans-serif', traces),
         { initialProps: { traces: initial } },
       );
 

--- a/apps/client/test/features/entries/utils/editor-effects-cache.test.ts
+++ b/apps/client/test/features/entries/utils/editor-effects-cache.test.ts
@@ -36,4 +36,34 @@ describe('editor-effects-cache', () => {
     window.localStorage.setItem('oryzae-entry-effects:e-1', 'not-json');
     expect(loadCachedEffects('e-1')).toBeNull();
   });
+
+  it('drops cache that does not match the current schema (e.g. legacy {t, duration} time variant)', () => {
+    // Old shape from before Issue #332 v2 — must NOT be returned because apply
+    // would write `style.fontSize = "undefinedpx"` and the text would render at
+    // the inherited (smaller) size.
+    window.localStorage.setItem(
+      'oryzae-entry-effects:e-old',
+      JSON.stringify({
+        version: 1,
+        textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.5, duration: 200 }],
+      }),
+    );
+    expect(loadCachedEffects('e-old')).toBeNull();
+    // …and the stale entry is purged so it doesn't keep failing on every load.
+    expect(window.localStorage.getItem('oryzae-entry-effects:e-old')).toBeNull();
+  });
+
+  it('returns the parsed effects when the cache matches the schema', () => {
+    window.localStorage.setItem(
+      'oryzae-entry-effects:e-new',
+      JSON.stringify({
+        version: 1,
+        textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 24 }],
+      }),
+    );
+    expect(loadCachedEffects('e-new')).toEqual({
+      version: 1,
+      textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 24 }],
+    });
+  });
 });

--- a/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
+++ b/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
@@ -75,6 +75,34 @@ describe('editor-effects-codec', () => {
       ]);
     });
 
+    it('emits a mark per text run for nested eblocks (innermost wins, like CSS cascade)', () => {
+      // use-time-inscription's nested-span quirk: continuous typing inside an existing
+      // eblock creates a deeper nest. Visually each text run renders at the *innermost*
+      // ancestor's fontSize. The codec must preserve that per-run sizing.
+      editor.innerHTML =
+        '<span class="eblock" data-mode="fontSize" style="font-size: 40px">' +
+        'A' +
+        '<span class="eblock" data-mode="fontSize" style="font-size: 26px">B</span>' +
+        'C' +
+        '</span>';
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toEqual([
+        { kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 40 }, // 'A' under outer
+        { kind: 'time', start: 1, end: 2, mode: 'fontSize', fontSize: 26 }, // 'B' under inner
+        { kind: 'time', start: 2, end: 3, mode: 'fontSize', fontSize: 40 }, // 'C' back under outer
+      ]);
+    });
+
+    it('drops marks for naked text outside any eblock', () => {
+      editor.innerHTML =
+        'naked<span class="eblock" data-mode="fontSize" style="font-size: 20px">wrapped</span>more';
+      const state = extractEditorEffects(editor, undefined);
+      // Only the wrapped run gets a mark; naked text contributes to cursor only.
+      expect(state?.textSpans).toEqual([
+        { kind: 'time', start: 5, end: 12, mode: 'fontSize', fontSize: 20 },
+      ]);
+    });
+
     it('includes eraserTraces snapshot when provided', () => {
       const traces = [{ rx: 1, ry: 2, w: 3, h: 4, chars: ['a'], intensity: 0.1, seed: 9 }];
       editor.textContent = 'text';

--- a/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
+++ b/apps/client/test/features/entries/utils/editor-effects-codec.test.ts
@@ -25,12 +25,23 @@ describe('editor-effects-codec', () => {
     });
 
     it('extracts a fontSize eblock span at the right character offset', () => {
+      // The hook writes the resolved px size; we save what we see.
       editor.innerHTML =
-        'ab<span class="eblock" data-mode="fontSize" data-t="0.5000" data-duration="200">c</span>de';
+        'ab<span class="eblock" data-mode="fontSize" style="font-size: 20px">c</span>de';
 
       const state = extractEditorEffects(editor, undefined);
       expect(state?.textSpans).toEqual([
-        { kind: 'time', start: 2, end: 3, mode: 'fontSize', t: 0.5, duration: 200 },
+        { kind: 'time', start: 2, end: 3, mode: 'fontSize', fontSize: 20 },
+      ]);
+    });
+
+    it('extracts a fontWeight eblock span', () => {
+      editor.innerHTML =
+        'ab<span class="eblock" data-mode="fontWeight" style="font-weight: 500">c</span>de';
+
+      const state = extractEditorEffects(editor, undefined);
+      expect(state?.textSpans).toEqual([
+        { kind: 'time', start: 2, end: 3, mode: 'fontWeight', fontWeight: 500 },
       ]);
     });
 
@@ -54,13 +65,13 @@ describe('editor-effects-codec', () => {
     it('counts <br> as one newline and <div> boundaries as newlines', () => {
       // mimic what contentEditable produces: text + <div>more</div>
       editor.innerHTML =
-        'a<br>b<div>c<span class="eblock" data-mode="fontSize" data-t="0.1" data-duration="100">d</span></div>';
+        'a<br>b<div>c<span class="eblock" data-mode="fontSize" style="font-size: 14px">d</span></div>';
 
       const state = extractEditorEffects(editor, undefined);
       // 'a' (0) + '\n' from <br> (1) + 'b' (2) + '\n' from <div> boundary (3) + 'c' (4)
       // span 'd' starts at 5
       expect(state?.textSpans).toEqual([
-        { kind: 'time', start: 5, end: 6, mode: 'fontSize', t: 0.1, duration: 100 },
+        { kind: 'time', start: 5, end: 6, mode: 'fontSize', fontSize: 14 },
       ]);
     });
 
@@ -79,13 +90,26 @@ describe('editor-effects-codec', () => {
       editor.textContent = 'abcde';
 
       applyTextSpansToEditor(editor, [
-        { kind: 'time', start: 2, end: 3, mode: 'fontSize', t: 0.5, duration: 200 },
+        { kind: 'time', start: 2, end: 3, mode: 'fontSize', fontSize: 24 },
       ]);
 
-      const span = editor.querySelector('span.eblock');
+      const span = editor.querySelector('span.eblock') as HTMLElement | null;
       expect(span?.textContent).toBe('c');
       expect(span?.getAttribute('data-mode')).toBe('fontSize');
-      expect(span?.getAttribute('data-t')).toBe('0.5000');
+      expect(span?.style.fontSize).toBe('24px');
+    });
+
+    it('wraps with a fontWeight eblock span', () => {
+      editor.textContent = 'abcde';
+
+      applyTextSpansToEditor(editor, [
+        { kind: 'time', start: 2, end: 3, mode: 'fontWeight', fontWeight: 600 },
+      ]);
+
+      const span = editor.querySelector('span.eblock') as HTMLElement | null;
+      expect(span?.textContent).toBe('c');
+      expect(span?.getAttribute('data-mode')).toBe('fontWeight');
+      expect(span?.style.fontWeight).toBe('600');
     });
 
     it('wraps a voice span', () => {
@@ -101,7 +125,7 @@ describe('editor-effects-codec', () => {
     it('applies multiple non-overlapping spans in order', () => {
       editor.textContent = '123456';
       applyTextSpansToEditor(editor, [
-        { kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.3, duration: 100 },
+        { kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 18 },
         { kind: 'pressure', start: 4, end: 5, intensity: 0.5, seed: 7 },
       ]);
       const spans = editor.querySelectorAll('span.eblock');
@@ -110,16 +134,25 @@ describe('editor-effects-codec', () => {
       expect(spans[1].textContent).toBe('5');
     });
 
-    it('round-trips extract → apply → extract', () => {
+    it('round-trips extract → apply → extract — fontSize survives the editor base size', () => {
+      // The span was rendered at 22.4px (e.g. baseFontSize=16 × scale=1.4 at write time).
       editor.innerHTML =
-        'ab<span class="eblock" data-mode="fontSize" data-t="0.7500" data-duration="500">c</span><span class="eblock" data-mode="pressureBleed" data-intensity="0.6200" data-seed="42">d</span>e';
+        'ab<span class="eblock" data-mode="fontSize" style="font-size: 22.4px">c</span><span class="eblock" data-mode="pressureBleed" data-intensity="0.6200" data-seed="42">d</span>e';
       const state = extractEditorEffects(editor, undefined);
       expect(state?.textSpans).toHaveLength(2);
 
-      // Now re-create from plain text + state
+      // Restore into an editor with a *different* base font size — the span
+      // must still render at 22.4px (regression test for Issue #332 v2 where
+      // we previously hardcoded 16 as the base).
       const rebuilt = document.createElement('div');
+      rebuilt.style.fontSize = '14px';
       rebuilt.textContent = 'abcde';
       applyTextSpansToEditor(rebuilt, state?.textSpans ?? []);
+
+      const restoredFontSize = rebuilt.querySelector<HTMLElement>(
+        'span.eblock[data-mode="fontSize"]',
+      )?.style.fontSize;
+      expect(restoredFontSize).toBe('22.4px');
 
       const round2 = extractEditorEffects(rebuilt, undefined);
       expect(round2?.textSpans).toEqual(state?.textSpans);
@@ -128,7 +161,7 @@ describe('editor-effects-codec', () => {
     it('silently skips invalid (start >= end) marks', () => {
       editor.textContent = 'abc';
       applyTextSpansToEditor(editor, [
-        { kind: 'time', start: 2, end: 2, mode: 'fontSize', t: 0.5, duration: 100 },
+        { kind: 'time', start: 2, end: 2, mode: 'fontSize', fontSize: 16 },
       ]);
       expect(editor.querySelector('span.eblock')).toBeNull();
     });

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -32,14 +32,8 @@ interface EraserTracePayload {
 }
 
 type TextSpanMark =
-  | {
-      kind: 'time';
-      start: number;
-      end: number;
-      mode: 'fontSize' | 'fontWeight';
-      t: number;
-      duration: number;
-    }
+  | { kind: 'time'; start: number; end: number; mode: 'fontSize'; fontSize: number }
+  | { kind: 'time'; start: number; end: number; mode: 'fontWeight'; fontWeight: number }
   | { kind: 'pressure'; start: number; end: number; intensity: number; seed: number }
   | { kind: 'voice'; start: number; end: number; fontSizeEm: number };
 

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -15,7 +15,7 @@ type EntryError =
  * Forward-compat: unknown `kind` values are ignored on apply (client-side),
  * so it's safe to extend the discriminated union without bumping version.
  */
-export interface EditorEffectsState {
+interface EditorEffectsState {
   version: 1;
   eraserTraces?: EraserTracePayload[];
   textSpans?: TextSpanMark[];

--- a/apps/server/src/contexts/entry/domain/models/entry.ts
+++ b/apps/server/src/contexts/entry/domain/models/entry.ts
@@ -1,9 +1,47 @@
-import type { EditorEffectsState } from '@oryzae/shared';
 import { err, ok, type Result } from '../../../shared/domain/types/result.js';
 
 type EntryError =
   | { type: 'EMPTY_CONTENT'; message: string }
   | { type: 'CONTENT_TOO_LONG'; message: string };
+
+/**
+ * Editor visual effects state — persisted with the entry.
+ *
+ * Defined locally in the domain (rather than imported from `@oryzae/shared`)
+ * because the domain layer must stay zod-free per `domain-no-shared-package`.
+ * Shared owns the matching zod schema for boundary validation; structural
+ * typing makes the two definitions interchangeable.
+ *
+ * Forward-compat: unknown `kind` values are ignored on apply (client-side),
+ * so it's safe to extend the discriminated union without bumping version.
+ */
+export interface EditorEffectsState {
+  version: 1;
+  eraserTraces?: EraserTracePayload[];
+  textSpans?: TextSpanMark[];
+}
+
+interface EraserTracePayload {
+  rx: number;
+  ry: number;
+  w: number;
+  h: number;
+  chars: string[];
+  intensity: number;
+  seed: number;
+}
+
+type TextSpanMark =
+  | {
+      kind: 'time';
+      start: number;
+      end: number;
+      mode: 'fontSize' | 'fontWeight';
+      t: number;
+      duration: number;
+    }
+  | { kind: 'pressure'; start: number; end: number; intensity: number; seed: number }
+  | { kind: 'voice'; start: number; end: number; fontSizeEm: number };
 
 export interface EntryProps {
   id: string;

--- a/apps/server/test/contexts/entry/application/usecases/create-entry.usecase.test.ts
+++ b/apps/server/test/contexts/entry/application/usecases/create-entry.usecase.test.ts
@@ -81,13 +81,13 @@ describe('CreateEntryUsecase', () => {
       extension: {},
       effects: {
         version: 1,
-        textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.5, duration: 200 }],
+        textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 18 }],
       },
     });
 
     expect(result.effects).toEqual({
       version: 1,
-      textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', t: 0.5, duration: 200 }],
+      textSpans: [{ kind: 'time', start: 0, end: 1, mode: 'fontSize', fontSize: 18 }],
     });
   });
 

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -29,14 +29,30 @@ const eraserTraceSchema = z.object({
   seed: z.number(),
 });
 
-const textSpanMarkSchema = z.discriminatedUnion('kind', [
+/**
+ * `time` variant stores the **resolved** font size (px) or font weight that the
+ * span was rendered with. We don't keep the `t` normalization because the
+ * effective size depends on `settings.fontSize` at composition time — re-deriving
+ * from `t` alone on restore would shrink/grow the text whenever the editor's
+ * base font size differs from the assumed default.
+ *
+ * Two `kind: 'time'` variants prevent us from using `z.discriminatedUnion('kind')`.
+ * `z.union` works — slightly slower parse for a small schema, fine here.
+ */
+const textSpanMarkSchema = z.union([
   z.object({
     kind: z.literal('time'),
     start: z.number().int().nonnegative(),
     end: z.number().int().nonnegative(),
-    mode: z.enum(['fontSize', 'fontWeight']),
-    t: z.number(),
-    duration: z.number(),
+    mode: z.literal('fontSize'),
+    fontSize: z.number().positive(),
+  }),
+  z.object({
+    kind: z.literal('time'),
+    start: z.number().int().nonnegative(),
+    end: z.number().int().nonnegative(),
+    mode: z.literal('fontWeight'),
+    fontWeight: z.number().int().positive(),
   }),
   z.object({
     kind: z.literal('pressure'),

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -70,7 +70,8 @@ export const createEntrySchema = z.object({
   editorVersion: z.string(),
   extension: z.record(z.unknown()).default({}),
   fermentationEnabled: z.boolean().optional(),
-  effects: editorEffectsStateSchema.optional(),
+  // undefined → 既存値を維持 / null → 明示的にクリア / object → 差し替え
+  effects: editorEffectsStateSchema.nullable().optional(),
 });
 
 export const questionStringSchema = z.object({


### PR DESCRIPTION
## Summary

エディタを保存して開き直すと、消し跡・時間内包(fontSize/fontWeight/圧力にじみ)・音量内包の痕跡がすべて失われていた。`entries` テーブルに `effects` JSONB カラムを追加し、エントリ単位で永続化する。

設計の詳細は [`docs/editor-effects-persistence.md`](./docs/editor-effects-persistence.md) を参照。

## 設計の要点

- **SSoT**: DB (`entries.effects`)
- **キャッシュ**: `localStorage` の warm cache。保存直後に書き込んで次回オープン時に即時表示。
- **文字オフセット**: `innerText` ベース（既存の保存挙動と一致）
- **保存形式**:
  - 消し跡: `Trace[]` をそのまま JSON 化
  - span 系: `(start, end, kind, 属性)` の配列で、`start` 昇順
- **ゴーストエフェクト**: 演出のみで対象外

## 主な変更

### サーバ
- マイグレーション `00016_add_effects_to_entries.sql` で `entries.effects jsonb` を追加（default `{}`）— Supabase MCP で本番にも適用済み
- `Entry` ドメインに `effects` フィールド + `withContent(content, mediaUrls, effects?)` を追加
  - `undefined` → 既存維持 / `null` → クリア / object → 差し替え
- `SupabaseEntryRepository` で zod パース + null fallback（壊れた行で読みが死なないように）
- `createEntrySchema` (shared/zod) に `effects` 追加。route と usecase 経由でそのまま流れる

### クライアント
- `editor-effects-codec.ts` — editor DOM ↔ `EditorEffectsState` の変換（`innerText` 互換のオフセット計算）
- `editor-effects-cache.ts` — `localStorage` ラッパ
- `useEraserTrace` に `initialTraces` 引数 + `getTracesSnapshot()` 戻り値
- `EntryEditor` で hydration（`textContent` 直後に span 復元）と保存時の extract を実装
- `@oryzae/shared` を `apps/client` の依存に追加

## Test plan

- [x] `pnpm typecheck` / `pnpm test` (642 件) / `pnpm lint` / `pnpm dep-cruise` / `pnpm knip` グリーン
- [x] `Entry` ドメインに effects 関連 5 ケース追加
- [x] `CreateEntryUsecase` / `UpdateEntryUsecase` に effects 経路のテスト追加（undefined 維持 / null クリア / 差し替え）
- [x] `editor-effects-codec` 11 ケース（extract / apply / round-trip / `<br>` `<div>` のオフセット計算）
- [x] `editor-effects-cache` 5 ケース
- [x] `useEraserTrace` の hydration 4 ケース
- [ ] 実機: 消し跡を出して保存 → 一覧 → 開き直すと再表示される
- [ ] 実機: 時間内包(fontSize/fontWeight)で打鍵して保存 → 再表示される
- [ ] 実機: 圧力にじみで打鍵して保存 → 再表示される
- [ ] 実機: 音量内包で発話して保存 → 再表示される
- [ ] 実機: 既存の effects なしエントリが壊れないことを確認

## 関連

- 親 Issue: #332 — エディタ視覚エフェクト永続化全般
- 兄弟 PR: #333 (Issue #313) — 消し跡のスクロール追随。両方マージ時には軽い conflict あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)