### PR TITLE
feat(verify): 実行時検証ハーネス @oryzae/verify の基盤＋導入ガイド

### DIFF
--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -5,7 +5,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
-  transpilePackages: ['@oryzae/shared', '@oryzae/server'],
+  transpilePackages: ['@oryzae/shared', '@oryzae/server', '@oryzae/verify'],
   turbopack: {},
   // Static MD-backed pages read their bodies from `src/content/**/*.md` at
   // request time. Next.js' file-trace can't detect dynamic `process.cwd()`

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@oryzae/server": "workspace:*",
     "@oryzae/shared": "workspace:*",
+    "@oryzae/verify": "workspace:*",
     "@sentry/nextjs": "^10.51.0",
     "next": "16.2.4",
     "next-intl": "^4.11.0",

--- a/apps/client/src/app/verify/[unit]/[fixture]/page.tsx
+++ b/apps/client/src/app/verify/[unit]/[fixture]/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from 'next/navigation';
+import { UnitPageClient } from './unit-client';
+
+/** 1ユニット×fixture の孤立マウント（dev/preview 限定。本番では 404）。 */
+export default async function VerifyUnitRoute({
+  params,
+}: {
+  params: Promise<{ unit: string; fixture: string }>;
+}) {
+  if (process.env.NODE_ENV === 'production') notFound();
+  const { unit, fixture } = await params;
+  return <UnitPageClient unitId={unit} fixtureId={fixture} />;
+}

--- a/apps/client/src/app/verify/[unit]/[fixture]/unit-client.tsx
+++ b/apps/client/src/app/verify/[unit]/[fixture]/unit-client.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { VerifyUnitPage } from '@oryzae/verify';
+import '@/lib/verify/register';
+
+export function UnitPageClient({ unitId, fixtureId }: { unitId: string; fixtureId: string }) {
+  return <VerifyUnitPage unitId={unitId} fixtureId={fixtureId} />;
+}

--- a/apps/client/src/app/verify/dashboard-client.tsx
+++ b/apps/client/src/app/verify/dashboard-client.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { VerifyDashboard } from '@oryzae/verify';
+// クライアントバンドルでユニット/verifier を登録する（registry はクライアント側で読まれる）。
+import '@/lib/verify/register';
+
+export function VerifyDashboardClient() {
+  return <VerifyDashboard />;
+}

--- a/apps/client/src/app/verify/page.tsx
+++ b/apps/client/src/app/verify/page.tsx
@@ -1,0 +1,8 @@
+import { notFound } from 'next/navigation';
+import { VerifyDashboardClient } from './dashboard-client';
+
+/** 検証ダッシュボード（dev/preview 限定。本番では 404）。 */
+export default function VerifyPage() {
+  if (process.env.NODE_ENV === 'production') notFound();
+  return <VerifyDashboardClient />;
+}

--- a/apps/client/src/lib/verify/example-progress.verify.tsx
+++ b/apps/client/src/lib/verify/example-progress.verify.tsx
@@ -1,0 +1,91 @@
+/**
+ * 横展開のリファレンス用・自己完結サンプル（実 feature 非依存・いつでも削除可）。
+ *
+ * 実 feature にユニットを足すときは、このファイルをテンプレートに、コンポーネント側へ
+ * `verifyAttrs` を付け、feature の隣に `<x>.verify.tsx` を置いて register.ts に1行足す。
+ * propsSchema には `@oryzae/shared` の既存 Zod スキーマを流用できる（このサンプルは
+ * 依存を増やさないため propsSchema を省き、不整合は invariant で検出する）。
+ */
+
+import { registerUnit, verifyAttrs } from '@oryzae/verify';
+
+interface ExampleProgressProps {
+  total: number;
+  done: number;
+  active: number;
+}
+
+function ExampleProgress({ total, done, active }: ExampleProgressProps) {
+  const complete = total > 0 && done === total;
+  return (
+    <div
+      className={complete ? 'progress is-complete' : 'progress'}
+      {...verifyAttrs({
+        unit: 'ExampleProgress',
+        total,
+        done,
+        active,
+        consistent: total === done + active,
+        complete,
+      })}
+    >
+      <strong>{done}</strong> / {total}
+    </div>
+  );
+}
+
+registerUnit<ExampleProgressProps>({
+  id: 'ExampleProgress',
+  title: 'ExampleProgress（リファレンス）',
+  description: '横展開テンプレート。実 feature には影響しない自己完結サンプル。',
+  kind: 'component',
+  render: (props) => <ExampleProgress {...props} />,
+  fixtures: [
+    { id: 'mixed', description: '3件中1件完了', props: { total: 3, done: 1, active: 2 } },
+    { id: 'all-done', description: '全件完了', props: { total: 2, done: 2, active: 0 } },
+    {
+      id: 'empty',
+      probe: true,
+      description: 'Probe: 0件でも崩れない',
+      props: { total: 0, done: 0, active: 0 },
+    },
+    {
+      id: 'inconsistent',
+      probe: true,
+      description: 'Probe: total≠done+active。invariant が FAIL すべき（嘘を捕まえる実証）。',
+      props: { total: 10, done: 3, active: 4 },
+    },
+  ],
+  invariants: [
+    {
+      id: 'counts-consistent',
+      description: 'total === done + active（合計が一致する）',
+      check: ({ props }) =>
+        props.total === props.done + props.active ||
+        `total=${props.total} !== done=${props.done} + active=${props.active}`,
+    },
+    {
+      id: 'complete-class-matches',
+      description: 'is-complete クラスは done===total のときだけ付く',
+      check: ({ root, contract }) => {
+        const el = root.querySelector('[data-verify-unit="ExampleProgress"]');
+        const hasClass = Boolean(el?.classList.contains('is-complete'));
+        return (
+          hasClass === (contract.complete === 'true') ||
+          `class/contract mismatch: complete=${contract.complete}, hasClass=${hasClass}`
+        );
+      },
+    },
+    {
+      id: 'rendered-done-matches',
+      description: '表示の done 数が props.done と一致',
+      check: ({ root, props }) => {
+        const strong = root.querySelector('strong');
+        return (
+          strong?.textContent?.trim() === String(props.done) ||
+          `rendered "${strong?.textContent}", expected "${props.done}"`
+        );
+      },
+    },
+  ],
+});

--- a/apps/client/src/lib/verify/register.ts
+++ b/apps/client/src/lib/verify/register.ts
@@ -1,0 +1,14 @@
+/**
+ * 検証ユニットの登録バレル。
+ *
+ * ビルトイン verifier を登録し、各 feature の `*.verify` を import（自己登録）する。
+ * 横展開時はここに `import './<feature>/<x>.verify';` を1行ずつ足すだけ。
+ *
+ * このバレルは「CIマトリクス（test）」「dashboard ルート」「window.__verify」の3経路から
+ * import され、同じレジストリを共有する。
+ */
+
+import { registerBuiltinVerifiers } from '@oryzae/verify';
+import './example-progress.verify';
+
+registerBuiltinVerifiers();

