### PR TITLE
perf(cron): fermentation のユーザーループ並列化 + maxDuration 800s

### DIFF
--- a/apps/client/src/app/api/cron/fermentation/route.ts
+++ b/apps/client/src/app/api/cron/fermentation/route.ts
@@ -1,6 +1,7 @@
 import app from '@oryzae/server';
 
-export const maxDuration = 300;
+// Vercel Pro + Fluid Compute の上限 (800s)。並列化と併用してタイムアウトを回避する。
+export const maxDuration = 800;
 
 export async function GET(req: Request) {
   // Vercel Cron sends GET with Authorization: Bearer <CRON_SECRET>

--- a/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
+++ b/apps/server/src/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.ts
@@ -35,6 +35,12 @@ interface ScheduledFermentationResult {
 //   5. readinessScore と charsSinceLast を毎回 DB に upsert (admin/UI 反映用)
 //   6. eligible なら fermentation_enabled=true のエントリで紐付く問いごとに発酵実行
 //   7. 1問でも実行されたら次回 X 時間 (24-168h) を再ロールして state を更新
+//
+// 並列化 (issue #341): ユーザー処理を worker-pool で並列実行。
+// LLM 1 呼び出しが数十秒かかるため、シリアルだと Vercel の 300s タイムアウトを
+// 超えることが判明 (実害発生)。AI Gateway のレート制限と DB 同時接続を考慮し
+// デフォルト同時実行 4 とした。質問単位のループは内側でシリアルのまま (各ユーザー
+// 内の質問数は通常 1-3 で支配的でない)。
 export class ScheduledFermentationUsecase {
   constructor(
     private entryRepo: EntryRepositoryGateway,
@@ -58,6 +64,8 @@ export class ScheduledFermentationUsecase {
     ) => Promise<unknown>,
     // 次回 X 時間生成器。テストでは固定値を注入して決定論的にする。
     private rollHours: () => number = rollRandomHours,
+    // ユーザー並列実行数。テストでは 1 を渡して順序を決定論的にできる。
+    private concurrency: number = 4,
   ) {}
 
   async execute(now: Date = new Date()): Promise<ScheduledFermentationResult> {
@@ -83,7 +91,9 @@ export class ScheduledFermentationUsecase {
     const successfulTitlesByUser = new Map<string, string[]>();
     const languageByUser = new Map<string, FermentationLanguage>();
 
-    for (const userId of userIds) {
+    // 1 ユーザー分の処理。共有 state (result/Map) を mutate するが、JS シングル
+    // スレッドかつ await 境界での mutate のみのため worker 間競合は起きない。
+    const processUser = async (userId: string): Promise<void> => {
       // 1. ロケール解決 (失敗時は 'ja')
       const language = await this.localeResolver.resolve(userId);
       languageByUser.set(userId, language);
@@ -109,17 +119,17 @@ export class ScheduledFermentationUsecase {
       const stateWithReadiness = readinessUpdate.success ? readinessUpdate.value : state;
       await this.userStateRepo.upsert(stateWithReadiness);
 
-      if (!evaluation.eligible) continue;
+      if (!evaluation.eligible) return;
 
       // 6. 発火対象のエントリを取得 (lastRunAt 以降の fermentation_enabled=true)
       const fermentationEnabledEntries = await this.entryRepo.listFermentationEnabledByUserIdSince(
         userId,
         sinceIso,
       );
-      if (fermentationEnabledEntries.length === 0) continue;
+      if (fermentationEnabledEntries.length === 0) return;
 
       const activeQuestions = await this.questionRepo.listActiveByUserId(userId);
-      if (activeQuestions.length === 0) continue;
+      if (activeQuestions.length === 0) return;
 
       let firedAtLeastOne = false;
 
@@ -178,7 +188,21 @@ export class ScheduledFermentationUsecase {
           await this.userStateRepo.upsert(fired.value);
         }
       }
-    }
+    };
+
+    // worker-pool でユーザーを並列処理 (issue #341)。
+    // queue.shift() を奪い合う方式で外部 dep なし。各 worker は順次次のユーザーを
+    // 取りに行くため、処理時間のばらつきがあっても遊休が出にくい。
+    const queue = [...userIds];
+    const workerCount = Math.min(this.concurrency, queue.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const userId = queue.shift();
+        if (!userId) return;
+        await processUser(userId);
+      }
+    });
+    await Promise.all(workers);
 
     for (const [userId, titles] of successfulTitlesByUser) {
       const lang = languageByUser.get(userId) ?? 'ja';

--- a/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
+++ b/apps/server/test/contexts/fermentation/application/usecases/scheduled-fermentation.usecase.test.ts
@@ -159,6 +159,7 @@ interface BuildArgs {
   userIds?: string[];
   sendDigest?: ReturnType<typeof vi.fn>;
   rollHours?: () => number;
+  concurrency?: number;
 }
 
 function buildUsecase(args: BuildArgs = {}) {
@@ -175,6 +176,7 @@ function buildUsecase(args: BuildArgs = {}) {
     vi.fn().mockResolvedValue(args.userIds ?? []),
     args.sendDigest ?? vi.fn().mockResolvedValue(undefined),
     args.rollHours ?? (() => 48),
+    args.concurrency,
   );
 }
 
@@ -647,5 +649,73 @@ describe('ScheduledFermentationUsecase (issue #268: 自動発火条件)', () => 
     expect(result.totalUsers).toBe(0);
     expect(result.totalFermentations).toBe(0);
     expect(userStateRepo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('issue #341: ユーザーを concurrency 上限まで並列実行する', async () => {
+    // 並列化前は for-of シリアル実行で Vercel 300s タイムアウト多発。
+    // concurrency=2 で 3 ユーザー走らせ、analyze が同時に最大 2 回 in-flight
+    // になることを確認する (シリアル時は常に 1)。
+    const entryRepo = mockEntryRepo();
+    vi.mocked(entryRepo.countCharsByUserIdSince).mockResolvedValue(2000);
+    vi.mocked(entryRepo.listFermentationEnabledByUserIdSince).mockImplementation(async (userId) => [
+      makeEntry(userId, `${userId}-e1`),
+    ]);
+
+    const questionRepo = mockQuestionRepo();
+    vi.mocked(questionRepo.listActiveByUserId).mockImplementation(async (userId) => [
+      makeQuestion(userId, `${userId}-q1`),
+    ]);
+
+    const qtRepo = mockQuestionTransactionRepo();
+    vi.mocked(qtRepo.findLatestValidatedByQuestionId).mockImplementation(async (questionId) =>
+      makeQuestionTransaction(questionId, `Q for ${questionId}`),
+    );
+
+    const linkRepo = mockLinkRepo();
+    vi.mocked(linkRepo.listEntryIdsByQuestionId).mockImplementation(async (questionId) => {
+      const userPart = questionId.replace('-q1', '');
+      return [`${userPart}-e1`];
+    });
+
+    let inflight = 0;
+    let maxInflight = 0;
+    const llm: LlmAnalysisGateway = {
+      analyze: vi.fn().mockImplementation(async () => {
+        inflight++;
+        maxInflight = Math.max(maxInflight, inflight);
+        // 数回イベントループを譲って他の worker が in-flight に到達できるようにする
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+        inflight--;
+        return {
+          output: {
+            worksheetMarkdown: 'W',
+            resultDiagramMarkdown: 'D',
+            snippets: [{ type: 'core' as const, text: 's', sourceDate: '5/4', reason: 'r' }],
+            letterBody: 'L',
+            keywords: [{ keyword: 'k', description: 'd' }],
+          },
+          usage: { inputTokens: 1, outputTokens: 1 },
+          generationId: 'gen_concurrency',
+        };
+      }),
+    };
+
+    const usecase = buildUsecase({
+      entryRepo,
+      questionRepo,
+      qtRepo,
+      linkRepo,
+      llm,
+      userIds: ['user-1', 'user-2', 'user-3'],
+      concurrency: 2,
+    });
+
+    const result = await usecase.execute(NOW);
+
+    expect(result.succeeded).toBe(3);
+    expect(llm.analyze).toHaveBeenCalledTimes(3);
+    expect(maxInflight).toBe(2);
+    expect(inflight).toBe(0); // 全て resolve 済
   });
 });


### PR DESCRIPTION
## Summary

PR #340 で入れた cron 観測性のおかげで、昨晩 `/api/cron/fermentation` が **Vercel 300s タイムアウト**で失敗したことが判明した。本 PR はその短期回避策。

- **並列化** (回避策 1): `ScheduledFermentationUsecase` のユーザーループを worker-pool で並列実行 (default concurrency=4)。質問単位の内側ループはシリアルのまま。
- **maxDuration 拡張** (回避策 2): `/api/cron/fermentation` の `maxDuration` を `300 → 800` (Vercel Pro + Fluid Compute 上限)。

## 原因の概要

1 LLM 呼び出し (Claude Sonnet 4, `maxOutputTokens: 16000`) が数十秒。シリアル `for` で N ユーザー × M 質問を回すと簡単に 300s を超える。CRON_SECRET 不在で 8 日間積み上がった eligible バックログが復活実行で一気に流れて顕在化した (Discord/Vercel ログで確認)。

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 0 errors (warnings は pre-existing)
- [x] `pnpm test` 全 67 ファイル / 366 テスト pass
- [x] 新規テスト `issue #341: ユーザーを concurrency 上限まで並列実行する` で 3 ユーザー × concurrency=2 を回し、`maxInflight === 2` を検証
- [x] `pnpm dep-cruise` violations なし
- [x] `pnpm knip` 既存の `createSupabaseClientForUser` 未使用のみ (pre-existing)
- [ ] マージ後、明日 18:00 JST の cron 実行で Discord 通知 / Vercel ログを確認

## 残りの回避策 (記録用 — 本 PR スコープ外)

短期で (1)(2) を入れれば現規模 (アクティブ ~16 ユーザー) は十分捌けるはず。スケールアップ時に検討する選択肢:

### (3) Cron ディスパッチャ分離

cron 本体は user-id を fan-out するだけ。各ユーザー実行は別 Function invocation として独立 300s 予算を持つ。実現手段:
- Vercel `waitUntil` でバックグラウンド呼び出し
- 外部キュー (QStash / Upstash Workflow / Inngest)

メリット: スケール耐性◎。デメリット: 実装コスト中、外部依存追加の可能性あり。

### (4) Vercel 外ワーカー

- Supabase pg_cron + Edge Function
- Railway / Fly などの常駐ワーカー

メリット: タイムアウト制約から解放。デメリット: インフラ複雑化。ユーザー数が 3 桁に近づいたら検討候補。

### (5) Anthropic Batch API

発酵に即時性は不要 (日次バッチ)。Batch API は 50% 安・数時間遅延で完全に適合。デメリット: オーケストレーション再設計が必要 (非同期ジョブ管理、結果 polling/webhook)。

## 並列化の安全性メモ

- `result` カウンタや `Map` の mutate は **await 境界**でしか起きない (JS シングルスレッド) ため worker 間競合は起きない
- AI Gateway / Supabase 双方ともユーザー単位なので、ユーザー間の同時実行は問題ない
- 内側の質問ループはシリアルのまま (各ユーザー内の質問数は 1〜3 で支配的でない、変更面を最小化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)