### PR TITLE
fix(server): /auth/* レート制限を strict/lenient の2ティアに分離 (#344)

### DIFF
--- a/apps/server/src/contexts/shared/presentation/middleware/rate-limit.ts
+++ b/apps/server/src/contexts/shared/presentation/middleware/rate-limit.ts
@@ -1,14 +1,23 @@
+import { createHash } from 'node:crypto';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import type { Context, MiddlewareHandler, Next } from 'hono';
 
-type RateLimitTier = 'fermentation' | 'auth' | 'general';
+type RateLimitTier = 'fermentation' | 'auth_strict' | 'auth_lenient' | 'general';
+type IdentifierMode = 'ip' | 'user_or_ip' | 'token_or_ip';
 
 const TIER_CONFIG: Record<RateLimitTier, { requests: number; windowMs: number }> = {
   fermentation: { requests: 5, windowMs: 60_000 },
-  auth: { requests: 10, windowMs: 60_000 },
+  auth_strict: { requests: 20, windowMs: 60_000 },
+  auth_lenient: { requests: 120, windowMs: 60_000 },
   general: { requests: 60, windowMs: 60_000 },
 };
+
+// Brute-force-prone or enumeration-prone segments under /auth/*.
+// These remain IP-based so a hostile actor cannot bypass the cap by rotating
+// tokens; everything else under /auth/* uses the lenient per-token tier so
+// shared-NAT users do not collide.
+const STRICT_AUTH_SEGMENTS = new Set(['login', 'signup', 'verify-otp', 'reset-password', 'oauth']);
 
 let redis: Redis | undefined;
 const limiters = new Map<RateLimitTier, Ratelimit>();
@@ -41,21 +50,42 @@ function getLimiter(tier: RateLimitTier): Ratelimit | undefined {
   return limiter;
 }
 
-function getIdentifier(c: Context, useIp: boolean): string {
-  if (useIp) {
-    return (
-      c.req.header('x-real-ip') ??
-      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ??
-      'unknown'
-    );
-  }
-  // @type-assertion-allowed: Hono context variable is set by authMiddleware before rate-limit runs
-  const userId = c.get('userId' as never);
-  if (typeof userId === 'string') return userId;
-  return c.req.header('x-real-ip') ?? 'unknown';
+function getIp(c: Context): string {
+  return (
+    c.req.header('x-real-ip') ?? c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+  );
 }
 
-function createRateLimitMiddleware(tier: RateLimitTier, useIp: boolean): MiddlewareHandler {
+function getIdentifier(c: Context, mode: IdentifierMode): string {
+  if (mode === 'ip') return getIp(c);
+
+  if (mode === 'user_or_ip') {
+    // @type-assertion-allowed: Hono context variable is set by authMiddleware before rate-limit runs
+    const userId = c.get('userId' as never);
+    if (typeof userId === 'string') return userId;
+    return getIp(c);
+  }
+
+  // token_or_ip — derive a stable per-session identifier from the Bearer token
+  // without verifying it (the rate-limit only needs a stable key, not auth).
+  // Hashing avoids storing raw tokens in Upstash keys.
+  const authHeader = c.req.header('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    const hash = createHash('sha256').update(token).digest('hex').slice(0, 32);
+    return `token:${hash}`;
+  }
+  return getIp(c);
+}
+
+export function isStrictAuthPath(path: string): boolean {
+  const segments = path.split('/');
+  const authIdx = segments.lastIndexOf('auth');
+  if (authIdx === -1 || authIdx >= segments.length - 1) return false;
+  return STRICT_AUTH_SEGMENTS.has(segments[authIdx + 1] ?? '');
+}
+
+function createRateLimitMiddleware(tier: RateLimitTier, mode: IdentifierMode): MiddlewareHandler {
   return async (c: Context, next: Next) => {
     // Skip rate limiting in local development to avoid DX friction.
     if (process.env.NODE_ENV !== 'production') {
@@ -69,7 +99,7 @@ function createRateLimitMiddleware(tier: RateLimitTier, useIp: boolean): Middlew
       return;
     }
 
-    const identifier = getIdentifier(c, useIp);
+    const identifier = getIdentifier(c, mode);
     const result = await limiter.limit(identifier);
 
     c.header('X-RateLimit-Limit', String(result.limit));
@@ -88,13 +118,24 @@ function createRateLimitMiddleware(tier: RateLimitTier, useIp: boolean): Middlew
 }
 
 export function rateLimitFermentation(): MiddlewareHandler {
-  return createRateLimitMiddleware('fermentation', false);
+  return createRateLimitMiddleware('fermentation', 'user_or_ip');
 }
 
+// Dispatches between strict (IP-based, 20/min — brute-force-prone endpoints)
+// and lenient (per-token, 120/min — post-auth endpoints like /me, /refresh,
+// /change-*) based on the request path. Registered once at /api/v1/auth/* so
+// requests are not double-counted.
 export function rateLimitAuth(): MiddlewareHandler {
-  return createRateLimitMiddleware('auth', true);
+  const strict = createRateLimitMiddleware('auth_strict', 'ip');
+  const lenient = createRateLimitMiddleware('auth_lenient', 'token_or_ip');
+  return async (c, next) => {
+    if (isStrictAuthPath(c.req.path)) {
+      return strict(c, next);
+    }
+    return lenient(c, next);
+  };
 }
 
 export function rateLimitGeneral(): MiddlewareHandler {
-  return createRateLimitMiddleware('general', false);
+  return createRateLimitMiddleware('general', 'user_or_ip');
 }

--- a/apps/server/test/contexts/shared/presentation/middleware/rate-limit.test.ts
+++ b/apps/server/test/contexts/shared/presentation/middleware/rate-limit.test.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  isStrictAuthPath,
   rateLimitAuth,
   rateLimitFermentation,
   rateLimitGeneral,
@@ -111,12 +113,12 @@ describe('rate-limit middleware', () => {
     });
   });
 
-  describe('rateLimitAuth', () => {
-    it('uses IP address as identifier', async () => {
+  describe('rateLimitAuth (strict — brute-force-prone paths)', () => {
+    it('uses IP address as identifier for /auth/login', async () => {
       mockLimit.mockResolvedValue({
         success: true,
-        limit: 10,
-        remaining: 9,
+        limit: 20,
+        remaining: 19,
         reset: Date.now() + 60000,
       });
 
@@ -126,10 +128,173 @@ describe('rate-limit middleware', () => {
 
       const res = await app.request('/auth/login', {
         method: 'POST',
-        headers: { 'x-real-ip': '5.6.7.8' },
+        headers: {
+          'x-real-ip': '5.6.7.8',
+          // Token must be ignored on strict paths so IP-based brute-force
+          // protection cannot be bypassed by rotating tokens.
+          Authorization: 'Bearer should-be-ignored',
+        },
       });
       expect(res.status).toBe(200);
       expect(mockLimit).toHaveBeenCalledWith('5.6.7.8');
+    });
+
+    it('uses IP for /auth/signup and /auth/signup/availability', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 20,
+        remaining: 19,
+        reset: Date.now() + 60000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .post('/auth/signup', (c) => c.json({ ok: true }))
+        .get('/auth/signup/availability', (c) => c.json({ ok: true }));
+
+      await app.request('/auth/signup', {
+        method: 'POST',
+        headers: { 'x-real-ip': '9.9.9.9' },
+      });
+      await app.request('/auth/signup/availability?nickname=foo', {
+        headers: { 'x-real-ip': '9.9.9.9' },
+      });
+
+      expect(mockLimit).toHaveBeenNthCalledWith(1, '9.9.9.9');
+      expect(mockLimit).toHaveBeenNthCalledWith(2, '9.9.9.9');
+    });
+
+    it('uses IP for /auth/oauth/* paths', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 20,
+        remaining: 19,
+        reset: Date.now() + 60000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .post('/auth/oauth/google', (c) => c.json({ ok: true }));
+
+      await app.request('/auth/oauth/google', {
+        method: 'POST',
+        headers: { 'x-real-ip': '1.1.1.1' },
+      });
+      expect(mockLimit).toHaveBeenCalledWith('1.1.1.1');
+    });
+
+    it('works under a /api/v1 mount prefix (production routing)', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 20,
+        remaining: 19,
+        reset: Date.now() + 60000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .post('/api/v1/auth/login', (c) => c.json({ ok: true }));
+
+      await app.request('/api/v1/auth/login', {
+        method: 'POST',
+        headers: { 'x-real-ip': '3.3.3.3' },
+      });
+      expect(mockLimit).toHaveBeenCalledWith('3.3.3.3');
+    });
+  });
+
+  describe('rateLimitAuth (lenient — per-token post-auth paths)', () => {
+    it('uses hashed Bearer token as identifier for /auth/me', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 120,
+        remaining: 119,
+        reset: Date.now() + 60000,
+      });
+
+      const token = 'eyJabc.def.ghi';
+      const expectedHash = createHash('sha256').update(token).digest('hex').slice(0, 32);
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .get('/auth/me', (c) => c.json({ ok: true }));
+
+      const res = await app.request('/auth/me', {
+        headers: {
+          'x-real-ip': '7.7.7.7',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(mockLimit).toHaveBeenCalledWith(`token:${expectedHash}`);
+    });
+
+    it('isolates per-token counters so shared-NAT users do not collide', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 120,
+        remaining: 119,
+        reset: Date.now() + 60000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .post('/auth/refresh', (c) => c.json({ ok: true }));
+
+      // Two users behind the same NAT IP but with distinct tokens must hash
+      // to distinct identifiers.
+      await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: { 'x-real-ip': '10.0.0.1', Authorization: 'Bearer user-a-token' },
+      });
+      await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: { 'x-real-ip': '10.0.0.1', Authorization: 'Bearer user-b-token' },
+      });
+
+      const idA = mockLimit.mock.calls[0]?.[0];
+      const idB = mockLimit.mock.calls[1]?.[0];
+      expect(idA).not.toEqual(idB);
+      expect(idA).toMatch(/^token:/);
+      expect(idB).toMatch(/^token:/);
+    });
+
+    it('falls back to IP when no Bearer token is present', async () => {
+      mockLimit.mockResolvedValue({
+        success: true,
+        limit: 120,
+        remaining: 119,
+        reset: Date.now() + 60000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .post('/auth/refresh', (c) => c.json({ ok: true }));
+
+      await app.request('/auth/refresh', {
+        method: 'POST',
+        headers: { 'x-real-ip': '4.4.4.4' },
+      });
+      expect(mockLimit).toHaveBeenCalledWith('4.4.4.4');
+    });
+
+    it('returns 429 with the lenient tier limit in the header', async () => {
+      mockLimit.mockResolvedValue({
+        success: false,
+        limit: 120,
+        remaining: 0,
+        reset: Date.now() + 30000,
+      });
+
+      const app = new Hono()
+        .use('/*', rateLimitAuth())
+        .get('/auth/me', (c) => c.json({ ok: true }));
+
+      const res = await app.request('/auth/me', {
+        headers: { Authorization: 'Bearer t', 'x-real-ip': '1.2.3.4' },
+      });
+      expect(res.status).toBe(429);
+      expect(res.headers.get('X-RateLimit-Limit')).toBe('120');
     });
   });
 
@@ -151,6 +316,47 @@ describe('rate-limit middleware', () => {
         headers: { 'x-real-ip': '1.2.3.4' },
       });
       expect(res.status).toBe(429);
+    });
+  });
+
+  describe('isStrictAuthPath', () => {
+    const strict = [
+      '/auth/login',
+      '/auth/signup',
+      '/auth/signup/availability',
+      '/auth/verify-otp',
+      '/auth/reset-password',
+      '/auth/oauth/google',
+      '/auth/oauth/callback',
+      '/auth/oauth/finalize',
+      '/api/v1/auth/login',
+      '/api/v1/auth/signup',
+      '/api/v1/auth/oauth/google',
+    ];
+    const lenient = [
+      '/auth/me',
+      '/auth/refresh',
+      '/auth/change-password',
+      '/auth/change-email',
+      '/auth/profile',
+      '/auth/update-password',
+      '/auth/nickname/check',
+      '/api/v1/auth/me',
+      '/api/v1/auth/refresh',
+      '/api/v1/auth/change-password',
+    ];
+
+    it.each(strict)('classifies %s as strict', (path) => {
+      expect(isStrictAuthPath(path)).toBe(true);
+    });
+
+    it.each(lenient)('classifies %s as lenient', (path) => {
+      expect(isStrictAuthPath(path)).toBe(false);
+    });
+
+    it('returns false when /auth/ segment is absent', () => {
+      expect(isStrictAuthPath('/api/v1/users/me')).toBe(false);
+      expect(isStrictAuthPath('/')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `/api/v1/auth/*` の Upstash レート制限を **strict (IP ベース 20/min)** と **lenient (Bearer トークンハッシュベース 120/min)** の2ティアに分離。共有 NAT 配下で複数ユーザーが「Too many requests」に詰まる問題を解消する。
- 振り分けはパスから自動ディスパッチ — `app.ts` のミドルウェア登録は無変更。

## 背景

100 名規模のアクティブユーザー環境で、テスト環境ログイン時に "Too many requests" が頻発していた (#344)。

調査の結果、`apps/server/src/contexts/shared/presentation/middleware/rate-limit.ts` の `auth` ティアが **10 req / 60s / IP** で全 `/auth/*` 系を一括制限していたことが原因。

問題のシナリオ:
- モバイルキャリアの CGN や社内 NAT で数十人が同一 IP 配下
- `useAuth` のセッション復元 (`/auth/me` → `/auth/refresh` → `/auth/me`) で1人あたり最大3リクエスト消費
- 数人ログインを試みただけで 10/60s を超過

## 変更内容

### 新ティア
| ティア | 上限 | 識別子 | 対象パス |
|---|---|---|---|
| `auth_strict` | 20 / 60s | IP | `/login`, `/signup`, `/verify-otp`, `/reset-password`, `/oauth/*` |
| `auth_lenient` | 120 / 60s | `token:<sha256_32>` (フォールバック: IP) | `/me`, `/refresh`, `/change-*`, `/profile`, `/nickname/check`, `/update-password` 等 |

### セキュリティ上の考慮
- ブルートフォース耐性が必要な未認証パスは **IP ベースを維持**。トークンローテーションで回避不可。
- Supabase Auth 自体も IP ベースの brute-force 防御を持つため二重に守られる。
- Bearer トークンは検証せず、SHA-256 の先頭 32 文字をハッシュ識別子として利用 (Upstash キーに生トークンを残さない)。

### コード変更
- `apps/server/src/contexts/shared/presentation/middleware/rate-limit.ts`: 2ティア追加 + パスベースディスパッチ。`rateLimitAuth()` のシグネチャは互換維持。
- `apps/server/test/contexts/shared/presentation/middleware/rate-limit.test.ts`: 新規ティアのテストケース追加 (12 ケース増)。
- `app.ts`: **無変更**（既存の `.use('/api/v1/auth/*', rateLimitAuth())` がそのまま機能）。

## Test plan
- [x] `pnpm test` — 407 server tests passed
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm dep-cruise` — 違反なし
- [x] `pnpm knip` — 未使用エクスポートなし
- [x] Biome — 当該ファイルに lint エラーなし
- [x] **テスト環境にデプロイ後、共有 NAT 環境からの連続ログインで 429 が出ないこと**
- [ ] **強制ブルートフォース試行 (`/login` を 25 回連打) で従来通り 429 が返ること**
- [ ] Upstash ダッシュボードで新キー `ratelimit:auth_strict:*` / `ratelimit:auth_lenient:token:*` が観測されること

## 制約への適合
- 「従来コードにクリティカルな影響を与えないこと」: ルートハンドラ・他ミドルウェアは無変更。`rateLimitAuth()` の公開 API も互換。

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)