--- a/apps/client/test/verify.matrix.test.ts
+++ b/apps/client/test/verify.matrix.test.ts
@@ -1,0 +1,52 @@
+/**
+ * 検証マトリクス（CIゲート本体）。
+ *
+ * 登録された全ユニット×fixture を全 verifier に通し verdict を assert する。
+ * これは window.__verify.runAll() と dashboard の Run all と同じコード経路。
+ * 1つの真実、3つの消費者。`pnpm test`（CI の test ジョブ）でそのまま走る。
+ *
+ * ルール:
+ *  - 全ユニットは最低1つの probe fixture を持つ（ハッピーパスだけの検証は不可）。
+ *  - 意図的に失敗する probe は EXPECTED_FAIL に登録し「FAILすること」を assert する
+ *    → ハーネスが嘘を捕まえられること自体を保証する。
+ */
+
+import { allUnits, runUnit } from '@oryzae/verify';
+import { describe, expect, it } from 'vitest';
+import '@/lib/verify/register';
+
+// runner は act 外で意図的に描画・観測するため、React の act 警告を抑止する。
+Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', false);
+
+/** 意図的に壊れていて FAIL すべき fixture（嘘検出の実証）。 */
+const EXPECTED_FAIL = new Set(['ExampleProgress::inconsistent']);
+
+describe('verify matrix', () => {
+  const units = allUnits();
+
+  it('has units registered', () => {
+    expect(units.length).toBeGreaterThan(0);
+  });
+
+  for (const unit of units) {
+    describe(unit.id, () => {
+      it('has at least one probe fixture', () => {
+        expect(
+          unit.fixtures.some((f) => f.probe),
+          `Unit "${unit.id}" has no probe fixtures — only the happy path is covered.`,
+        ).toBe(true);
+      });
+
+      for (const fixture of unit.fixtures) {
+        const key = `${unit.id}::${fixture.id}`;
+        const shouldFail = EXPECTED_FAIL.has(key);
+        it(`${fixture.probe ? '🔍 ' : ''}${fixture.id} → ${shouldFail ? 'FAIL (by design)' : 'PASS'}`, async () => {
+          const results = await runUnit(unit);
+          const r = results.find((x) => x.fixtureId === fixture.id);
+          expect(r, `no result for ${key}`).toBeDefined();
+          expect(r?.verdict).toBe(shouldFail ? 'FAIL' : 'PASS');
+        });
+      }
+    });
+  }
+});

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
     environment: 'jsdom',
     root: '.',
     passWithNoTests: true,
+    // ソース提供の workspace パッケージ（TSX）を vitest 側でも変換させる。
+    server: {
+      deps: {
+        inline: [/@oryzae\/verify/],
+      },
+    },
   },
   resolve: {
     alias: {

--- a/docs/verify-harness-rollout.md
+++ b/docs/verify-harness-rollout.md
@@ -1,0 +1,177 @@
+# 検証ハーネス（Verify Harness）導入ガイドライン
+
+> このドキュメントは SSoT。検証ハーネスを Oryzae（および将来の別プロジェクト）へ
+> 低コストで横展開するための設計判断と手順をまとめる。実装は `packages/verify`
+> （`@oryzae/verify`）に集約する。
+
+## 0. これは何か / なぜやるか
+
+CLAUDE.md が思想の拠り所として挙げている「[超並列LLMコーディングのハーネスエンジニアリング](https://note.com/jujunjun110/n/n66306cab294a)」を、**フロントエンドUIに対して具体実装したもの**。
+
+複数エージェントが長時間自律で開発する時代の大前提は、**エージェントがアプリの状態を実行時に観測・検証できること**。そのために各コンポーネントが自分の状態を機械可読な「DOM契約（`data-verify-*`）」として公表し、その契約に対して fixture（状態）と invariant（不変条件）を宣言する。
+
+この1セットの定義が、**3つの利用者を同時に満たす**のが最大の利点（Storybook やアサート追加では3面を1定義で賄えない）:
+
+| 利用者 | 何をするか |
+|---|---|
+| **CI回帰ゲート** | PR ごとに全ユニット×fixture を検証し、契約違反・probe欠落をブロック |
+| **人間QA / デザインレビュー** | `/verify` ダッシュボードで各部品の状態を目視確認 |
+| **AIエージェントの自己検証** | 稼働中アプリで `window.__verify` を叩き、自分の変更を実行時に確認 |
+
+設計の出典は Code with Claude のワークショップ `how-we-claude-code/phase-3-verify`（動く実装）。`@oryzae/verify` はそれを Oryzae 向けに移植した「動く正解」であり、本ガイドラインが破綻しても実体が常に残る。
+
+## 1. 用語
+
+- **DOM契約（contract）**: コンポーネントが `data-verify-*` 属性として公表する自己申告の状態。例 `data-verify-unit="EntryCard" data-verify-status="draft"`。
+- **VerifiableUnit（ユニット）**: 検証対象の単位。単一コンポーネントでも、複数を束ねた feature スライスでもよい。
+- **fixture**: 名前付きの再現可能な状態（props ＋ 任意の `act()` 操作）。`probe: true` は「壊しにかかる」敵対的エッジケース。
+- **invariant（不変条件）**: マウントされたDOM上で常に真であるべき述語。`onlyFixtures` で特定 fixture に限定可。
+- **verifier（検証器）**: ユニットに依存しないプラグイン（schema / invariants / dom-contract / a11y）。
+- **verdict**: `PASS | FAIL | BLOCKED | SKIP`。`BLOCKED`（観測不能）は `FAIL`（観測して不正）と区別する。
+
+## 2. 配置（monorepo）
+
+エンジンは共有パッケージに1度だけ。定義は各アプリに置く。
+
+```
+packages/
+  shared/                       既存（Zodスキーマ）。propsSchema に流用できる
+  verify/   ← @oryzae/verify     エンジン（移植・全アプリ/将来プロジェクトで再利用）
+    src/core/                    contract / types / registry / runner
+    src/verifiers/               schema / invariants / dom-contract / a11y
+    src/harness/                 handle(window.__verify) / Dashboard / UnitPage
+apps/client/                    （admin も同型）
+  src/lib/verify/register.ts     全 *.verify を import ＋ ビルトイン verifier 登録（バレル）
+  src/features/<x>/*.verify.tsx  各 feature のユニット定義（co-located）
+  src/app/verify/                ダッシュボード/孤立マウントの薄いルート（dev限定）
+  test/verify.matrix.test.ts     CIゲート（全ユニット×fixture を実行・probe必須を強制）
+```
+
+**エンジン＝道具、`*.verify.tsx`＝中身**。エンジンは1回書いて `client`/`admin`/将来の別リポジトリが使い回す。これが低コスト横展開の本体。
+
+## 3. コンポーネント側に書くこと
+
+### (a) 状態をDOMに公表する
+
+```tsx
+import { verifyAttrs } from '@oryzae/verify';
+
+<article
+  {...verifyAttrs({
+    unit: 'EntryCard',
+    status: entry.status,
+    hasPrompt: Boolean(entry.prompt),
+    len: entry.body.length,
+  })}
+>
+```
+
+`verifyAttrs({status: 'draft'})` → `data-verify-status="draft"`。**FSAのどの層のコンポーネントにも付けられる**。これがハーネスの最小単位。
+
+### (b) ユニットを登録する（`*.verify.tsx`）
+
+feature の隣に co-located（例 `src/features/entries/entry-card.verify.tsx`）:
+
+```tsx
+import { registerUnit } from '@oryzae/verify';
+import { EntryCardSchema } from '@oryzae/shared'; // 既存Zodを流用可
+import { EntryCard } from './components/entry-card';
+
+registerUnit({
+  id: 'EntryCard',
+  title: 'EntryCard',
+  description: 'ジャーナルのエントリ表示カード',
+  kind: 'component',
+  render: (props) => <EntryCard {...props} />,
+  propsSchema: EntryCardSchema,
+  fixtures: [
+    { id: 'draft', description: '下書き状態', props: { /* ... */ } },
+    { id: 'empty-body', probe: true, description: 'Probe: 本文空でも崩れない', props: { /* ... */ } },
+  ],
+  invariants: [
+    {
+      id: 'status-contract-matches-class',
+      description: 'data-verify-status と見た目のクラスが一致する',
+      check: ({ root, contract }) => {
+        const el = root.querySelector('[data-verify-unit="EntryCard"]');
+        const hasDraftClass = Boolean(el?.classList.contains('is-draft'));
+        return hasDraftClass === (contract.status === 'draft')
+          || `class/contract mismatch: status=${contract.status}`;
+      },
+    },
+  ],
+});
+```
+
+**ルール: 全ユニットは最低1つの probe fixture を持つこと**（ハッピーパスだけの検証は禁止）。CI がこれを強制する（§5）。
+
+## 4. 3つの利用者の配線（実パス）
+
+### CI回帰ゲート — `apps/client/test/verify.matrix.test.ts`
+
+`apps/client` の test スクリプトは `vitest run test/`（環境 jsdom 設定済み）。`test/` 配下に matrix を置けば既存の `pnpm test` に自動で乗り、**`.github/workflows/ci.yml` の `test` ジョブ経由で PR ごとにCIゲートになる**（新規ワークフロー不要）。
+
+### 人間QA — `apps/client/src/app/verify/`（dev限定）
+
+- `app/verify/page.tsx` … ダッシュボード（「Run all」→ verdict グリッド）
+- `app/verify/[unit]/[fixture]/page.tsx` … そのユニットだけを孤立マウント
+
+FSA 規約に従い `app/` は薄いラッパーにし、UI 本体は `@oryzae/verify` の harness コンポーネントを使う。**本番ビルドに出さない**よう `process.env.NODE_ENV !== 'production'` でガードする。
+
+### AIエージェント自己検証 — `window.__verify`
+
+dev 時のみ `installVerifyHandle()` を呼び、稼働中アプリに `window.__verify` を生やす。エージェント（Claude Code / Playwright）は次で自己検証できる:
+
+```js
+await window.__verify.runAll();              // 全マトリクスを実行→結果JSON
+window.__verify.manifest();                  // 全ユニット×fixtureを列挙
+// ハンドル無しでもDOM直読み可:
+document.querySelector('[data-verify-unit="EntryCard"]').dataset;
+```
+
+## 5. CIで「probe必須」を強制する
+
+`verify.matrix.test.ts` が、全登録ユニットについて (1) 各 fixture の verdict、(2) **probe fixture を最低1つ持つこと**を assert する。これは `pnpm test`（CI の `test` ジョブ）でそのまま走る。Biome のカスタム lint は無理に作らず、**強制は matrix（Vitest）で行う**のが低コストかつ確実。
+
+意図的に失敗する probe（例: 契約とクラスを不一致にした fixture）を1つ用意し、「FAILすることを期待する」と assert しておくと、**ハーネスが嘘を捕まえられること自体**を保証できる。
+
+## 6. どの導入タイミングでも成立させる（アダプション手順）
+
+エンジン導入は既存コードに無影響で、**マトリクスは「登録されたユニットだけ」を検査する**。この性質が新規/既存どちらでも成立させる。
+
+**新規（greenfield）**: 1日目から、新コンポーネントは `verifyAttrs` ＋ `.verify.tsx`（probe込み）をセットで出す。matrix が最初からゲート。
+
+**既存（brownfield・段階導入）**:
+1. `@oryzae/verify` を入れる（既存コードへの影響ゼロ）
+2. **回帰しやすい / エージェントがよく触る**コンポーネントから契約と `.verify.tsx` を足す
+3. matrix は登録済みユニットだけ縛るのでビッグバン不要。未対応は素通り
+4. **カバレッジ・ラチェット**: 契約済み比率を記録し、PR で下がったら落とす（後戻り禁止・前進は任意）
+
+どちらも「登録したものは厳格（probe必須）、未登録は自由」なので、同じガイドラインで回る。
+
+## 7. Oryzae 固有の制約への準拠（重要）
+
+CLAUDE.md の共通ルールに従い、移植コードは以下を厳守（CI検出）:
+
+- **`any` 禁止** … エンジンは `unknown` ＋ ジェネリクスで型付け（移植時に workshop の `any` を除去済み）
+- **`as` キャスト禁止** … 型ガード / ジェネリクスで回避。やむを得ない箇所は前行に `// @type-assertion-allowed: <理由>`
+- **`--no-verify` 禁止** … pre-commit（simple-git-hooks + lint-staged）を飛ばさない
+- Biome: single quote / 2スペース / セミコロンあり / trailing comma all / lineWidth 100
+- `next.config.ts` の `transpilePackages` に `@oryzae/verify` を追加（source-only パッケージのため）
+- `knip.json` に `packages/verify` ワークスペースを追加（デッドコード検出の対象化）
+- ルート `package.json` の `typecheck` に `@oryzae/verify` を追加
+
+## 8. 最初のPRチェックリスト（PoC）
+
+1. `@oryzae/verify` を作成（`core/` `verifiers/` `harness/` を移植、`any`/`as` 除去）
+2. `apps/client` に依存追加＋`transpilePackages`＋`knip.json`＋ルート`typecheck` を更新
+3. **回帰しやすいUIを1つ**選び `verifyAttrs` ＋ `.verify.tsx`（probe込み）
+4. `test/verify.matrix.test.ts` を追加（`pnpm test` で緑になる＝CIゲート成立）
+5. dev限定で `app/verify` ダッシュボード＋`window.__verify`
+6. **わざと壊して**（契約とクラスを不一致に）CI・ダッシュボード・`window.__verify` の3面で FAIL が出ることを確認 → そのままチームへのデモになる
+
+## 9. 将来の拡張（今回は対象外）
+
+- **バックエンド（Hono DDD）**: 同じ「契約＋不変条件＋probe」を、`packages/shared` の Zod を契約に、domain 層の不変条件を invariant に対応させて段階展開（ハーネス階層の②）
+- **別プロジェクト**: `@oryzae/verify` を publish すれば、他リポジトリは `*.verify.tsx` を書くだけ
+- **視覚回帰 / perf / i18n**: verifier を1ファイル追加して登録するだけ（コンポーネント無改変）

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,9 @@
     },
     "packages/shared": {
       "project": ["src/**/*.ts"]
+    },
+    "packages/verify": {
+      "project": ["src/**/*.{ts,tsx}"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "biome check apps/ packages/",
     "lint:fix": "biome check --write apps/ packages/",
-    "typecheck": "pnpm --filter @oryzae/server typecheck && pnpm --filter @oryzae/shared typecheck && pnpm --filter @oryzae/client typecheck && pnpm --filter @oryzae/admin typecheck",
+    "typecheck": "pnpm --filter @oryzae/server typecheck && pnpm --filter @oryzae/shared typecheck && pnpm --filter @oryzae/verify typecheck && pnpm --filter @oryzae/client typecheck && pnpm --filter @oryzae/admin typecheck",
     "test": "pnpm --filter @oryzae/server test && pnpm --filter @oryzae/client test && pnpm --filter @oryzae/admin test",
     "knip": "knip",
     "dep-cruise": "pnpm --filter @oryzae/server dep-cruise && pnpm --filter @oryzae/client dep-cruise && pnpm --filter @oryzae/admin dep-cruise",

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@oryzae/verify",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "peerDependencies": {
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/verify/src/core/contract.ts
+++ b/packages/verify/src/core/contract.ts
@@ -1,0 +1,51 @@
+/**
+ * DOM契約: `data-verify-*` 属性。
+ *
+ * 各コンポーネントは自分の状態を `data-verify-*` 属性として公表し、レンダリング後の
+ * DOM 自体を機械可読なグラウンドトゥルースにする。検証器やエージェントは React 内部
+ * ではなくこの契約を読むため、リファクタしても表面が安定する。
+ *
+ * 例: <li data-verify-unit="EntryCard" data-verify-status="draft" ...>
+ */
+
+export const VERIFY_PREFIX = 'data-verify-';
+
+/** プレーンなレコードから `data-verify-*` props オブジェクトを組み立てる。 */
+export function verifyAttrs(
+  attrs: Record<string, string | number | boolean | null | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === null || value === undefined) continue;
+    out[`${VERIFY_PREFIX}${key}`] = String(value);
+  }
+  return out;
+}
+
+/** `root`（または内部の最初の契約要素）から `data-verify-*` をフラットなマップで読む。 */
+export function readContract(root: HTMLElement): Record<string, string> {
+  const el = findContractRoot(root);
+  if (!el) return {};
+  return collect(el);
+}
+
+/** すべての契約要素から契約を読む（リスト/feature 用）。 */
+export function readAllContracts(root: HTMLElement): Record<string, string>[] {
+  const els = root.querySelectorAll<HTMLElement>(`[${VERIFY_PREFIX}unit]`);
+  return Array.from(els).map(collect);
+}
+
+function collect(el: HTMLElement): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const attr of Array.from(el.attributes)) {
+    if (attr.name.startsWith(VERIFY_PREFIX)) {
+      out[attr.name.slice(VERIFY_PREFIX.length)] = attr.value;
+    }
+  }
+  return out;
+}
+
+function findContractRoot(root: HTMLElement): HTMLElement | null {
+  if (root.hasAttribute(`${VERIFY_PREFIX}unit`)) return root;
+  return root.querySelector<HTMLElement>(`[${VERIFY_PREFIX}unit]`);
+}

--- a/packages/verify/src/core/registry.ts
+++ b/packages/verify/src/core/registry.ts
@@ -1,0 +1,70 @@
+/**
+ * ユニットと verifier の中央レジストリ。
+ *
+ * spec は自分自身をここに登録する。verifier も同様。ハーネスはこのレジストリを通じて
+ * すべてを発見する（magic glob もビルド時 codegen もなし）。
+ */
+
+import type { VerifiableUnit, Verifier, VerifyManifestEntry } from './types';
+
+const units = new Map<string, VerifiableUnit<unknown>>();
+const verifiers = new Map<string, Verifier>();
+
+export function registerUnit<P>(unit: VerifiableUnit<P>): VerifiableUnit<P> {
+  // ホットリロード対応: throw せず置き換える。
+  if (units.has(unit.id)) units.delete(unit.id);
+  // @type-assertion-allowed: レジストリは prop ジェネリクスを消去して保持する。render と fixtures は同一ユニット内で常に整合するため実行時に安全。
+  units.set(unit.id, unit as VerifiableUnit<unknown>);
+  return unit;
+}
+
+export function registerVerifier(verifier: Verifier): Verifier {
+  if (verifiers.has(verifier.id)) verifiers.delete(verifier.id);
+  verifiers.set(verifier.id, verifier);
+  return verifier;
+}
+
+export function getUnit(id: string): VerifiableUnit<unknown> | undefined {
+  return units.get(id);
+}
+
+export function getVerifier(id: string): Verifier | undefined {
+  return verifiers.get(id);
+}
+
+export function allUnits(): VerifiableUnit<unknown>[] {
+  return Array.from(units.values());
+}
+
+export function allVerifiers(): Verifier[] {
+  return Array.from(verifiers.values());
+}
+
+/**
+ * ユニットに適用する verifier を解決する（既定で全部、または宣言されたサブセット）。
+ * 未知の ID は黙ってスキップ — それが0個になれば runner で BLOCKED として表面化する。
+ */
+export function verifiersFor(unit: VerifiableUnit<unknown>): Verifier[] {
+  if (!unit.verifiers) return allVerifiers();
+  return unit.verifiers.map((id) => verifiers.get(id)).filter((v): v is Verifier => Boolean(v));
+}
+
+export function buildManifest(): VerifyManifestEntry[] {
+  return allUnits().map((u) => ({
+    unitId: u.id,
+    title: u.title,
+    kind: u.kind,
+    fixtures: u.fixtures.map((f) => ({
+      id: f.id,
+      description: f.description,
+      probe: Boolean(f.probe),
+    })),
+    verifiers: verifiersFor(u).map((v) => v.id),
+    invariants: u.invariants.map((i) => ({
+      id: i.id,
+      description: i.description,
+    })),
+    route: (fixtureId: string) =>
+      `/verify/${encodeURIComponent(u.id)}/${encodeURIComponent(fixtureId)}`,
+  }));
+}

--- a/packages/verify/src/core/runner.ts
+++ b/packages/verify/src/core/runner.ts
@@ -1,0 +1,196 @@
+/**
+ * runner: ユニット×fixture を（画面外に）マウントし、適用 verifier を全実行し、
+ * verdict を計算して構造化 VerifyResult を返す。
+ *
+ * verdict ルール:
+ *  - マウント不能/verifier 0個/setup で throw → BLOCKED
+ *  - いずれかの check が "fail" → FAIL
+ *  - それ以外 → PASS（warn と probe は落とさない）
+ *  - fixture 0個のユニット → SKIP
+ *
+ * 「迷ったら FAIL」。verifier 内の例外は error を証拠にした "fail" check になる（握り潰さない）。
+ */
+
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { readContract } from './contract';
+import { verifiersFor } from './registry';
+import type { ActContext, Check, Fixture, Verdict, VerifiableUnit, VerifyResult } from './types';
+
+export interface RunOptions {
+  /** この要素にマウントする（画面外コンテナの代わりに可視マウントを検証できる）。 */
+  container?: HTMLElement;
+  /** 既にマウント済み: マウントをスキップし container を読んで検証するだけ。 */
+  alreadyMounted?: boolean;
+  /** 検証後に unmount しない（UnitPage が可視マウントを残すため）。 */
+  keepMounted?: boolean;
+}
+
+export async function runFixture(
+  unit: VerifiableUnit<unknown>,
+  fixture: Fixture<unknown>,
+  opts: RunOptions = {},
+): Promise<VerifyResult> {
+  const started = now();
+  const base = {
+    unitId: unit.id,
+    fixtureId: fixture.id,
+    timestamp: new Date().toISOString(),
+  };
+
+  const applicable = verifiersFor(unit);
+  if (applicable.length === 0) {
+    return {
+      ...base,
+      verdict: 'BLOCKED',
+      checks: [],
+      domSnapshot: {},
+      durationMs: ms(started),
+      blockedReason: `No verifiers registered for unit "${unit.id}".`,
+    };
+  }
+
+  let container = opts.container ?? null;
+  let ownRoot: Root | null = null;
+  let ownContainer: HTMLElement | null = null;
+
+  try {
+    if (!opts.alreadyMounted) {
+      if (!container) {
+        ownContainer = document.createElement('div');
+        ownContainer.setAttribute('data-verify-sandbox', 'true');
+        ownContainer.style.position = 'fixed';
+        ownContainer.style.left = '-10000px';
+        ownContainer.style.top = '0';
+        ownContainer.style.width = '800px';
+        document.body.appendChild(ownContainer);
+        container = ownContainer;
+      }
+      ownRoot = createRoot(container);
+      const root = ownRoot;
+      flushSync(() => {
+        root.render(unit.render(fixture.props));
+      });
+      await tick();
+      if (fixture.act) {
+        await fixture.act(makeActContext(container));
+        await tick();
+      }
+    }
+
+    if (!container) {
+      return {
+        ...base,
+        verdict: 'BLOCKED',
+        checks: [],
+        domSnapshot: {},
+        durationMs: ms(started),
+        blockedReason: 'No container to observe.',
+      };
+    }
+
+    const contract = readContract(container);
+    const checks: Check[] = [];
+
+    for (const v of applicable) {
+      try {
+        const produced = await v.run({ unit, fixture, root: container, contract });
+        checks.push(...produced);
+      } catch (err) {
+        checks.push({
+          verifier: v.id,
+          status: 'fail',
+          label: `Verifier "${v.id}" threw`,
+          detail: String(err),
+          evidence: err instanceof Error ? err.stack : err,
+        });
+      }
+    }
+
+    return {
+      ...base,
+      verdict: verdictOf(checks),
+      checks,
+      domSnapshot: contract,
+      durationMs: ms(started),
+    };
+  } catch (err) {
+    return {
+      ...base,
+      verdict: 'BLOCKED',
+      checks: [],
+      domSnapshot: {},
+      durationMs: ms(started),
+      blockedReason: `Mount failed: ${String(err)}`,
+    };
+  } finally {
+    if (!opts.keepMounted) {
+      if (ownRoot) ownRoot.unmount();
+      if (ownContainer) ownContainer.remove();
+    }
+  }
+}
+
+export async function runUnit(unit: VerifiableUnit<unknown>): Promise<VerifyResult[]> {
+  if (unit.fixtures.length === 0) {
+    return [
+      {
+        unitId: unit.id,
+        fixtureId: '(none)',
+        verdict: 'SKIP',
+        checks: [],
+        domSnapshot: {},
+        durationMs: 0,
+        blockedReason: 'Unit declares no fixtures — nothing to observe.',
+        timestamp: new Date().toISOString(),
+      },
+    ];
+  }
+  const out: VerifyResult[] = [];
+  for (const f of unit.fixtures) {
+    out.push(await runFixture(unit, f));
+  }
+  return out;
+}
+
+export function verdictOf(checks: Check[]): Verdict {
+  if (checks.some((c) => c.status === 'fail')) return 'FAIL';
+  return 'PASS';
+}
+
+/* ----------------------------- helpers ----------------------------- */
+
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function ms(since: number): number {
+  return Math.round(now() - since);
+}
+
+function tick(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+export function makeActContext(root: HTMLElement): ActContext {
+  return {
+    root,
+    click(selector) {
+      const el = root.querySelector<HTMLElement>(selector);
+      if (!el) throw new Error(`act.click: no element matching "${selector}"`);
+      el.click();
+    },
+    type(selector, text) {
+      const el = root.querySelector<HTMLInputElement>(selector);
+      if (!el) throw new Error(`act.type: no element matching "${selector}"`);
+      // React の onChange を発火させるためネイティブ setter 経由で値を設定する。
+      const proto = Object.getPrototypeOf(el);
+      const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+      setter?.call(el, text);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    },
+    wait(msAmount) {
+      return new Promise((r) => setTimeout(r, msAmount));
+    },
+  };
+}

--- a/packages/verify/src/core/types.ts
+++ b/packages/verify/src/core/types.ts
@@ -1,0 +1,199 @@
+/**
+ * 検証フレームワークのコア型。
+ *
+ * 設計原則:
+ *  - 検証は「表面（レンダリング後のDOM）での実行時観測」。静的解析やユニットテストではない。
+ *  - verdict は PASS / FAIL / BLOCKED / SKIP。BLOCKED（観測不能）は FAIL（観測して不正）と区別する。
+ *  - 各ユニットは fixture（名前付き再現状態）を宣言する。`probe: true` はハッピーパスを外した
+ *    敵対的ケース（🔍）。
+ *  - verifier はプラグイン。マウント済みユニットを検査し Check を返す。新種の verifier は
+ *    コンポーネントを触らずに追加できる。
+ *  - 出力は機械可読 JSON が第一、人間向けダッシュボードが第二。
+ */
+
+import type { ReactElement } from 'react';
+import type { ZodTypeAny } from 'zod';
+
+/* -------------------------------------------------------------------------- */
+/* Verdict & Check                                                            */
+/* -------------------------------------------------------------------------- */
+
+export type Verdict = 'PASS' | 'FAIL' | 'BLOCKED' | 'SKIP';
+
+/**
+ * 1つの観測。4分類のステータス:
+ *  ok    (✅) — 確認
+ *  fail  (❌) — 観測して不正
+ *  warn  (⚠️) — 懸念あり（不合格ではない）
+ *  probe (🔍) — ハッピーパス外のストレスケースが成立した
+ */
+export type CheckStatus = 'ok' | 'fail' | 'warn' | 'probe';
+
+export interface Check {
+  /** どの verifier が生成したか（例 "schema", "invariants"）。 */
+  verifier: string;
+  status: CheckStatus;
+  /** 何を確認したかの短いラベル。 */
+  label: string;
+  /** 任意の詳細（実測値 vs 期待値など）。 */
+  detail?: string;
+  /** 任意の生の証拠（シリアライズ可能）。 */
+  evidence?: unknown;
+}
+
+/** 1つのユニット×fixture に全 verifier を回した結果。 */
+export interface VerifyResult {
+  unitId: string;
+  fixtureId: string;
+  verdict: Verdict;
+  checks: Check[];
+  /** 実行時点の DOM 契約のスナップショット。 */
+  domSnapshot: Record<string, string>;
+  /** 実行のウォールクロック時間（ms）。 */
+  durationMs: number;
+  /** BLOCKED の場合、なぜ観測できなかったか。 */
+  blockedReason?: string;
+  timestamp: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Fixture は名前付きの再現可能なレンダリング設定。
+ * `probe: true` は敵対的/エッジケース（🔍）。probe が0個のユニットはハッピーパスしか
+ * 再生していない。
+ */
+export interface Fixture<P = unknown> {
+  id: string;
+  /** シナリオの一行説明。 */
+  description: string;
+  /** ユニットをマウントする props。 */
+  props: P;
+  /** ハッピーパス外/ストレス fixture として印を付ける。 */
+  probe?: boolean;
+  /**
+   * マウント後・検証前に実行する命令的アクション（任意）。
+   * 「描画→Xをクリック→検証」を表現できる。常に await すること。
+   */
+  act?: (ctx: ActContext) => void | Promise<void>;
+}
+
+export interface ActContext {
+  /** ユニットがマウントされた root 要素。 */
+  root: HTMLElement;
+  /** root 内のセレクタ要素をクリック。無ければ throw。 */
+  click: (selector: string) => void | Promise<void>;
+  /** input にタイプ。無ければ throw。 */
+  type: (selector: string, text: string) => void | Promise<void>;
+  /** n ミリ秒待つ（遷移/非同期 state の安定待ち）。 */
+  wait: (ms: number) => Promise<void>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Invariant                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** invariant 述語が見るもの: マウント済み DOM ＋ fixture の props。 */
+export interface InvariantContext<P = unknown> {
+  root: HTMLElement;
+  props: P;
+  fixture: Fixture<P>;
+  /** 便利: DOM 契約（`data-verify-*`）をマップで読む。 */
+  contract: Record<string, string>;
+}
+
+/**
+ * Invariant はマウント済みユニットに対する名前付き述語。
+ * `true`（成立）、`false`（違反）、または string（違反＋人間可読な説明）を返す。
+ */
+export interface Invariant<P = unknown> {
+  id: string;
+  description: string;
+  check: (ctx: InvariantContext<P>) => boolean | string;
+  /** 特定 fixture に限定（既定: 全 fixture）。 */
+  onlyFixtures?: string[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Verifier（プラグイン）                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** 全 Verifier が受け取るコンテキスト。 */
+export interface VerifierContext {
+  unit: VerifiableUnit<unknown>;
+  fixture: Fixture<unknown>;
+  root: HTMLElement;
+  contract: Record<string, string>;
+}
+
+/**
+ * Verifier はプラグイン式のチェック。マウント済みユニットを検査し Check を返す。
+ * コンポーネントから独立しているため、新種（a11y, perf, visual）をコンポーネント
+ * 無改変で足せる。
+ */
+export interface Verifier {
+  id: string;
+  description: string;
+  run: (ctx: VerifierContext) => Check[] | Promise<Check[]>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* VerifiableUnit                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * VerifiableUnit はモジュール性の単位。単一コンポーネントでも feature スライスでもよい。
+ */
+export interface VerifiableUnit<P = unknown> {
+  id: string;
+  title: string;
+  description: string;
+  /** leaf は "component"、自前 state を持つスライスは "feature"。 */
+  kind: 'component' | 'feature';
+  /** 与えられた fixture でユニットを孤立レンダリングする。 */
+  render: (props: P) => ReactElement;
+  /** props 形状を検証する Zod スキーマ。 */
+  propsSchema?: ZodTypeAny;
+  fixtures: Fixture<P>[];
+  invariants: Invariant<P>[];
+  /** 実行する verifier ID。省略で全登録 verifier。 */
+  verifiers?: string[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* エージェントハンドル: window.__verify                                      */
+/* -------------------------------------------------------------------------- */
+
+export interface VerifyManifestEntry {
+  unitId: string;
+  title: string;
+  kind: 'component' | 'feature';
+  fixtures: Array<{ id: string; description: string; probe: boolean }>;
+  verifiers: string[];
+  invariants: Array<{ id: string; description: string }>;
+  /** 孤立マウントへのディープリンク。 */
+  route: (fixtureId: string) => string;
+}
+
+/**
+ * エージェント向けハンドル。`window.__verify` で公開。AI エージェント（や Playwright）は
+ * manifest() で全ユニット×fixture を発見し、孤立ルートへ移動し、current()/runAll() で
+ * 構造化結果を得られる。
+ */
+export interface VerifyHandle {
+  manifest: () => VerifyManifestEntry[];
+  /** 現在マウント中のユニット/fixture の結果（無ければ null）。 */
+  current: () => VerifyResult | null;
+  /** 全ユニット×fixture を実行してマトリクスを返す。 */
+  runAll: () => Promise<VerifyResult[]>;
+  /** verify プロトコルのバージョン。 */
+  version: string;
+}
+
+declare global {
+  interface Window {
+    __verify?: VerifyHandle;
+  }
+}

--- a/packages/verify/src/harness/Dashboard.tsx
+++ b/packages/verify/src/harness/Dashboard.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * 人間QA用ダッシュボード。「Run all」で全ユニット×fixture を実行し verdict グリッドを表示する。
+ * 同じ runUnit を CI（matrix test）と window.__verify も使う — 1つの真実、3つの消費者。
+ */
+
+import { useEffect, useState } from 'react';
+import { allUnits, buildManifest } from '../core/registry';
+import { runUnit } from '../core/runner';
+import type { Verdict, VerifyResult } from '../core/types';
+import { installVerifyHandle } from './handle';
+
+const keyOf = (unitId: string, fixtureId: string) => `${unitId}::${fixtureId}`;
+
+const VERDICT_COLOR: Record<Verdict, string> = {
+  PASS: '#059669',
+  FAIL: '#dc2626',
+  BLOCKED: '#d97706',
+  SKIP: '#6b7280',
+};
+
+const VERDICT_ORDER: Verdict[] = ['PASS', 'FAIL', 'BLOCKED', 'SKIP'];
+
+export function VerifyDashboard() {
+  const manifest = buildManifest();
+  const [results, setResults] = useState<Record<string, VerifyResult>>({});
+  const [running, setRunning] = useState(false);
+
+  // 稼働中アプリに window.__verify を生やす（エージェント/Playwright の自己検証用）。
+  useEffect(() => {
+    installVerifyHandle();
+  }, []);
+
+  const runAll = async () => {
+    setRunning(true);
+    const next: Record<string, VerifyResult> = {};
+    for (const unit of allUnits()) {
+      for (const r of await runUnit(unit)) {
+        next[keyOf(r.unitId, r.fixtureId)] = r;
+      }
+    }
+    setResults(next);
+    setRunning(false);
+  };
+
+  const counts = Object.values(results).reduce<Record<string, number>>((acc, r) => {
+    acc[r.verdict] = (acc[r.verdict] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', padding: 24, maxWidth: 900 }}>
+      <h1 style={{ fontSize: 20 }}>Verify Dashboard</h1>
+      <p style={{ color: '#6b7280', fontSize: 13 }}>
+        {manifest.length} unit(s). コンソールで <code>window.__verify.runAll()</code> も同じ結果。
+      </p>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', margin: '12px 0' }}>
+        <button
+          type="button"
+          onClick={runAll}
+          disabled={running}
+          style={{ padding: '6px 14px', borderRadius: 6, border: '1px solid #d1d5db' }}
+        >
+          {running ? 'Running…' : 'Run all'}
+        </button>
+        {Object.keys(counts).length > 0 && (
+          <span style={{ fontSize: 13 }}>
+            {VERDICT_ORDER.filter((v) => counts[v])
+              .map((v) => `${v}: ${counts[v]}`)
+              .join('  /  ')}
+          </span>
+        )}
+      </div>
+
+      {manifest.map((unit) => (
+        <section key={unit.unitId} style={{ marginTop: 18 }}>
+          <h2 style={{ fontSize: 15 }}>
+            {unit.title} <span style={{ color: '#9ca3af', fontSize: 12 }}>({unit.kind})</span>
+          </h2>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <tbody>
+              {unit.fixtures.map((f) => {
+                const r = results[keyOf(unit.unitId, f.id)];
+                return (
+                  <tr key={f.id} style={{ borderTop: '1px solid #eee' }}>
+                    <td style={{ padding: '6px 8px', whiteSpace: 'nowrap' }}>
+                      {f.probe ? '🔍 ' : ''}
+                      <code>{f.id}</code>
+                    </td>
+                    <td style={{ padding: '6px 8px', color: '#6b7280' }}>{f.description}</td>
+                    <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                      {r ? (
+                        <strong style={{ color: VERDICT_COLOR[r.verdict] }}>{r.verdict}</strong>
+                      ) : (
+                        <span style={{ color: '#d1d5db' }}>—</span>
+                      )}
+                    </td>
+                    <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                      <a
+                        href={`/verify/${encodeURIComponent(unit.unitId)}/${encodeURIComponent(f.id)}`}
+                      >
+                        open →
+                      </a>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/packages/verify/src/harness/UnitPage.tsx
+++ b/packages/verify/src/harness/UnitPage.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * 孤立マウントページ。1つのユニット×fixture だけを可視マウントし、その実物 DOM に対して
+ * 検証を回す。結果は画面表示 ＋ window.__verify.current()（と #verify-result-json）に反映。
+ * エージェント/Playwright がこのルートに来て observe する想定。
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getUnit } from '../core/registry';
+import { runFixture } from '../core/runner';
+import type { Check, Verdict, VerifyResult } from '../core/types';
+import { installVerifyHandle, setCurrentResult } from './handle';
+
+const VERDICT_COLOR: Record<Verdict, string> = {
+  PASS: '#059669',
+  FAIL: '#dc2626',
+  BLOCKED: '#d97706',
+  SKIP: '#6b7280',
+};
+
+const CHECK_ICON: Record<Check['status'], string> = {
+  ok: '✅',
+  fail: '❌',
+  warn: '⚠️',
+  probe: '🔍',
+};
+
+export function VerifyUnitPage({ unitId, fixtureId }: { unitId: string; fixtureId: string }) {
+  const mountRef = useRef<HTMLDivElement>(null);
+  const [result, setResult] = useState<VerifyResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async () => {
+    setError(null);
+    const unit = getUnit(unitId);
+    if (!unit) {
+      setError(`unknown unit "${unitId}"`);
+      return;
+    }
+    const fixture = unit.fixtures.find((f) => f.id === fixtureId);
+    if (!fixture) {
+      setError(`unknown fixture "${fixtureId}" on unit "${unitId}"`);
+      return;
+    }
+    const container = mountRef.current;
+    if (!container) return;
+    // 毎回フレッシュなホストに描画する（同一ノードへの createRoot 再呼び出しを避ける）。
+    const host = document.createElement('div');
+    container.replaceChildren(host);
+    const r = await runFixture(unit, fixture, { container: host, keepMounted: true });
+    setResult(r);
+    setCurrentResult(r);
+  }, [unitId, fixtureId]);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  // 稼働中アプリに window.__verify を生やす（エージェント/Playwright の自己検証用）。
+  useEffect(() => {
+    installVerifyHandle();
+  }, []);
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', padding: 24, maxWidth: 900 }}>
+      <p style={{ fontSize: 13 }}>
+        <a href="/verify">← dashboard</a>
+      </p>
+      <h1 style={{ fontSize: 18 }}>
+        <code>{unitId}</code> / <code>{fixtureId}</code>
+      </h1>
+      <button
+        type="button"
+        onClick={() => void run()}
+        style={{ padding: '4px 12px', borderRadius: 6, border: '1px solid #d1d5db' }}
+      >
+        Re-run
+      </button>
+
+      {error && <p style={{ color: '#dc2626' }}>{error}</p>}
+
+      <h2 style={{ fontSize: 14, marginTop: 16 }}>Live mount</h2>
+      <div
+        ref={mountRef}
+        style={{ border: '1px dashed #d1d5db', borderRadius: 8, padding: 16, minHeight: 48 }}
+      />
+
+      {result && (
+        <>
+          <h2 style={{ fontSize: 14, marginTop: 16 }}>
+            Verdict: <span style={{ color: VERDICT_COLOR[result.verdict] }}>{result.verdict}</span>{' '}
+            <span style={{ color: '#9ca3af', fontSize: 12 }}>({result.durationMs}ms)</span>
+          </h2>
+          <ul style={{ fontSize: 13, lineHeight: 1.7, listStyle: 'none', paddingLeft: 0 }}>
+            {result.checks.map((c) => (
+              <li key={`${c.verifier}:${c.label}`}>
+                {CHECK_ICON[c.status]} <code>[{c.verifier}]</code> {c.label}
+                {c.detail && <span style={{ color: '#9ca3af' }}> — {c.detail}</span>}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* DOM しか読めないエージェント向けの結果置き場 */}
+      <pre id="verify-result-json" style={{ display: 'none' }} />
+    </div>
+  );
+}

--- a/packages/verify/src/harness/handle.ts
+++ b/packages/verify/src/harness/handle.ts
@@ -1,0 +1,38 @@
+/**
+ * エージェントハンドル: window.__verify。
+ *
+ * 「検証器のための表面」。AI エージェントや Playwright が `window.__verify.manifest()` で
+ * 全ユニット×fixture を発見し、孤立ルートへ移動し、`window.__verify.current()` で構造化
+ * VerifyResult を得られる。DOM スクレイピングのヒューリスティック不要。
+ */
+
+import { allUnits, buildManifest } from '../core/registry';
+import { runUnit } from '../core/runner';
+import type { VerifyHandle, VerifyResult } from '../core/types';
+
+let currentResult: VerifyResult | null = null;
+
+export function setCurrentResult(r: VerifyResult | null): void {
+  currentResult = r;
+  // DOM しか読めないエージェント向けに、発見しやすい場所にも置く。
+  if (typeof document === 'undefined') return;
+  const host = document.getElementById('verify-result-json');
+  if (host) host.textContent = r ? JSON.stringify(r, null, 2) : '';
+}
+
+export function installVerifyHandle(): VerifyHandle {
+  const handle: VerifyHandle = {
+    version: '1.0',
+    manifest: () => buildManifest(),
+    current: () => currentResult,
+    runAll: async () => {
+      const out: VerifyResult[] = [];
+      for (const unit of allUnits()) {
+        out.push(...(await runUnit(unit)));
+      }
+      return out;
+    },
+  };
+  window.__verify = handle;
+  return handle;
+}

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @oryzae/verify — 検証ハーネスのエンジン。
+ * 詳しい横展開ガイドは docs/verify-harness-rollout.md を参照。
+ */
+
+export { readAllContracts, readContract, VERIFY_PREFIX, verifyAttrs } from './core/contract';
+export {
+  allUnits,
+  allVerifiers,
+  buildManifest,
+  getUnit,
+  getVerifier,
+  registerUnit,
+  registerVerifier,
+  verifiersFor,
+} from './core/registry';
+export { makeActContext, type RunOptions, runFixture, runUnit, verdictOf } from './core/runner';
+export type {
+  ActContext,
+  Check,
+  CheckStatus,
+  Fixture,
+  Invariant,
+  InvariantContext,
+  Verdict,
+  VerifiableUnit,
+  Verifier,
+  VerifierContext,
+  VerifyHandle,
+  VerifyManifestEntry,
+  VerifyResult,
+} from './core/types';
+export { VerifyDashboard } from './harness/Dashboard';
+export { installVerifyHandle, setCurrentResult } from './harness/handle';
+export { VerifyUnitPage } from './harness/UnitPage';
+export { registerBuiltinVerifiers } from './verifiers';

--- a/packages/verify/src/verifiers/a11y.ts
+++ b/packages/verify/src/verifiers/a11y.ts
@@ -1,0 +1,88 @@
+/**
+ * a11y verifier — 依存ゼロの最小アクセシビリティチェック。axe-core の代替ではなく、
+ * 「新種の verifier をコンポーネント無改変で足せる」ことを示すための実例。
+ */
+
+import { registerVerifier } from '../core/registry';
+import type { Check, Verifier } from '../core/types';
+
+export const a11yVerifier: Verifier = registerVerifier({
+  id: 'a11y',
+  description: 'Basic accessibility checks (labels, roles, alt text).',
+  run({ root, fixture }) {
+    const checks: Check[] = [];
+    const base: Check['status'] = fixture.probe ? 'probe' : 'ok';
+
+    const buttons = root.querySelectorAll<HTMLElement>('button, [role=button]');
+    const unnamed = Array.from(buttons).filter((b) => !accessibleName(b));
+    if (buttons.length > 0) {
+      checks.push(
+        unnamed.length === 0
+          ? {
+              verifier: 'a11y',
+              status: base,
+              label: `All ${buttons.length} button(s) have accessible names`,
+            }
+          : {
+              verifier: 'a11y',
+              status: 'fail',
+              label: `${unnamed.length}/${buttons.length} button(s) lack accessible names`,
+              detail: unnamed.map((b) => b.outerHTML.slice(0, 80)).join(' | '),
+            },
+      );
+    }
+
+    const inputs = root.querySelectorAll<HTMLInputElement>(
+      'input:not([type=hidden]), textarea, select',
+    );
+    const unlabeled = Array.from(inputs).filter((i) => !inputLabel(i, root));
+    if (inputs.length > 0) {
+      checks.push(
+        unlabeled.length === 0
+          ? { verifier: 'a11y', status: base, label: `All ${inputs.length} input(s) are labeled` }
+          : {
+              verifier: 'a11y',
+              status: 'fail',
+              label: `${unlabeled.length}/${inputs.length} input(s) are unlabeled`,
+              detail: unlabeled.map((i) => i.outerHTML.slice(0, 80)).join(' | '),
+            },
+      );
+    }
+
+    const imgs = root.querySelectorAll<HTMLImageElement>('img');
+    const noAlt = Array.from(imgs).filter((i) => !i.hasAttribute('alt'));
+    if (imgs.length > 0) {
+      checks.push(
+        noAlt.length === 0
+          ? { verifier: 'a11y', status: base, label: 'All images have alt' }
+          : {
+              verifier: 'a11y',
+              status: 'fail',
+              label: `${noAlt.length}/${imgs.length} image(s) missing alt`,
+            },
+      );
+    }
+
+    if (checks.length === 0) {
+      checks.push({ verifier: 'a11y', status: base, label: 'No interactive elements to check' });
+    }
+    return checks;
+  },
+});
+
+function accessibleName(el: HTMLElement): string {
+  return (
+    el.getAttribute('aria-label') ||
+    el.getAttribute('aria-labelledby') ||
+    el.getAttribute('title') ||
+    el.textContent?.trim() ||
+    ''
+  );
+}
+
+function inputLabel(el: HTMLInputElement, root: HTMLElement): boolean {
+  if (el.getAttribute('aria-label') || el.getAttribute('aria-labelledby')) return true;
+  if (el.id && root.querySelector(`label[for="${CSS.escape(el.id)}"]`)) return true;
+  if (el.closest('label')) return true;
+  return false;
+}

--- a/packages/verify/src/verifiers/dom-contract.ts
+++ b/packages/verify/src/verifiers/dom-contract.ts
@@ -1,0 +1,64 @@
+/**
+ * dom-contract verifier — マウント済みユニットが実際に `data-verify-*` 契約を出しているか、
+ * 契約がユニットを自己同定しているかをチェックする。
+ *
+ * DOM は表面。契約を出さないユニットはエージェントが信頼して読むものが無い → warn ではなく FAIL。
+ */
+
+import { readAllContracts } from '../core/contract';
+import { registerVerifier } from '../core/registry';
+import type { Check, Verifier } from '../core/types';
+
+export const domContractVerifier: Verifier = registerVerifier({
+  id: 'dom-contract',
+  description: 'Checks the unit emits a machine-readable data-verify-* contract.',
+  run({ unit, fixture, root, contract }) {
+    const checks: Check[] = [];
+
+    if (Object.keys(contract).length === 0) {
+      return [
+        {
+          verifier: 'dom-contract',
+          status: 'fail',
+          label: 'No DOM contract emitted',
+          detail:
+            'No element with data-verify-* attributes found. The surface is not machine-readable.',
+        },
+      ];
+    }
+
+    checks.push({
+      verifier: 'dom-contract',
+      status: fixture.probe ? 'probe' : 'ok',
+      label: `Contract present (${Object.keys(contract).length} attrs)`,
+      evidence: contract,
+    });
+
+    if (contract.unit) {
+      checks.push({
+        verifier: 'dom-contract',
+        status: 'ok',
+        label: `Contract self-identifies as "${contract.unit}"`,
+      });
+    } else {
+      checks.push({
+        verifier: 'dom-contract',
+        status: 'warn',
+        label: 'Contract missing data-verify-unit',
+        detail: "Agents can't confirm they're observing the right component.",
+      });
+    }
+
+    const all = readAllContracts(root);
+    if (unit.kind === 'component' && all.length > 1) {
+      checks.push({
+        verifier: 'dom-contract',
+        status: 'warn',
+        label: `Multiple contract nodes found (${all.length})`,
+        detail: 'A component-kind unit emitted more than one data-verify-unit node.',
+      });
+    }
+
+    return checks;
+  },
+});

--- a/packages/verify/src/verifiers/index.ts
+++ b/packages/verify/src/verifiers/index.ts
@@ -1,0 +1,16 @@
+/**
+ * ビルトイン verifier の登録。
+ * 各 verifier はモジュール読み込み時に自己登録する。この関数はそれらを参照することで
+ * バンドラのツリーシェイクを防ぎ、明示的な登録 API を提供する。
+ * 新種を足す = ファイルを足してここに1行足すだけ。コンポーネントは無改変。
+ */
+
+import type { Verifier } from '../core/types';
+import { a11yVerifier } from './a11y';
+import { domContractVerifier } from './dom-contract';
+import { invariantVerifier } from './invariants';
+import { schemaVerifier } from './schema';
+
+export function registerBuiltinVerifiers(): readonly Verifier[] {
+  return [schemaVerifier, invariantVerifier, domContractVerifier, a11yVerifier];
+}

--- a/packages/verify/src/verifiers/invariants.ts
+++ b/packages/verify/src/verifiers/invariants.ts
@@ -1,0 +1,54 @@
+/**
+ * invariant verifier — ユニットが宣言した invariant 述語をマウント済み DOM に対して回す。
+ * invariant は実行時アサーション。design-by-contract の片割れ。
+ */
+
+import { registerVerifier } from '../core/registry';
+import type { Check, Verifier } from '../core/types';
+
+export const invariantVerifier: Verifier = registerVerifier({
+  id: 'invariants',
+  description: "Runs the unit's declared invariant predicates against the DOM.",
+  run({ unit, fixture, root, contract }) {
+    const checks: Check[] = [];
+    for (const inv of unit.invariants) {
+      if (inv.onlyFixtures && !inv.onlyFixtures.includes(fixture.id)) continue;
+      let outcome: boolean | string;
+      try {
+        outcome = inv.check({ root, props: fixture.props, fixture, contract });
+      } catch (err) {
+        checks.push({
+          verifier: 'invariants',
+          status: 'fail',
+          label: inv.description,
+          detail: `Invariant "${inv.id}" threw: ${String(err)}`,
+        });
+        continue;
+      }
+      if (outcome === true) {
+        checks.push({
+          verifier: 'invariants',
+          status: fixture.probe ? 'probe' : 'ok',
+          label: inv.description,
+        });
+      } else {
+        checks.push({
+          verifier: 'invariants',
+          status: 'fail',
+          label: inv.description,
+          detail: typeof outcome === 'string' ? outcome : `Invariant "${inv.id}" returned false.`,
+        });
+      }
+    }
+    if (checks.length === 0) {
+      checks.push({
+        verifier: 'invariants',
+        status: 'warn',
+        label: 'No invariants ran',
+        detail:
+          'Unit declares no invariants for this fixture. A surface with zero invariants is unverified.',
+      });
+    }
+    return checks;
+  },
+});

--- a/packages/verify/src/verifiers/schema.ts
+++ b/packages/verify/src/verifiers/schema.ts
@@ -1,0 +1,44 @@
+/**
+ * schema verifier — fixture の props をユニットの Zod スキーマで検証する。
+ * 契約の「静的な形」側。fixture が主張する props と実際にコンポーネントが期待する形の
+ * ズレを捕まえる。
+ */
+
+import { registerVerifier } from '../core/registry';
+import type { Verifier } from '../core/types';
+
+export const schemaVerifier: Verifier = registerVerifier({
+  id: 'schema',
+  description: "Validates fixture props against the unit's Zod propsSchema.",
+  run({ unit, fixture }) {
+    if (!unit.propsSchema) {
+      return [
+        {
+          verifier: 'schema',
+          status: 'warn',
+          label: 'No propsSchema declared',
+          detail: 'Unit has no Zod schema — fixtures are unvalidated. Consider declaring one.',
+        },
+      ];
+    }
+    const result = unit.propsSchema.safeParse(fixture.props);
+    if (result.success) {
+      return [
+        {
+          verifier: 'schema',
+          status: fixture.probe ? 'probe' : 'ok',
+          label: 'Props match schema',
+        },
+      ];
+    }
+    return [
+      {
+        verifier: 'schema',
+        status: 'fail',
+        label: 'Props violate schema',
+        detail: result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+        evidence: result.error.issues,
+      },
+    ];
+  },
+});

--- a/packages/verify/tsconfig.json
+++ b/packages/verify/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@oryzae/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@oryzae/verify':
+        specifier: workspace:*
+        version: link:../../packages/verify
       '@sentry/nextjs':
         specifier: ^10.51.0
         version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.1)
@@ -222,6 +225,28 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/verify:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## 概要

Code with Claude のワークショップ `how-we-claude-code/phase-3-verify` の「**DOM契約による実行時検証**」を Oryzae 向けに移植した**基盤**です。CLAUDE.md が掲げる「ハーネスエンジニアリング」の、フロントUIに対する具体実装にあたります。

**1セットの `*.verify` 定義が、3つの消費者を同時に駆動**します:
- **CI回帰ゲート** — `apps/client/test/verify.matrix.test.ts` が `pnpm test` に乗り、全ユニット×fixture を検証＋「probe必須」を強制
- **人間QA** — dev限定 `/verify` ダッシュボード(Run all → verdictグリッド)
- **エージェント自己検証** — 稼働中アプリに `window.__verify` を生やす

## 主な変更

- `packages/verify`(`@oryzae/verify`): エンジン（contract / fixture / invariant / verifier / runner / handle / dashboard）
- `apps/client` 配線: 登録バレル、自己完結サンプル `ExampleProgress`(削除可のテンプレート)、dev限定 `/verify` ルート、`verify.matrix.test.ts`
- `docs/verify-harness-rollout.md`: 横展開ガイドライン(SSoT)
- 設定: `transpilePackages` / vitest `deps.inline` / root `typecheck` / `knip.json`

## 準拠・検証

- 共通ルール準拠: **`any` 禁止**(`unknown`＋ジェネリクス)、**`as` 禁止**(generic消去1箇所のみ `// @type-assertion-allowed:` 付き)、Biome
- ローカルで **`pnpm lint` / `pnpm typecheck` / `pnpm --filter @oryzae/client test` すべて緑**
- 意図的に壊した `ExampleProgress::inconsistent` probe が**期待どおり FAIL**(=嘘検出を実証)

## このPRの位置づけ

これは**基盤のみ**です。実 feature への適用(PoC)は、このブランチを土台にした**別PR**で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)